### PR TITLE
Make Challenge.lean self-contained over Mathlib

### DIFF
--- a/Challenge.lean
+++ b/Challenge.lean
@@ -1,6 +1,78 @@
 module
 
-public import SphereSixComplex.ComplexStructure
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+
+/-!
+# The Comparator challenge statement
+
+This module is the trusted statement boundary, and it depends only on Mathlib.  Every definition
+the final theorem mentions is declared here, so the challenge can be read and audited in full
+without opening any file in `SphereSixComplex/`.  The formalization re-exports these definitions
+through `SphereSixComplex.ComplexStructure`.
+
+The final theorem is stated as the existence of a complex atlas compatible with the standard smooth
+structure on the six-sphere. This is stronger than the existence of an almost-complex tangent
+endomorphism.
+-/
+
+open scoped ContDiff Manifold
+
+namespace SphereSixComplex
+
+/-- The standard unit six-sphere in seven-dimensional Euclidean space. -/
+public abbrev SixSphere : Type := ↥(Metric.sphere (0 : EuclideanSpace ℝ (Fin 7)) 1)
+
+/-- The complex vector space used as the local model for a complex threefold. -/
+public abbrev ComplexModel : Type := EuclideanSpace ℂ (Fin 3)
+
+/- The real vector space used by the standard smooth structure on the six-sphere. -/
+public abbrev RealModel : Type := EuclideanSpace ℝ (Fin 6)
+
+/-- A real-linear identification of the underlying real space of `ℂ³` with `ℝ⁶`. -/
+public noncomputable def complexToRealModel : ComplexModel ≃L[ℝ] RealModel :=
+  ContinuousLinearEquiv.ofFinrankEq (by
+    rw [finrank_real_of_complex]
+    norm_num [ComplexModel, RealModel])
+
+/-- The real coordinate system on `ℂ³` obtained from `complexToRealModel`. -/
+@[instance_reducible]
+public noncomputable def complexModelRealChartedSpace : ChartedSpace RealModel ComplexModel :=
+  complexToRealModel.symm.toHomeomorph.chartedSpace
+
+/-- The real atlas underlying a complex atlas. -/
+@[instance_reducible, expose]
+public noncomputable def underlyingRealChartedSpace {M : Type*} [TopologicalSpace M]
+    (c : ChartedSpace ComplexModel M) : ChartedSpace RealModel M :=
+  letI : ChartedSpace RealModel ComplexModel := complexModelRealChartedSpace
+  letI : ChartedSpace ComplexModel M := c
+  ChartedSpace.comp RealModel ComplexModel M
+
+/--
+A complex atlas is compatible with a specified smooth six-dimensional atlas when its underlying real
+atlas is diffeomorphic to that atlas. This prevents the final statement from forgetting the standard smooth
+structure on the sphere.
+-/
+@[expose]
+public def SmoothlyCompatible {M : Type*} [TopologicalSpace M]
+    (standard : ChartedSpace RealModel M) (complex : ChartedSpace ComplexModel M) : Prop :=
+  Nonempty
+    (@Diffeomorph ℝ inferInstance RealModel inferInstance inferInstance RealModel inferInstance
+      inferInstance RealModel inferInstance RealModel inferInstance 𝓘(ℝ, RealModel) 𝓘(ℝ, RealModel) M
+      inferInstance (underlyingRealChartedSpace complex) M inferInstance standard ∞)
+
+/--
+A standard smooth six-manifold admits a complex structure when it has a complex-differentiable atlas whose
+underlying real smooth structure is diffeomorphic to the specified one.
+-/
+@[expose]
+public def AdmitsComplexStructure (M : Type*) [TopologicalSpace M]
+    [standard : ChartedSpace RealModel M] : Prop :=
+  ∃ c : ChartedSpace ComplexModel M,
+    @IsManifold ℂ inferInstance ComplexModel inferInstance inferInstance ComplexModel inferInstance
+      𝓘(ℂ, ComplexModel) ∞ M inferInstance c ∧ SmoothlyCompatible standard c
+
+end SphereSixComplex
 
 open SphereSixComplex
 

--- a/SphereSixComplex/ComplexStructure.lean
+++ b/SphereSixComplex/ComplexStructure.lean
@@ -1,70 +1,11 @@
 module
 
-public import Mathlib.Geometry.Manifold.Instances.Sphere
-public import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+public import Challenge
 
 /-!
 # Complex Structures on the Six-Sphere
 
-The final theorem is stated as the existence of a complex atlas compatible with the standard smooth
-structure on the six-sphere. This is stronger than the existence of an almost-complex tangent
-endomorphism.
+The statement of the main theorem, and every definition it mentions, lives in `Challenge.lean` so
+that the Comparator boundary is self-contained and depends only on Mathlib.  This module re-exports
+those definitions to the rest of the development, so downstream imports are unchanged.
 -/
-
-open scoped ContDiff Manifold
-
-namespace SphereSixComplex
-
-/-- The standard unit six-sphere in seven-dimensional Euclidean space. -/
-public abbrev SixSphere : Type := ↥(Metric.sphere (0 : EuclideanSpace ℝ (Fin 7)) 1)
-
-/-- The complex vector space used as the local model for a complex threefold. -/
-public abbrev ComplexModel : Type := EuclideanSpace ℂ (Fin 3)
-
-/- The real vector space used by the standard smooth structure on the six-sphere. -/
-public abbrev RealModel : Type := EuclideanSpace ℝ (Fin 6)
-
-/-- A real-linear identification of the underlying real space of `ℂ³` with `ℝ⁶`. -/
-public noncomputable def complexToRealModel : ComplexModel ≃L[ℝ] RealModel :=
-  ContinuousLinearEquiv.ofFinrankEq (by
-    rw [finrank_real_of_complex]
-    norm_num [ComplexModel, RealModel])
-
-/-- The real coordinate system on `ℂ³` obtained from `complexToRealModel`. -/
-@[instance_reducible]
-public noncomputable def complexModelRealChartedSpace : ChartedSpace RealModel ComplexModel :=
-  complexToRealModel.symm.toHomeomorph.chartedSpace
-
-/-- The real atlas underlying a complex atlas. -/
-@[instance_reducible, expose]
-public noncomputable def underlyingRealChartedSpace {M : Type*} [TopologicalSpace M]
-    (c : ChartedSpace ComplexModel M) : ChartedSpace RealModel M :=
-  letI : ChartedSpace RealModel ComplexModel := complexModelRealChartedSpace
-  letI : ChartedSpace ComplexModel M := c
-  ChartedSpace.comp RealModel ComplexModel M
-
-/--
-A complex atlas is compatible with a specified smooth six-dimensional atlas when its underlying real
-atlas is diffeomorphic to that atlas. This prevents the final statement from forgetting the standard smooth
-structure on the sphere.
--/
-@[expose]
-public def SmoothlyCompatible {M : Type*} [TopologicalSpace M]
-    (standard : ChartedSpace RealModel M) (complex : ChartedSpace ComplexModel M) : Prop :=
-  Nonempty
-    (@Diffeomorph ℝ inferInstance RealModel inferInstance inferInstance RealModel inferInstance
-      inferInstance RealModel inferInstance RealModel inferInstance 𝓘(ℝ, RealModel) 𝓘(ℝ, RealModel) M
-      inferInstance (underlyingRealChartedSpace complex) M inferInstance standard ∞)
-
-/--
-A standard smooth six-manifold admits a complex structure when it has a complex-differentiable atlas whose
-underlying real smooth structure is diffeomorphic to the specified one.
--/
-@[expose]
-public def AdmitsComplexStructure (M : Type*) [TopologicalSpace M]
-    [standard : ChartedSpace RealModel M] : Prop :=
-  ∃ c : ChartedSpace ComplexModel M,
-    @IsManifold ℂ inferInstance ComplexModel inferInstance inferInstance ComplexModel inferInstance
-      𝓘(ℂ, ComplexModel) ∞ M inferInstance c ∧ SmoothlyCompatible standard c
-
-end SphereSixComplex


### PR DESCRIPTION
Would you consider making the trusted Comparator statement self-contained? Right now `Challenge.lean` imports `SphereSixComplex.ComplexStructure`, so auditing the challenge means also reading (and trusting the stability of) a file inside the development. This PR moves every definition the final theorem mentions into `Challenge.lean` itself.

`SphereSixComplex/ComplexStructure.lean` becomes a re-export shim (`public import Challenge`), so every existing `import SphereSixComplex.ComplexStructure` site keeps working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)