### PR TITLE
Generalize compact complex threefold homology input

### DIFF
--- a/SphereSixComplex/Topology/EstablishedCompactSmoothOrientedManifoldHomology.lean
+++ b/SphereSixComplex/Topology/EstablishedCompactSmoothOrientedManifoldHomology.lean
@@ -1,0 +1,38 @@
+module
+
+public import SphereSixComplex.Topology.IntegralPoincareUCT
+public import SphereSixComplex.Topology.SmoothAtlasOrientation
+
+/-!
+# Integral homology of compact smooth oriented manifolds
+
+This file is the single boundary for classical algebraic topology not yet present in Mathlib.
+Mathlib currently lacks the compact-manifold finite-CW theorem, singular cohomology and its integral
+UCT, manifold fundamental classes, and Poincare duality.  Those standard results are packaged here
+as one dimension-generic theorem.  The orientation input itself is concrete atlas data and is
+proved for complex manifolds in `SmoothAtlasOrientation`.
+-/
+
+@[expose] public section
+
+open scoped ContDiff Manifold
+
+namespace SphereSixComplex
+
+/-- Classical finite-CW, dimension-vanishing, integral UCT, and Poincare-duality theorem for a
+compact smooth oriented manifold without boundary.
+
+The self model gives a manifold without boundary.  Hausdorffness and second countability are the
+standard hypotheses used in smooth triangulation/finite-CW arguments.  This is the only new axiom:
+its conclusion is the reduced homological interface, not an application-specific homology answer. -/
+public axiom establishedCompactSmoothOrientedManifoldHomologyTheory
+    (d : ℕ) (E X : Type)
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    [TopologicalSpace X] [ChartedSpace E X]
+    [T2Space X] [SecondCountableTopology X]
+    (hManifold : IsManifold (modelWithCornersSelf ℝ E) 1 X)
+    (hOrientation : SmoothAtlasOrientation d E X)
+    (hCompact : CompactSpace X) :
+    IntegralPoincareUCTData d X
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/IntegralPoincareUCT.lean
+++ b/SphereSixComplex/Topology/IntegralPoincareUCT.lean
@@ -1,0 +1,207 @@
+module
+
+public import SphereSixComplex.Topology.HomologySphere
+public import Mathlib.LinearAlgebra.FreeModule.PID
+
+/-!
+# Integral Poincare duality and UCT, in homological form
+
+This file records the part of integral Poincare duality and the universal coefficient theorem that
+can be stated using Mathlib's existing singular-homology API.  Mathlib does not yet provide
+singular cohomology, cap products, or Poincare duality, so the interface below records only the
+resulting perfect evaluation pairings.  It is dimension-generic and independent of the application
+to Section 7.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology
+
+namespace SphereSixComplex
+
+/-- The homological consequences of integral Poincare duality and the integral UCT in real
+dimension `d`.
+
+The first equivalence is the composite
+`H_d ≃ H^0 ≃ Hom(H_0, ℤ)`.  In positive degree `k`, the UCT evaluation map becomes an
+isomorphism when `H_{k-1}` is free, giving the second family of equivalences after Poincare
+duality.  The remaining fields are finite generation and the dimension bound. -/
+public structure IntegralPoincareUCTData
+    (d : ℕ) (X : Type) [TopologicalSpace X] where
+  /-- The top-dimensional Poincare/UCT evaluation pairing. -/
+  topHomologyEquivDualZero :
+    IntegralSingularHomology d X ≃+ (IntegralSingularHomology 0 X →+ ℤ)
+  /-- The complementary-degree pairing when the UCT `Ext` term vanishes. -/
+  complementaryHomologyEquivDualOfPreviousFree : ∀ (k : Fin (d + 1)), 0 < k.1 →
+    Module.Free ℤ (IntegralSingularHomology (k.1 - 1) X) →
+      IntegralSingularHomology (d - k.1) X ≃+
+        (IntegralSingularHomology k.1 X →+ ℤ)
+  /-- Compact smooth manifolds have finitely generated integral homology. -/
+  finiteHomology : ∀ k, Module.Finite ℤ (IntegralSingularHomology k X)
+  /-- Homology vanishes above the real dimension. -/
+  homologyAboveDimension : ∀ k, d < k → Subsingleton (IntegralSingularHomology k X)
+
+/-- The dimension-six specialization used by the Section 7 calculation. -/
+public abbrev ClosedOrientedSixManifoldHomologyTheory
+    (X : Type) [TopologicalSpace X] := IntegralPoincareUCTData 6 X
+
+/-- The alternating integral-homology rank sum through real dimension six. -/
+public noncomputable def integralHomologyEulerCharacteristicSix
+    (X : Type) [TopologicalSpace X] : ℤ :=
+  (Module.finrank ℤ (IntegralSingularHomology 0 X) : ℤ) -
+  (Module.finrank ℤ (IntegralSingularHomology 1 X) : ℤ) +
+  (Module.finrank ℤ (IntegralSingularHomology 2 X) : ℤ) -
+  (Module.finrank ℤ (IntegralSingularHomology 3 X) : ℤ) +
+  (Module.finrank ℤ (IntegralSingularHomology 4 X) : ℤ) -
+  (Module.finrank ℤ (IntegralSingularHomology 5 X) : ℤ) +
+  (Module.finrank ℤ (IntegralSingularHomology 6 X) : ℤ)
+
+namespace ClosedOrientedSixManifoldHomologyTheory
+
+variable {X : Type} [TopologicalSpace X]
+
+private theorem subsingleton_of_addEquiv_to_subsingleton
+    {G H : Type} [AddCommGroup G] [AddCommGroup H] (e : G ≃+ H)
+    (hH : Subsingleton H) : Subsingleton G := by
+  constructor
+  intro x y
+  apply e.injective
+  exact @Subsingleton.elim H hH _ _
+
+private theorem hom_subsingleton_of_domain_subsingleton
+    {G : Type} [AddCommGroup G] (hG : Subsingleton G) : Subsingleton (G →+ ℤ) := by
+  constructor
+  intro f g
+  ext x
+  have hx : x = 0 := @Subsingleton.elim G hG x 0
+  simp only [hx, map_zero]
+
+private theorem moduleFree_of_addEquiv_integer {G : Type} [AddCommGroup G]
+    (e : G ≃+ ℤ) : Module.Free ℤ G :=
+  Module.Free.of_equiv' (inferInstance : Module.Free ℤ ℤ) e.symm.toIntLinearEquiv
+
+private theorem moduleFree_of_subsingleton {G : Type} [AddCommGroup G]
+    (hG : Subsingleton G) : Module.Free ℤ G := by
+  let _ : Subsingleton G := hG
+  exact inferInstance
+
+private theorem intDual_isTorsionFree {G : Type} [AddCommGroup G] :
+    Module.IsTorsionFree ℤ (G →+ ℤ) := by
+  rw [Module.isTorsionFree_iff_smul_eq_zero]
+  intro n f hnf
+  by_cases hn : n = 0
+  · exact Or.inl hn
+  right
+  ext x
+  have hx := DFunLike.congr_fun hnf x
+  simp only [AddMonoidHom.zero_apply, AddMonoidHom.smul_apply, smul_eq_mul] at hx
+  exact (mul_eq_zero.mp hx).resolve_left hn
+
+private theorem isTorsionFree_of_injective_to_intDual
+    {G H : Type} [AddCommGroup G] [AddCommGroup H]
+    (f : G →+ (H →+ ℤ)) (hf : Function.Injective f) : Module.IsTorsionFree ℤ G := by
+  let _ : Module.IsTorsionFree ℤ (H →+ ℤ) := intDual_isTorsionFree
+  exact Function.Injective.moduleIsTorsionFree f hf (fun n x ↦ map_zsmul f n x)
+
+public theorem homologyFive_subsingleton (T : ClosedOrientedSixManifoldHomologyTheory X)
+    (hZero : IntegralSingularHomology 0 X ≃+ ℤ)
+    (hOne : Subsingleton (IntegralSingularHomology 1 X)) :
+    Subsingleton (IntegralSingularHomology 5 X) := by
+  let hFreeZero : Module.Free ℤ (IntegralSingularHomology 0 X) :=
+    moduleFree_of_addEquiv_integer hZero
+  have hDual : Subsingleton (IntegralSingularHomology 1 X →+ ℤ) :=
+    hom_subsingleton_of_domain_subsingleton hOne
+  exact subsingleton_of_addEquiv_to_subsingleton
+    (T.complementaryHomologyEquivDualOfPreviousFree 1 (by norm_num) hFreeZero) hDual
+
+public theorem homologyFour_subsingleton (T : ClosedOrientedSixManifoldHomologyTheory X)
+    (hOne : Subsingleton (IntegralSingularHomology 1 X))
+    (hTwo : Subsingleton (IntegralSingularHomology 2 X)) :
+    Subsingleton (IntegralSingularHomology 4 X) := by
+  let hFreeOne : Module.Free ℤ (IntegralSingularHomology 1 X) :=
+    moduleFree_of_subsingleton hOne
+  have hDual : Subsingleton (IntegralSingularHomology 2 X →+ ℤ) :=
+    hom_subsingleton_of_domain_subsingleton hTwo
+  exact subsingleton_of_addEquiv_to_subsingleton
+    (T.complementaryHomologyEquivDualOfPreviousFree 2 (by norm_num) hFreeOne) hDual
+
+public theorem homologyThree_isTorsionFree
+    (T : ClosedOrientedSixManifoldHomologyTheory X)
+    (hTwo : Subsingleton (IntegralSingularHomology 2 X)) :
+    Module.IsTorsionFree ℤ (IntegralSingularHomology 3 X) := by
+  let hFreeTwo : Module.Free ℤ (IntegralSingularHomology 2 X) :=
+    moduleFree_of_subsingleton hTwo
+  let e := T.complementaryHomologyEquivDualOfPreviousFree 3 (by norm_num) hFreeTwo
+  exact isTorsionFree_of_injective_to_intDual e.toAddMonoidHom e.injective
+
+public noncomputable def homologySixEquivInteger
+    (T : ClosedOrientedSixManifoldHomologyTheory X)
+    (hZero : IntegralSingularHomology 0 X ≃+ ℤ) :
+    IntegralSingularHomology 6 X ≃+ ℤ := by
+  let precomp : (IntegralSingularHomology 0 X →+ ℤ) ≃+ (ℤ →+ ℤ) := {
+    toFun := fun (f : IntegralSingularHomology 0 X →+ ℤ) ↦
+      f.comp hZero.symm.toAddMonoidHom
+    invFun := fun (f : ℤ →+ ℤ) ↦ f.comp hZero.toAddMonoidHom
+    left_inv f := by
+      ext x
+      simp
+    right_inv f := AddMonoidHom.ext_int (by simp)
+    map_add' f g := AddMonoidHom.ext_int rfl }
+  let evalOne : (ℤ →+ ℤ) ≃+ ℤ := {
+    toFun := fun f ↦ f 1
+    invFun := AddMonoidHom.mulLeft
+    left_inv := fun f ↦ AddMonoidHom.ext_int (by simp)
+    right_inv := by
+      intro n
+      change n * 1 = n
+      exact mul_one n
+    map_add' := by simp }
+  exact T.topHomologyEquivDualZero.trans (precomp.trans evalOne)
+
+private theorem finrank_zero_of_subsingleton_finite {G : Type} [AddCommGroup G]
+    (hFinite : Module.Finite ℤ G) (hG : Subsingleton G) : Module.finrank ℤ G = 0 := by
+  let _ : Module.Finite ℤ G := hFinite
+  let _ : Subsingleton G := hG
+  let _ : Module.Free ℤ G := inferInstance
+  exact Module.finrank_eq_zero_of_subsingleton ℤ G
+
+private theorem finrank_one_of_addEquiv_integer {G : Type} [AddCommGroup G]
+    (e : G ≃+ ℤ) : Module.finrank ℤ G = 1 := by
+  rw [e.toIntLinearEquiv.finrank_eq]
+  simp
+
+public theorem homologyThree_subsingleton_of_eulerCharacteristic
+    (T : ClosedOrientedSixManifoldHomologyTheory X)
+    (hZero : IntegralSingularHomology 0 X ≃+ ℤ)
+    (hOne : Subsingleton (IntegralSingularHomology 1 X))
+    (hTwo : Subsingleton (IntegralSingularHomology 2 X))
+    (hEuler : integralHomologyEulerCharacteristicSix X = 2) :
+    Subsingleton (IntegralSingularHomology 3 X) := by
+  have hFive := T.homologyFive_subsingleton hZero hOne
+  have hFour := T.homologyFour_subsingleton hOne hTwo
+  let hSix := T.homologySixEquivInteger hZero
+  have h0rank : Module.finrank ℤ (IntegralSingularHomology 0 X) = 1 :=
+    finrank_one_of_addEquiv_integer hZero
+  have h1rank : Module.finrank ℤ (IntegralSingularHomology 1 X) = 0 :=
+    finrank_zero_of_subsingleton_finite (T.finiteHomology 1) hOne
+  have h2rank : Module.finrank ℤ (IntegralSingularHomology 2 X) = 0 :=
+    finrank_zero_of_subsingleton_finite (T.finiteHomology 2) hTwo
+  have h4rank : Module.finrank ℤ (IntegralSingularHomology 4 X) = 0 :=
+    finrank_zero_of_subsingleton_finite (T.finiteHomology 4) hFour
+  have h5rank : Module.finrank ℤ (IntegralSingularHomology 5 X) = 0 :=
+    finrank_zero_of_subsingleton_finite (T.finiteHomology 5) hFive
+  have h6rank : Module.finrank ℤ (IntegralSingularHomology 6 X) = 1 :=
+    finrank_one_of_addEquiv_integer hSix
+  have h3rank : Module.finrank ℤ (IntegralSingularHomology 3 X) = 0 := by
+    unfold integralHomologyEulerCharacteristicSix at hEuler
+    omega
+  let _ : Module.Finite ℤ (IntegralSingularHomology 3 X) := T.finiteHomology 3
+  let _ : Module.IsTorsionFree ℤ (IntegralSingularHomology 3 X) :=
+    T.homologyThree_isTorsionFree hTwo
+  exact Module.finrank_zero_iff.mp h3rank
+
+end ClosedOrientedSixManifoldHomologyTheory
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SectionSevenSixManifoldCompletion.lean
+++ b/SphereSixComplex/Topology/SectionSevenSixManifoldCompletion.lean
@@ -1,24 +1,21 @@
 module
 
+public import SphereSixComplex.Topology.EstablishedCompactSmoothOrientedManifoldHomology
 public import SphereSixComplex.Topology.EstablishedSphereHomology
 public import SphereSixComplex.Topology.SectionSevenMayerVietorisHomologyAssembly
 public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
-public import Mathlib.LinearAlgebra.FreeModule.PID
 
 /-!
 # Completing the Section 7 homology calculation by six-manifold duality
 
-The Mayer--Vietoris calculation supplies the vanishing of `H₁` and `H₂`.  This file isolates the
-standard general-topology input needed to finish the calculation for a compact connected complex
-threefold: finite generation and dimension bounds, integral Poincaré duality, the universal
-coefficient theorem, and Euler--Poincaré.  No field of the general-topology package records the
-desired homology groups of the glued space.
+The Mayer--Vietoris calculation supplies the vanishing of `H₁` and `H₂`. General compact
+oriented-manifold topology then supplies finite generation, the dimension bound, and the integral
+Poincare-duality/UCT pairings needed to finish the calculation. The complex atlas orientation is
+proved from its transition derivatives; only the dimension-generic classical manifold homology
+theorem remains behind the reusable established-theorem boundary.
 
-Mathlib currently has neither singular cohomology nor Poincaré duality for manifolds.  The exact
-UCT and duality interface below, and the theorem supplying it for compact complex threefolds, are
-therefore isolated as an established general theorem.  The final Section 7 theorem additionally
-requires the numerical Euler characteristic `2`; that geometric calculation is deliberately an
-explicit hypothesis.
+The final Section 7 theorem additionally requires the numerical Euler characteristic `2`; that
+geometric calculation remains an explicit hypothesis here.
 -/
 
 @[expose] public section
@@ -30,55 +27,27 @@ open scoped ContDiff Manifold
 
 namespace SphereSixComplex
 
-/-- The alternating integral-homology rank sum through real dimension six. -/
-public noncomputable def integralHomologyEulerCharacteristicSix
-    (X : Type) [TopologicalSpace X] : ℤ :=
-  (Module.finrank ℤ (IntegralSingularHomology 0 X) : ℤ) -
-  (Module.finrank ℤ (IntegralSingularHomology 1 X) : ℤ) +
-  (Module.finrank ℤ (IntegralSingularHomology 2 X) : ℤ) -
-  (Module.finrank ℤ (IntegralSingularHomology 3 X) : ℤ) +
-  (Module.finrank ℤ (IntegralSingularHomology 4 X) : ℤ) -
-  (Module.finrank ℤ (IntegralSingularHomology 5 X) : ℤ) +
-  (Module.finrank ℤ (IntegralSingularHomology 6 X) : ℤ)
+/-- Classical compact oriented-manifold homology specialized to a complex threefold.
 
-/-- The exact part of integral Poincaré duality and UCT used in real dimension six.
-
-`cohomology k` models `H^k(X; ℤ)`.  The evaluation map is the UCT quotient
-`H^k(X; ℤ) → Hom(H_k(X; ℤ), ℤ)`.  Its kernel is `Ext(H_{k-1}(X; ℤ), ℤ)`, so it is injective when
-the preceding homology group is free. -/
-public structure ClosedOrientedSixManifoldHomologyTheory
-    (X : Type) [TopologicalSpace X] where
-  /-- Integral singular cohomology in degrees zero through six. -/
-  cohomology : Fin 7 → AddCommGrpCat
-  /-- Cap product with the fundamental class. -/
-  poincareDuality : ∀ k : Fin 7,
-    cohomology k ≃+ IntegralSingularHomology (6 - k.1) X
-  /-- The UCT evaluation map to the integral dual of homology. -/
-  uctEvaluation : ∀ k : Fin 7,
-    cohomology k →+ (IntegralSingularHomology k.1 X →+ ℤ)
-  /-- The UCT evaluation map is always onto. -/
-  uctEvaluation_surjective : ∀ k, Function.Surjective (uctEvaluation k)
-  /-- In degree zero there is no `Ext` term. -/
-  uctEvaluation_zero_injective : Function.Injective (uctEvaluation 0)
-  /-- A free preceding homology group kills the UCT `Ext` term. -/
-  uctEvaluation_injective_of_previous_free : ∀ (k : Fin 7), 0 < k.1 →
-    Module.Free ℤ (IntegralSingularHomology (k.1 - 1) X) →
-      Function.Injective (uctEvaluation k)
-  /-- Compact manifolds have finitely generated integral homology. -/
-  finiteHomology : ∀ k, Module.Finite ℤ (IntegralSingularHomology k X)
-  /-- A six-manifold has no homology above its dimension. -/
-  homologyAboveDimension : ∀ k, 6 < k → Subsingleton (IntegralSingularHomology k X)
-
-/-- Classical finite-CW, integral UCT, and integral Poincaré-duality package for a compact complex
-threefold.  A complex atlas gives the real orientation canonically; compactness gives closedness,
-and the self model has no boundary.  Hausdorffness and second countability are included because
-they are needed by the standard finite-CW-type theorem for manifolds. -/
-public axiom establishedCompactComplexThreefoldHomologyTheory
+The complex atlas is converted to a real smooth atlas on the same model carrier. Its orientation
+is constructed from the complex transition maps, whose real determinants are positive. -/
+public noncomputable def establishedCompactComplexThreefoldHomologyTheory
     (X : Type) [TopologicalSpace X] [ChartedSpace ComplexModel X]
     [T2Space X] [SecondCountableTopology X]
     (hManifold : IsManifold (modelWithCornersSelf ℂ ComplexModel) ∞ X)
     (hCompact : CompactSpace X) :
-    ClosedOrientedSixManifoldHomologyTheory X
+    ClosedOrientedSixManifoldHomologyTheory X := by
+  letI : IsManifold (modelWithCornersSelf ℂ ComplexModel) ∞ X := hManifold
+  let hComplexOne : IsManifold (modelWithCornersSelf ℂ ComplexModel) 1 X := inferInstance
+  let hRealOne : IsManifold (modelWithCornersSelf ℝ ComplexModel) 1 X :=
+    isManifoldRealOfComplex hComplexOne
+  have hdim : Module.finrank ℝ ComplexModel = 6 := by
+    rw [finrank_real_of_complex]
+    norm_num [ComplexModel]
+  let hOrientation : SmoothAtlasOrientation 6 ComplexModel X :=
+    hdim ▸ smoothAtlasOrientationOfComplex hComplexOne
+  exact establishedCompactSmoothOrientedManifoldHomologyTheory
+    6 ComplexModel X hRealOne hOrientation hCompact
 
 /-- Degree-zero homology of a connected complex manifold is infinite cyclic. -/
 public noncomputable def connectedComplexManifoldHomologyZeroEquivInteger
@@ -90,174 +59,6 @@ public noncomputable def connectedComplexManifoldHomologyZeroEquivInteger
   let _ : PathConnectedSpace X := PathConnectedSpace.of_locallyPathConnectedSpace
   exact (asIso ((TopCat.of X).singularHomology₀ε (AddCommGrpCat.of ℤ)))
     |>.addCommGroupIsoToAddEquiv
-
-namespace ClosedOrientedSixManifoldHomologyTheory
-
-variable {X : Type} [TopologicalSpace X]
-
-private theorem subsingleton_of_addEquiv_to_subsingleton
-    {G H : Type} [AddCommGroup G] [AddCommGroup H] (e : G ≃+ H)
-    (hH : Subsingleton H) : Subsingleton G := by
-  constructor
-  intro x y
-  apply e.injective
-  exact @Subsingleton.elim H hH _ _
-
-private theorem hom_subsingleton_of_domain_subsingleton
-    {G : Type} [AddCommGroup G] (hG : Subsingleton G) : Subsingleton (G →+ ℤ) := by
-  constructor
-  intro f g
-  ext x
-  have hx : x = 0 := @Subsingleton.elim G hG x 0
-  simp only [hx, map_zero]
-
-private theorem subsingleton_of_injective_to_subsingleton
-    {G H : Type} [AddCommGroup G] [AddCommGroup H] (f : G →+ H)
-    (hf : Function.Injective f) (hH : Subsingleton H) : Subsingleton G := by
-  constructor
-  intro x y
-  apply hf
-  exact @Subsingleton.elim H hH _ _
-
-private theorem moduleFree_of_addEquiv_integer {G : Type} [AddCommGroup G]
-    (e : G ≃+ ℤ) : Module.Free ℤ G :=
-  Module.Free.of_equiv' (inferInstance : Module.Free ℤ ℤ) e.symm.toIntLinearEquiv
-
-private theorem moduleFree_of_subsingleton {G : Type} [AddCommGroup G]
-    (hG : Subsingleton G) : Module.Free ℤ G := by
-  let _ : Subsingleton G := hG
-  exact inferInstance
-
-private theorem intDual_isTorsionFree {G : Type} [AddCommGroup G] :
-    Module.IsTorsionFree ℤ (G →+ ℤ) := by
-  rw [Module.isTorsionFree_iff_smul_eq_zero]
-  intro n f hnf
-  by_cases hn : n = 0
-  · exact Or.inl hn
-  right
-  ext x
-  have hx := DFunLike.congr_fun hnf x
-  simp only [AddMonoidHom.zero_apply, AddMonoidHom.smul_apply, smul_eq_mul] at hx
-  exact (mul_eq_zero.mp hx).resolve_left hn
-
-private theorem isTorsionFree_of_injective_to_intDual
-    {G H : Type} [AddCommGroup G] [AddCommGroup H]
-    (f : G →+ (H →+ ℤ)) (hf : Function.Injective f) : Module.IsTorsionFree ℤ G := by
-  let _ : Module.IsTorsionFree ℤ (H →+ ℤ) := intDual_isTorsionFree
-  exact Function.Injective.moduleIsTorsionFree f hf (fun n x ↦ map_zsmul f n x)
-
-public theorem homologyFive_subsingleton (T : ClosedOrientedSixManifoldHomologyTheory X)
-    (hZero : IntegralSingularHomology 0 X ≃+ ℤ)
-    (hOne : Subsingleton (IntegralSingularHomology 1 X)) :
-    Subsingleton (IntegralSingularHomology 5 X) := by
-  let hFreeZero : Module.Free ℤ (IntegralSingularHomology 0 X) :=
-    moduleFree_of_addEquiv_integer hZero
-  have hEval : Function.Injective (T.uctEvaluation (1 : Fin 7)) :=
-    T.uctEvaluation_injective_of_previous_free 1 (by omega) hFreeZero
-  have hDual : Subsingleton (IntegralSingularHomology 1 X →+ ℤ) :=
-    hom_subsingleton_of_domain_subsingleton hOne
-  have hCohomology : Subsingleton (T.cohomology 1) :=
-    subsingleton_of_injective_to_subsingleton _ hEval hDual
-  exact subsingleton_of_addEquiv_to_subsingleton (T.poincareDuality 1).symm hCohomology
-
-public theorem homologyFour_subsingleton (T : ClosedOrientedSixManifoldHomologyTheory X)
-    (hOne : Subsingleton (IntegralSingularHomology 1 X))
-    (hTwo : Subsingleton (IntegralSingularHomology 2 X)) :
-    Subsingleton (IntegralSingularHomology 4 X) := by
-  let hFreeOne : Module.Free ℤ (IntegralSingularHomology 1 X) :=
-    moduleFree_of_subsingleton hOne
-  have hEval : Function.Injective (T.uctEvaluation (2 : Fin 7)) :=
-    T.uctEvaluation_injective_of_previous_free 2 (by omega) hFreeOne
-  have hDual : Subsingleton (IntegralSingularHomology 2 X →+ ℤ) :=
-    hom_subsingleton_of_domain_subsingleton hTwo
-  have hCohomology : Subsingleton (T.cohomology 2) :=
-    subsingleton_of_injective_to_subsingleton _ hEval hDual
-  exact subsingleton_of_addEquiv_to_subsingleton (T.poincareDuality 2).symm hCohomology
-
-public theorem homologyThree_isTorsionFree
-    (T : ClosedOrientedSixManifoldHomologyTheory X)
-    (hTwo : Subsingleton (IntegralSingularHomology 2 X)) :
-    Module.IsTorsionFree ℤ (IntegralSingularHomology 3 X) := by
-  let hFreeTwo : Module.Free ℤ (IntegralSingularHomology 2 X) :=
-    moduleFree_of_subsingleton hTwo
-  have hEval : Function.Injective (T.uctEvaluation (3 : Fin 7)) :=
-    T.uctEvaluation_injective_of_previous_free 3 (by omega) hFreeTwo
-  let f : IntegralSingularHomology 3 X →+
-      (IntegralSingularHomology 3 X →+ ℤ) :=
-    (T.uctEvaluation 3).comp (T.poincareDuality 3).symm.toAddMonoidHom
-  have hf : Function.Injective f := hEval.comp (T.poincareDuality 3).symm.injective
-  exact isTorsionFree_of_injective_to_intDual f hf
-
-public noncomputable def homologySixEquivInteger
-    (T : ClosedOrientedSixManifoldHomologyTheory X)
-    (hZero : IntegralSingularHomology 0 X ≃+ ℤ) :
-    IntegralSingularHomology 6 X ≃+ ℤ := by
-  let evalEquiv : T.cohomology 0 ≃+ (IntegralSingularHomology 0 X →+ ℤ) :=
-    AddEquiv.ofBijective (T.uctEvaluation 0)
-      ⟨T.uctEvaluation_zero_injective, T.uctEvaluation_surjective 0⟩
-  let precomp : (IntegralSingularHomology 0 X →+ ℤ) ≃+ (ℤ →+ ℤ) := {
-    toFun := fun (f : IntegralSingularHomology 0 X →+ ℤ) ↦
-      f.comp hZero.symm.toAddMonoidHom
-    invFun := fun (f : ℤ →+ ℤ) ↦ f.comp hZero.toAddMonoidHom
-    left_inv f := by
-      ext x
-      simp
-    right_inv f := AddMonoidHom.ext_int (by simp)
-    map_add' f g := AddMonoidHom.ext_int rfl }
-  let evalOne : (ℤ →+ ℤ) ≃+ ℤ := {
-    toFun := fun f ↦ f 1
-    invFun := AddMonoidHom.mulLeft
-    left_inv := fun f ↦ AddMonoidHom.ext_int (by simp)
-    right_inv := by
-      intro n
-      change n * 1 = n
-      exact mul_one n
-    map_add' := by simp }
-  exact (T.poincareDuality 0).symm.trans (evalEquiv.trans (precomp.trans evalOne))
-
-private theorem finrank_zero_of_subsingleton_finite {G : Type} [AddCommGroup G]
-    (hFinite : Module.Finite ℤ G) (hG : Subsingleton G) : Module.finrank ℤ G = 0 := by
-  let _ : Module.Finite ℤ G := hFinite
-  let _ : Subsingleton G := hG
-  let _ : Module.Free ℤ G := inferInstance
-  exact Module.finrank_eq_zero_of_subsingleton ℤ G
-
-private theorem finrank_one_of_addEquiv_integer {G : Type} [AddCommGroup G]
-    (e : G ≃+ ℤ) : Module.finrank ℤ G = 1 := by
-  rw [e.toIntLinearEquiv.finrank_eq]
-  simp
-
-public theorem homologyThree_subsingleton_of_eulerCharacteristic
-    (T : ClosedOrientedSixManifoldHomologyTheory X)
-    (hZero : IntegralSingularHomology 0 X ≃+ ℤ)
-    (hOne : Subsingleton (IntegralSingularHomology 1 X))
-    (hTwo : Subsingleton (IntegralSingularHomology 2 X))
-    (hEuler : integralHomologyEulerCharacteristicSix X = 2) :
-    Subsingleton (IntegralSingularHomology 3 X) := by
-  have hFive := T.homologyFive_subsingleton hZero hOne
-  have hFour := T.homologyFour_subsingleton hOne hTwo
-  let hSix := T.homologySixEquivInteger hZero
-  have h0rank : Module.finrank ℤ (IntegralSingularHomology 0 X) = 1 :=
-    finrank_one_of_addEquiv_integer hZero
-  have h1rank : Module.finrank ℤ (IntegralSingularHomology 1 X) = 0 :=
-    finrank_zero_of_subsingleton_finite (T.finiteHomology 1) hOne
-  have h2rank : Module.finrank ℤ (IntegralSingularHomology 2 X) = 0 :=
-    finrank_zero_of_subsingleton_finite (T.finiteHomology 2) hTwo
-  have h4rank : Module.finrank ℤ (IntegralSingularHomology 4 X) = 0 :=
-    finrank_zero_of_subsingleton_finite (T.finiteHomology 4) hFour
-  have h5rank : Module.finrank ℤ (IntegralSingularHomology 5 X) = 0 :=
-    finrank_zero_of_subsingleton_finite (T.finiteHomology 5) hFive
-  have h6rank : Module.finrank ℤ (IntegralSingularHomology 6 X) = 1 :=
-    finrank_one_of_addEquiv_integer hSix
-  have h3rank : Module.finrank ℤ (IntegralSingularHomology 3 X) = 0 := by
-    unfold integralHomologyEulerCharacteristicSix at hEuler
-    omega
-  let _ : Module.Finite ℤ (IntegralSingularHomology 3 X) := T.finiteHomology 3
-  let _ : Module.IsTorsionFree ℤ (IntegralSingularHomology 3 X) :=
-    T.homologyThree_isTorsionFree hTwo
-  exact Module.finrank_zero_iff.mp h3rank
-
-end ClosedOrientedSixManifoldHomologyTheory
 
 private noncomputable def addEquivOfSubsingleton
     {G H : Type} [AddCommGroup G] [AddCommGroup H]

--- a/SphereSixComplex/Topology/SmoothAtlasOrientation.lean
+++ b/SphereSixComplex/Topology/SmoothAtlasOrientation.lean
@@ -1,0 +1,119 @@
+module
+
+public import Mathlib.Geometry.Manifold.IsManifold.ExtChartAt
+public import Mathlib.LinearAlgebra.Orientation
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.RingTheory.Norm.Transitivity
+public import Mathlib.RingTheory.Complex
+public import Mathlib.LinearAlgebra.Complex.FiniteDimensional
+
+/-!
+# Orientations carried by smooth atlases
+
+Mathlib has linear orientations but no orientation structure for manifolds.  This file supplies the
+small atlas-level certificate needed by Poincare duality: a real orientation of the model space
+that is preserved by every transition map in the chosen atlas.
+
+It also proves the standard fact that a complex atlas has such an orientation.  The proof restricts
+complex derivatives to the reals and uses that their real determinant is the squared norm of the
+complex determinant.
+-/
+
+@[expose] public section
+
+open scoped ContDiff Manifold
+
+noncomputable section
+
+namespace SphereSixComplex
+
+/-- An orientation of a real `d`-dimensional model space preserved by the transition derivatives
+of a chosen smooth atlas.
+
+This intentionally quantifies over `atlas`, not `IsManifold.maximalAtlas`: the maximal smooth atlas
+also contains orientation-reversing charts.  A real `IsManifold` hypothesis is kept separate by the
+consumer, so the derivative appearing here is known to be the derivative of a smooth transition. -/
+public structure SmoothAtlasOrientation (d : ℕ) (E M : Type*)
+    [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace M] [ChartedSpace E M] where
+  /-- The selected orientation of the model vector space. -/
+  orientation : Orientation ℝ E (Fin d)
+  /-- The model really has real dimension `d`. -/
+  dimension_eq : Module.finrank ℝ E = d
+  /-- Every transition derivative in the selected atlas preserves the orientation. -/
+  transitionDerivativePreserves :
+    ∀ (e e' : OpenPartialHomeomorph M E), e ∈ atlas E M → e' ∈ atlas E M →
+      ∀ x ∈ ((modelWithCornersSelf ℝ E).extendCoordChange e e').source,
+        ∃ D : E ≃L[ℝ] E,
+          (D : E →L[ℝ] E) = fderivWithin ℝ
+              ((modelWithCornersSelf ℝ E).extendCoordChange e e')
+              ((modelWithCornersSelf ℝ E).extendCoordChange e e').source x ∧
+            Orientation.map (Fin d) D.toLinearEquiv orientation = orientation
+
+/-- A complex manifold is a real manifold on the same chart carrier and with the same selected
+atlas. -/
+public theorem isManifoldRealOfComplex
+    {E M : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    [TopologicalSpace M] [ChartedSpace E M] {n : ℕ∞ω}
+    (h : IsManifold (modelWithCornersSelf ℂ E) n M) :
+    IsManifold (modelWithCornersSelf ℝ E) n M := by
+  let _ : IsManifold (modelWithCornersSelf ℂ E) n M := h
+  apply isManifold_of_contDiffOn (modelWithCornersSelf ℝ E) n M
+  intro e e' he he'
+  have hc := (modelWithCornersSelf ℂ E).contDiffOn_extendCoordChange
+    (IsManifold.subset_maximalAtlas (I := modelWithCornersSelf ℂ E) (n := n) he)
+    (IsManifold.subset_maximalAtlas (I := modelWithCornersSelf ℂ E) (n := n) he')
+  simpa [ModelWithCorners.extendCoordChange, modelWithCornersSelf_coe,
+    modelWithCornersSelf_coe_symm] using hc.restrict_scalars ℝ
+
+/-- A complex-linear equivalence preserves every real orientation of its underlying real vector
+space. -/
+public theorem complexLinearEquiv_preserves_real_orientation
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    [FiniteDimensional ℂ E] {d : ℕ}
+    (o : Orientation ℝ E (Fin d)) (hd : Module.finrank ℝ E = d)
+    (f : E ≃L[ℂ] E) :
+    Orientation.map (Fin d) (f.restrictScalars ℝ).toLinearEquiv o = o := by
+  apply (Orientation.map_eq_iff_det_pos o
+    (f.restrictScalars ℝ).toLinearEquiv (by simpa using hd.symm)).2
+  change 0 < LinearMap.det ((f.toLinearEquiv : E →ₗ[ℂ] E).restrictScalars ℝ)
+  rw [LinearMap.det_restrictScalars, Algebra.norm_complex_apply]
+  exact Complex.normSq_pos.mpr f.toLinearEquiv.isUnit_det'.ne_zero
+
+/-- An atlas orientation of a complex manifold, viewed in its real dimension. -/
+public noncomputable def smoothAtlasOrientationOfComplex
+    {E M : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    [FiniteDimensional ℂ E] [TopologicalSpace M] [ChartedSpace E M]
+    (h : IsManifold (modelWithCornersSelf ℂ E) 1 M) :
+    SmoothAtlasOrientation (Module.finrank ℝ E) E M := by
+  letI : IsManifold (modelWithCornersSelf ℂ E) 1 M := h
+  refine ⟨(Module.finBasis ℝ E).orientation, rfl, ?_⟩
+  intro e e' he he' x hx
+  have hInv := (modelWithCornersSelf ℂ E).isInvertible_fderivWithin_extendCoordChange
+    (n := 1) one_ne_zero
+    (IsManifold.subset_maximalAtlas (I := modelWithCornersSelf ℂ E) (n := 1) he)
+    (IsManifold.subset_maximalAtlas (I := modelWithCornersSelf ℂ E) (n := 1) he') hx
+  obtain ⟨D, hD⟩ := hInv
+  refine ⟨D.restrictScalars ℝ, ?_,
+    complexLinearEquiv_preserves_real_orientation (Module.finBasis ℝ E).orientation rfl D⟩
+  have hdiff : DifferentiableWithinAt ℂ
+      ((modelWithCornersSelf ℂ E).extendCoordChange e e')
+      ((modelWithCornersSelf ℂ E).extendCoordChange e e').source x :=
+    ((modelWithCornersSelf ℂ E).contDiffOn_extendCoordChange
+      (IsManifold.subset_maximalAtlas (I := modelWithCornersSelf ℂ E) (n := 1) he)
+      (IsManifold.subset_maximalAtlas (I := modelWithCornersSelf ℂ E) (n := 1) he')
+      x hx).differentiableWithinAt one_ne_zero
+  have hDr := hdiff.restrictScalars_fderivWithin (𝕜 := ℝ)
+    ((modelWithCornersSelf ℝ E).uniqueDiffOn_extendCoordChange_source x hx)
+  apply ContinuousLinearMap.ext
+  intro y
+  change D y = fderivWithin ℝ
+    ((modelWithCornersSelf ℝ E).extendCoordChange e e')
+    ((modelWithCornersSelf ℝ E).extendCoordChange e e').source x y
+  rw [show D y = fderivWithin ℂ
+      ((modelWithCornersSelf ℂ E).extendCoordChange e e')
+      ((modelWithCornersSelf ℂ E).extendCoordChange e e').source x y by
+    exact DFunLike.congr_fun hD y]
+  exact DFunLike.congr_fun hDr y
+
+end SphereSixComplex


### PR DESCRIPTION
Closes #31

## Summary

- Replaces establishedCompactComplexThreefoldHomologyTheory as an axiom with a proved specialization of a reusable compact smooth oriented manifold theorem.
- Adds a dimension-generic IntegralPoincareUCTData interface containing only the perfect evaluation pairings, finite generation, and dimension vanishing used downstream.
- Proves that a complex manifold is a real manifold on the same atlas and constructs its real atlas orientation from positivity of real determinants of complex-linear transition derivatives.
- Moves the general dimension-six homological algebra out of the Section 7 target file.

## Mathlib boundary

The pinned Mathlib provides singular homology and the needed linear orientation/determinant API, but not the compact-manifold finite-CW bridge, singular cohomology and integral UCT, manifold fundamental classes, or Poincare duality. Those standard results are isolated behind one dimension-generic, source-independent declaration: establishedCompactSmoothOrientedManifoldHomologyTheory. No paper-specific theorem is assumed, and the old fake cohomology package is removed.

## Verification

- lake build SphereSixComplex.Topology.IntegralPoincareUCT SphereSixComplex.Topology.SmoothAtlasOrientation SphereSixComplex.Topology.EstablishedCompactSmoothOrientedManifoldHomology SphereSixComplex.Topology.SectionSevenSixManifoldCompletion SphereSixComplex.Main
- Full Main build completed successfully: 9028 jobs.
- git diff --check passes.
- Changed files contain no sorry, admit, or unsafe declaration and exactly one new axiom.
- Axiom audit: the complex-to-real and orientation proofs use only standard Lean axioms; establishedCompactComplexThreefoldHomologyTheory adds only establishedCompactSmoothOrientedManifoldHomologyTheory. The final Section 7 bridge additionally retains only its two pre-existing established Mayer-Vietoris and six-sphere inputs.

No active van Kampen, Mayer-Vietoris, or paper-specific source file was modified.