### PR TITLE
Prove exact Fuchsian elliptic stabilizers

### DIFF
--- a/SphereSixComplex/TriangleGroup/EstablishedFuchsianEllipticStabilizers.lean
+++ b/SphereSixComplex/TriangleGroup/EstablishedFuchsianEllipticStabilizers.lean
@@ -1,25 +1,47 @@
 module
 
-public import SphereSixComplex.TriangleGroup.FreeProductTorsion
+public import SphereSixComplex.TriangleGroup.FreeProductCentralizers
+public import SphereSixComplex.TriangleGroup.FuchsianOneFixedCommutation
+public import SphereSixComplex.TriangleGroup.FuchsianTwoFixedCommutation
 
 /-!
 # Established elliptic stabilizers of the explicit Fuchsian triangle group
 
-The two statements below are the classical stabilizer calculation for the explicit
-orientation-preserving `(3, 4, ∞)` triangle group. They are independent of the period family and
-the six-sphere construction.
+The two statements below are the stabilizer calculation for the explicit orientation-preserving
+`(3, 4, ∞)` triangle group.  Fixing an elliptic point forces matrix commutation with its elliptic
+generator, while the reduced-word normal form identifies that generator's centralizer with the
+corresponding cyclic free factor.
 -/
 
 namespace SphereSixComplex.TriangleGroup
 
 /-- The stabilizer of the order-three elliptic point is exactly the embedded `C₃` factor. -/
-public axiom establishedFuchsianOneStabilizerExact (g : Delta) :
+public theorem establishedFuchsianOneStabilizerExact (g : Delta) :
     fuchsianSourceAction g • fuchsianOneFixedPoint = fuchsianOneFixedPoint ↔
-      ∃ a : CyclicThree, g = Monoid.Coprod.inl a
+      ∃ a : CyclicThree, g = Monoid.Coprod.inl a := by
+  constructor
+  · intro hfixed
+    exact eq_inl_of_commute_g₁ g (commute_gOne_of_fuchsianOneFixed g hfixed)
+  · rintro ⟨a, rfl⟩
+    by_cases ha : a = 1
+    · subst a
+      simp
+    · exact (FreeProductTorsion.fuchsianSourceAction_inl_fixed_iff
+        a ha fuchsianOneFixedPoint).2 rfl
 
 /-- The stabilizer of the order-four elliptic point is exactly the embedded `C₄` factor. -/
-public axiom establishedFuchsianTwoStabilizerExact (g : Delta) :
+public theorem establishedFuchsianTwoStabilizerExact (g : Delta) :
     fuchsianSourceAction g • fuchsianTwoFixedPoint = fuchsianTwoFixedPoint ↔
-      ∃ a : CyclicFour, g = Monoid.Coprod.inr a
+      ∃ a : CyclicFour, g = Monoid.Coprod.inr a := by
+  constructor
+  · intro hfixed
+    exact eq_inr_of_commute_g₂ g
+      (FuchsianTwoFixedCommutation.commute_gTwo_of_fuchsianTwoFixedPoint_fixed g hfixed)
+  · rintro ⟨a, rfl⟩
+    by_cases ha : a = 1
+    · subst a
+      simp
+    · exact (FreeProductTorsion.fuchsianSourceAction_inr_fixed_iff
+        a ha fuchsianTwoFixedPoint).2 rfl
 
 end SphereSixComplex.TriangleGroup

--- a/SphereSixComplex/TriangleGroup/FreeProductCentralizers.lean
+++ b/SphereSixComplex/TriangleGroup/FreeProductCentralizers.lean
@@ -1,0 +1,162 @@
+module
+
+public import SphereSixComplex.TriangleGroup.BinaryIndexedCoprod
+import all SphereSixComplex.TriangleGroup.BinaryIndexedCoprod
+
+/-!
+# Centralizers of the distinguished free-product generators
+
+This file proves, from the indexed reduced-word normal form, that an element of
+`CyclicThree * CyclicFour` commuting with either distinguished generator belongs to the
+corresponding free factor.
+-/
+
+noncomputable section
+
+namespace SphereSixComplex.TriangleGroup.FreeProductCentralizers
+
+open SphereSixComplex.TriangleGroup
+open BinaryIndexedCoprod
+open Monoid.CoprodI
+
+variable {I : Type*} {G : I → Type*} [DecidableEq I]
+variable [∀ i, Group (G i)] [∀ i, DecidableEq (G i)]
+
+/-- Two nonempty reduced words with equal products are the same reduced word. -/
+private theorem neWord_toWord_eq_of_prod_eq {i j k l : I}
+    {u : NeWord G i j} {v : NeWord G k l} (h : u.prod = v.prod) :
+    u.toWord = v.toWord := by
+  apply (Word.equiv (M := G)).symm.injective
+  change u.toWord.prod = v.toWord.prod
+  exact h
+
+/-- A reduced word whose last factor differs from that of a nonidentity letter cannot commute
+with that letter. -/
+public theorem neWord_not_commute_of_last_ne {i j k : I} (w : NeWord G i j)
+    (s : G k) (hjk : j ≠ k) (hs : s ≠ 1) :
+    ¬Commute w.prod (Monoid.CoprodI.of s) := by
+  let single : NeWord G k k := .singleton s hs
+  let middle : NeWord G i k := .append w hjk single
+  let conjugate : NeWord G i i := .append middle hjk.symm w.inv
+  intro hcomm
+  have hprod : conjugate.prod = single.prod := by
+    simp only [conjugate, middle, NeWord.append_prod, NeWord.inv_prod]
+    exact hcomm.mul_inv_cancel
+  have hword : conjugate.toWord = single.toWord :=
+    neWord_toWord_eq_of_prod_eq hprod
+  have hlen := congrArg (fun q : Word G ↦ q.toList.length) hword
+  have hwpos : 0 < w.toList.length := List.length_pos_of_ne_nil w.toList_ne_nil
+  simp only [conjugate, middle, NeWord.toWord, NeWord.toList, List.length_append] at hlen
+  omega
+
+/-- In an indexed free product, if every element of one factor commutes with a fixed nonidentity
+letter of that factor, then its centralizer is contained in the factor. -/
+public theorem eq_of_of_commute_of {k : I} (s : G k) (hs : s ≠ 1)
+    (hfactor : ∀ a : G k, Commute a s) (x : Monoid.CoprodI G)
+    (hx : Commute x (Monoid.CoprodI.of s)) :
+    ∃ a : G k, x = Monoid.CoprodI.of a := by
+  let word := Word.equiv (M := G) x
+  have hwordProd : word.prod = x := by
+    exact (Word.equiv (M := G)).symm_apply_apply x
+  by_cases hword : word = Word.empty
+  · refine ⟨1, ?_⟩
+    rw [hword, Word.prod_empty] at hwordProd
+    simpa only [map_one] using hwordProd.symm
+  · obtain ⟨i, j, w, hw⟩ := NeWord.of_word word hword
+    have hprod : w.prod = x := by
+      change w.toWord.prod = x
+      rw [hw]
+      exact hwordProd
+    have hwcomm : Commute w.prod (Monoid.CoprodI.of s) := by
+      simpa only [hprod] using hx
+    by_cases hjk : j = k
+    · subst j
+      rcases BinaryIndexedCoprod.NeWord.singleton_or_init_last w with
+        hsingle | ⟨l, p, hlk, hsplit, _⟩
+      · refine ⟨w.last, ?_⟩
+        exact hprod.symm.trans hsingle.2.1
+      · have hletter : Commute (Monoid.CoprodI.of w.last) (Monoid.CoprodI.of s) :=
+          (hfactor w.last).map (Monoid.CoprodI.of : G k →* Monoid.CoprodI G)
+        have hwhole : Commute (p.prod * Monoid.CoprodI.of w.last)
+            (Monoid.CoprodI.of s) := by
+          simpa only [hsplit] using hwcomm
+        have hpcomm : Commute p.prod (Monoid.CoprodI.of s) := by
+          have hcancel := hwhole.mul_left hletter.inv_left
+          simpa only [mul_assoc, mul_inv_cancel, mul_one] using hcancel
+        exact (neWord_not_commute_of_last_ne p s hlk hs hpcomm).elim
+    · exact (neWord_not_commute_of_last_ne w s hjk hs hwcomm).elim
+
+end SphereSixComplex.TriangleGroup.FreeProductCentralizers
+
+namespace SphereSixComplex.TriangleGroup
+
+open BinaryIndexedCoprod
+open FreeProductCentralizers
+
+/-- An element commuting with the order-three generator lies in the embedded `C₃` factor. -/
+public theorem eq_inl_of_commute_g₁ (g : Delta) (h : Commute g g₁) :
+    ∃ a : CyclicThree, g = Monoid.Coprod.inl a := by
+  let s : DeltaFactor false := Multiplicative.ofAdd (1 : ZMod 3)
+  have hs : s ≠ 1 := by
+    intro h
+    have h' := congrArg Multiplicative.toAdd h
+    change (1 : ZMod 3) = 0 at h'
+    norm_num at h'
+  have hmapped : Commute (deltaToIndexed g) (Monoid.CoprodI.of s) := by
+    have hmapped' := h.map deltaToIndexed
+    rw [SphereSixComplex.TriangleGroup.g₁.eq_def, deltaToIndexed_inl] at hmapped'
+    exact hmapped'
+  obtain ⟨a, ha⟩ := eq_of_of_commute_of s hs (fun a ↦ by
+      change Commute (show CyclicThree from a)
+        (Multiplicative.ofAdd (1 : ZMod 3))
+      exact Commute.all _ _)
+    (deltaToIndexed g) hmapped
+  refine ⟨a, ?_⟩
+  apply deltaIndexedEquiv.injective
+  change deltaToIndexed g = deltaToIndexed (Monoid.Coprod.inl a)
+  exact ha.trans (deltaToIndexed_inl a).symm
+
+/-- An element commuting with the order-four generator lies in the embedded `C₄` factor. -/
+public theorem eq_inr_of_commute_g₂ (g : Delta) (h : Commute g g₂) :
+    ∃ a : CyclicFour, g = Monoid.Coprod.inr a := by
+  let s : DeltaFactor true := Multiplicative.ofAdd (1 : ZMod 4)
+  have hs : s ≠ 1 := by
+    intro h
+    have h' := congrArg Multiplicative.toAdd h
+    change (1 : ZMod 4) = 0 at h'
+    exact (by decide : (1 : ZMod 4) ≠ 0) h'
+  have hmapped : Commute (deltaToIndexed g) (Monoid.CoprodI.of s) := by
+    have hmapped' := h.map deltaToIndexed
+    rw [SphereSixComplex.TriangleGroup.g₂.eq_def, deltaToIndexed_inr] at hmapped'
+    exact hmapped'
+  obtain ⟨a, ha⟩ := eq_of_of_commute_of s hs (fun a ↦ by
+      change Commute (show CyclicFour from a)
+        (Multiplicative.ofAdd (1 : ZMod 4))
+      exact Commute.all _ _)
+    (deltaToIndexed g) hmapped
+  refine ⟨a, ?_⟩
+  apply deltaIndexedEquiv.injective
+  change deltaToIndexed g = deltaToIndexed (Monoid.Coprod.inr a)
+  exact ha.trans (deltaToIndexed_inr a).symm
+
+/-- Exact centralizer membership criterion for the order-three generator. -/
+public theorem commute_g₁_iff_eq_inl (g : Delta) :
+    Commute g g₁ ↔ ∃ a : CyclicThree, g = Monoid.Coprod.inl a := by
+  constructor
+  · exact eq_inl_of_commute_g₁ g
+  · rintro ⟨a, rfl⟩
+    rw [SphereSixComplex.TriangleGroup.g₁.eq_def]
+    exact (Commute.all a (Multiplicative.ofAdd (1 : ZMod 3))).map
+      (Monoid.Coprod.inl : CyclicThree →* Delta)
+
+/-- Exact centralizer membership criterion for the order-four generator. -/
+public theorem commute_g₂_iff_eq_inr (g : Delta) :
+    Commute g g₂ ↔ ∃ a : CyclicFour, g = Monoid.Coprod.inr a := by
+  constructor
+  · exact eq_inr_of_commute_g₂ g
+  · rintro ⟨a, rfl⟩
+    rw [SphereSixComplex.TriangleGroup.g₂.eq_def]
+    exact (Commute.all a (Multiplicative.ofAdd (1 : ZMod 4))).map
+      (Monoid.Coprod.inr : CyclicFour →* Delta)
+
+end SphereSixComplex.TriangleGroup

--- a/SphereSixComplex/TriangleGroup/FuchsianOneFixedCommutation.lean
+++ b/SphereSixComplex/TriangleGroup/FuchsianOneFixedCommutation.lean
@@ -1,0 +1,81 @@
+module
+
+public import SphereSixComplex.TriangleGroup.FuchsianArithmeticTermination
+public import Mathlib.Analysis.Complex.UpperHalfPlane.FixedPoints
+
+/-!
+# Commutation forced by the order-three Fuchsian fixed point
+
+An element of the explicit triangle group that fixes the order-three elliptic point commutes
+with the order-three generator.  The proof works with the canonical special-linear lift: the
+fixed-point equation forces its matrix to lie in the centralizer of `fuchsianOneSL`, and
+faithfulness of the Fuchsian action then reflects commutation back to the free product.
+-/
+
+open Matrix UpperHalfPlane
+open scoped MatrixGroups
+
+noncomputable section
+
+namespace SphereSixComplex.TriangleGroup
+
+open FuchsianArithmeticTermination
+
+/-- A triangle-group element fixing the order-three elliptic point commutes with the
+order-three generator. -/
+public theorem commute_gOne_of_fuchsianOneFixed (g : Delta)
+    (hg : fuchsianSourceAction g • fuchsianOneFixedPoint = fuchsianOneFixedPoint) :
+    Commute g g₁ := by
+  let A : SL2R := deltaRealSL g
+  have hfix :
+      (Matrix.SpecialLinearGroup.mapGL ℝ A) • fuchsianOneFixedPoint =
+        fuchsianOneFixedPoint := by
+    rw [fuchsianSourceAction_eq_deltaRealSL] at hg
+    exact hg
+  have hquad :=
+    (UpperHalfPlane.gl_smul_eq_self_iff_quadratic
+      (g := Matrix.SpecialLinearGroup.mapGL ℝ A)
+      (z := fuchsianOneFixedPoint)
+      (by norm_num [Matrix.SpecialLinearGroup.det_mapGL])).mp hfix
+  simp only [Matrix.SpecialLinearGroup.mapGL_coe_matrix,
+    Matrix.SpecialLinearGroup.map_apply_coe, RingHom.mapMatrix_apply, Matrix.map_apply,
+    Algebra.algebraMap_self, RingHom.id_apply, fuchsianOneFixedPoint] at hquad
+  change
+    ((A 1 0 : ℂ) *
+          ((⟨1 / 2, Real.sqrt 3 / 2⟩ : ℂ) * ⟨1 / 2, Real.sqrt 3 / 2⟩) +
+        ((A 1 1 : ℂ) - (A 0 0 : ℂ)) * ⟨1 / 2, Real.sqrt 3 / 2⟩ +
+        -(A 0 1 : ℂ)) = 0 at hquad
+  have him := congrArg Complex.im hquad
+  have hre := congrArg Complex.re hquad
+  norm_num [Complex.mul_re, Complex.mul_im] at him hre
+  have hsqrtmul : Real.sqrt 3 / 2 * (Real.sqrt 3 / 2) = (3 : ℝ) / 4 := by
+    nlinarith [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 3)]
+  rw [hsqrtmul] at hre
+  have him' :
+      (Real.sqrt 3 / 2) * (A 1 0 + A 1 1 - A 0 0) = 0 := by
+    linear_combination him
+  have hsqrt : Real.sqrt 3 / 2 ≠ 0 := by positivity
+  have hdiag : A 1 1 = A 0 0 - A 1 0 := by
+    have := (mul_eq_zero.mp him').resolve_left hsqrt
+    linarith
+  have hoff : A 0 1 = -A 1 0 := by
+    linarith
+  have hA : Commute A fuchsianOneSL := by
+    apply Subtype.ext
+    change
+      (A : Matrix (Fin 2) (Fin 2) ℝ) *
+          (fuchsianOneSL : Matrix (Fin 2) (Fin 2) ℝ) =
+        (fuchsianOneSL : Matrix (Fin 2) (Fin 2) ℝ) *
+          (A : Matrix (Fin 2) (Fin 2) ℝ)
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Matrix.mul_apply, Fin.sum_univ_succ, fuchsianOneSL, hdiag, hoff]
+    all_goals ring
+  apply FuchsianPingPong.fuchsianSourceAction_injective
+  rw [map_mul, map_mul, fuchsianSourceAction_eq_deltaRealSL,
+    fuchsianSourceAction_g₁]
+  change fuchsianSLAction A * fuchsianSLAction fuchsianOneSL =
+    fuchsianSLAction fuchsianOneSL * fuchsianSLAction A
+  simpa only [← map_mul] using congrArg fuchsianSLAction hA.eq
+
+end SphereSixComplex.TriangleGroup

--- a/SphereSixComplex/TriangleGroup/FuchsianTwoFixedCommutation.lean
+++ b/SphereSixComplex/TriangleGroup/FuchsianTwoFixedCommutation.lean
@@ -1,0 +1,89 @@
+module
+
+public import SphereSixComplex.TriangleGroup.FuchsianArithmeticTermination
+public import SphereSixComplex.TriangleGroup.FuchsianPingPong
+
+/-!
+# Commutation forced by the order-four fixed point
+
+An element of the `(3, 4, ∞)` triangle group which fixes the order-four
+elliptic point commutes with the order-four generator.  The proof is carried
+out on the chosen real special-linear lift and then transported back through
+the faithful Fuchsian action.
+-/
+
+open Matrix UpperHalfPlane
+open scoped MatrixGroups
+
+noncomputable section
+
+namespace SphereSixComplex.TriangleGroup.FuchsianTwoFixedCommutation
+
+open SphereSixComplex.TriangleGroup
+open SphereSixComplex.TriangleGroup.FuchsianArithmeticTermination
+
+private theorem specialLinear_commutes_with_fuchsianTwo_of_fixed
+    (A : SL2R)
+    (hfixed : fuchsianSLAction A • fuchsianTwoFixedPoint =
+      fuchsianTwoFixedPoint) :
+    Commute A fuchsianTwoSL := by
+  let G : GL (Fin 2) ℝ := Matrix.SpecialLinearGroup.mapGL ℝ A
+  have hcomplex := congrArg (fun z : UpperHalfPlane ↦ (z : ℂ)) hfixed
+  change ((G • fuchsianTwoFixedPoint : UpperHalfPlane) : ℂ) =
+    (fuchsianTwoFixedPoint : ℂ) at hcomplex
+  rw [UpperHalfPlane.coe_smul_of_det_pos] at hcomplex
+  · have hden : UpperHalfPlane.denom G (fuchsianTwoFixedPoint : ℂ) ≠ 0 :=
+      UpperHalfPlane.denom_ne_zero G fuchsianTwoFixedPoint
+    have hcross := (div_eq_iff hden).mp hcomplex
+    change
+      (A 0 0 : ℂ) * (fuchsianTwoFixedPoint : ℂ) + A 0 1 =
+        (fuchsianTwoFixedPoint : ℂ) *
+          ((A 1 0 : ℂ) * (fuchsianTwoFixedPoint : ℂ) + A 1 1)
+      at hcross
+    have hre := congrArg Complex.re hcross
+    have him := congrArg Complex.im hcross
+    have hsqrt : (Real.sqrt 2) ^ 2 = (2 : ℝ) :=
+      Real.sq_sqrt (by norm_num)
+    have hsqrt_pos : 0 < Real.sqrt 2 := Real.sqrt_pos.2 (by norm_num)
+    norm_num [fuchsianTwoFixedPoint, Complex.mul_re, Complex.mul_im] at hre him
+    have hd : A 1 1 = A 0 0 + Real.sqrt 2 * A 1 0 := by
+      have hmul : Real.sqrt 2 *
+          (A 1 1 - A 0 0 - Real.sqrt 2 * A 1 0) = 0 := by
+        nlinarith [hsqrt]
+      have hzero := (mul_eq_zero.mp hmul).resolve_left (ne_of_gt hsqrt_pos)
+      nlinarith
+    have hb : A 0 1 = -A 1 0 := by
+      rw [hd] at hre
+      ring_nf at hre
+      rw [hsqrt] at hre
+      linarith
+    apply Subtype.ext
+    change
+      (A : Matrix (Fin 2) (Fin 2) ℝ) *
+          (!![0, -1; 1, Real.sqrt 2] : Matrix (Fin 2) (Fin 2) ℝ) =
+        (!![0, -1; 1, Real.sqrt 2] : Matrix (Fin 2) (Fin 2) ℝ) * A
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Matrix.mul_apply, Fin.sum_univ_succ, hb, hd]
+    all_goals ring
+  · simp [G, Matrix.SpecialLinearGroup.det_mapGL]
+
+/-- Fixing the order-four elliptic point forces commutation with `g₂`. -/
+public theorem commute_gTwo_of_fuchsianTwoFixedPoint_fixed
+    (g : Delta)
+    (hfixed : fuchsianSourceAction g • fuchsianTwoFixedPoint =
+      fuchsianTwoFixedPoint) :
+    Commute g g₂ := by
+  have hmatrix : Commute (deltaRealSL g) fuchsianTwoSL :=
+    specialLinear_commutes_with_fuchsianTwo_of_fixed (deltaRealSL g) (by
+      rw [← fuchsianSourceAction_eq_deltaRealSL g]
+      exact hfixed)
+  apply FuchsianPingPong.fuchsianSourceAction_injective
+  simp only [map_mul, fuchsianSourceAction_eq_deltaRealSL g,
+    fuchsianSourceAction_g₂]
+  change
+    fuchsianSLAction (deltaRealSL g) * fuchsianSLAction fuchsianTwoSL =
+      fuchsianSLAction fuchsianTwoSL * fuchsianSLAction (deltaRealSL g)
+  rw [← map_mul, ← map_mul, hmatrix.eq]
+
+end SphereSixComplex.TriangleGroup.FuchsianTwoFixedCommutation


### PR DESCRIPTION
## Summary

- replace `establishedFuchsianOneStabilizerExact` and `establishedFuchsianTwoStabilizerExact` axioms with proved theorems
- add fixed-point commutation lemmas for the one- and two-stabilizer cases
- add generic free-product centralizer lemmas used by both proofs

## Verification

- refreshed the mathlib cache with `lake exe cache get`
- `lake build` completed successfully (4,275 jobs)
- `git diff --check` passes
- the target theorems were audited without `sorryAx` or project axioms; their remaining axioms are `propext`, `Classical.choice`, and `Quot.sound`
- the project import closure of the target file contains no `sorry` or `admit`

The full build replays unrelated existing `sorry` warnings in `SphereSixComplex/Final.lean` and `Challenge.lean`.