### PR TITLE
Prove establishedUnderlyingRealIsManifold instead of assuming it

### DIFF
--- a/SphereSixComplex/Geometry/EstablishedComplexToRealManifold.lean
+++ b/SphereSixComplex/Geometry/EstablishedComplexToRealManifold.lean
@@ -1,6 +1,7 @@
 module
 
 public import SphereSixComplex.ComplexStructure
+import all SphereSixComplex.ComplexStructure
 
 /-!
 # Restricting a complex manifold atlas to the real scalars
@@ -8,20 +9,83 @@ public import SphereSixComplex.ComplexStructure
 The underlying real atlas of a complex three-manifold is a smooth real six-manifold atlas.  This
 is the standard restriction-of-scalars theorem, stated for the concrete models used by this
 project.
+
+The real atlas `underlyingRealChartedSpace c` is the composite of the complex atlas `c` with the
+single real-linear chart `complexToRealModel : ℂ³ ≃L[ℝ] ℝ⁶`.  Its transition maps are therefore the
+complex transition maps conjugated by that real-linear identification, and a holomorphic (indeed
+`C^∞` over `ℂ`) map is `C^∞` over `ℝ` by `ContDiffOn.restrict_scalars`.
+
+This module used to state the theorem as an axiom; it is now proved.
 -/
 
 open scoped ContDiff Manifold
+open Set
 
 namespace SphereSixComplex.Geometry.EstablishedComplexToRealManifold
 
+/-- Every chart of the real coordinate system on `ℂ³` agrees with the real-linear identification
+`complexToRealModel` on its source. -/
+public theorem complexModelRealChart_eq_on_source
+    (f : OpenPartialHomeomorph ComplexModel RealModel)
+    (hf : f ∈ complexModelRealChartedSpace.atlas) {y : ComplexModel} (hy : y ∈ f.source) :
+    f y = complexToRealModel y := by
+  obtain ⟨q, rfl⟩ := hf
+  simp only [chartAt_self_eq, OpenPartialHomeomorph.trans_refl] at hy ⊢
+  apply complexToRealModel.symm.injective
+  rw [ContinuousLinearEquiv.symm_apply_apply]
+  exact IsLocalHomeomorph.apply_localInverseAt_of_mem _ hy
+
+/-- The inverse of every chart of the real coordinate system on `ℂ³` is the inverse real-linear
+identification, as a function. -/
+public theorem complexModelRealChart_symm_eq
+    (f : OpenPartialHomeomorph ComplexModel RealModel)
+    (hf : f ∈ complexModelRealChartedSpace.atlas) :
+    (f.symm : RealModel → ComplexModel) = complexToRealModel.symm := by
+  obtain ⟨q, rfl⟩ := hf
+  simp only [chartAt_self_eq, OpenPartialHomeomorph.trans_refl,
+    IsLocalHomeomorph.localInverseAt_symm]
+  rfl
+
 /-- Standard restriction of scalars from a complex three-manifold to its underlying smooth real
-six-manifold. -/
-public axiom establishedUnderlyingRealIsManifold
+six-manifold: the transition maps of the underlying real atlas are the complex transition maps
+conjugated by `complexToRealModel`, hence real-smooth. -/
+public theorem establishedUnderlyingRealIsManifold
     {M : Type*} [TopologicalSpace M]
     (c : ChartedSpace ComplexModel M)
     (h : @IsManifold ℂ inferInstance ComplexModel inferInstance inferInstance ComplexModel
       inferInstance (modelWithCornersSelf ℂ ComplexModel) ∞ M inferInstance c) :
     @IsManifold ℝ inferInstance RealModel inferInstance inferInstance RealModel inferInstance
-      (modelWithCornersSelf ℝ RealModel) ∞ M inferInstance (underlyingRealChartedSpace c)
+      (modelWithCornersSelf ℝ RealModel) ∞ M inferInstance (underlyingRealChartedSpace c) := by
+  let _ := c
+  let _ : ChartedSpace RealModel ComplexModel := complexModelRealChartedSpace
+  refine @isManifold_of_contDiffOn ℝ _ RealModel _ _ RealModel _ (modelWithCornersSelf ℝ RealModel)
+    ∞ M _ (underlyingRealChartedSpace c) ?_
+  rintro e e' ⟨e₁, he₁, f₁, hf₁, rfl⟩ ⟨e₂, he₂, f₂, hf₂, rfl⟩
+  simp only [mfld_simps]
+  set T := e₁.symm ≫ₕ e₂ with hT
+  have hmem : T ∈ contDiffGroupoid ∞ (modelWithCornersSelf ℂ ComplexModel) :=
+    StructureGroupoid.compatible _ he₁ he₂
+  have hC : ContDiffOn ℂ ∞ T T.source := by
+    rw [contDiffGroupoid, mem_groupoid_of_pregroupoid, contDiffPregroupoid] at hmem
+    simpa [mfld_simps] using hmem.1
+  have hR : ContDiffOn ℝ ∞ T T.source := hC.restrict_scalars ℝ
+  have hg : ContDiffOn ℝ ∞
+      (⇑complexToRealModel ∘ ⇑T ∘ ⇑complexToRealModel.symm)
+      (⇑complexToRealModel.symm ⁻¹' T.source) := by
+    have := (hR.comp_continuousLinearMap
+      (complexToRealModel.symm : RealModel →L[ℝ] ComplexModel)).continuousLinearMap_comp
+      (complexToRealModel : ComplexModel →L[ℝ] RealModel)
+    simpa using this
+  have hf₁' : (f₁.symm : RealModel → ComplexModel) = complexToRealModel.symm :=
+    complexModelRealChart_symm_eq f₁ hf₁
+  refine (hg.mono ?_).congr ?_
+  · rintro x ⟨⟨_, hx₁⟩, hx₂, _⟩
+    simp only [mem_preimage, Function.comp] at hx₁ hx₂ ⊢
+    rw [← hf₁']
+    exact ⟨hx₁, hx₂⟩
+  · rintro x ⟨⟨_, _⟩, _, hx₃⟩
+    simp only [mem_preimage, Function.comp] at hx₃ ⊢
+    rw [hf₁']
+    exact complexModelRealChart_eq_on_source f₂ hf₂ (by simpa [hf₁'] using hx₃)
 
 end SphereSixComplex.Geometry.EstablishedComplexToRealManifold

--- a/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
+++ b/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
@@ -410,9 +410,9 @@ Glue {uses "cusp-filling"}[the cusp filling] and
 :::theorem "manifold-gluing" (parent := "compact-complex-threefold") (lean := "SphereSixComplex.CrossPieceGluingCompatible, SphereSixComplex.gluingAtlasCompatible_of_crossPiece, SphereSixComplex.pieceInclusion_contMDiff_of_crossPiece, SphereSixComplex.gluedChartedSpace, SphereSixComplex.isManifold_gluedChartedSpace, SphereSixComplex.secondCountableTopology_gluedSpace, SphereSixComplex.compactSpace_gluedSpace, SphereSixComplex.connectedSpace_gluedSpace, SphereSixComplex.Geometry.EstablishedBiholomorphicStarGluing.establishedFourPieceBiholomorphicGluingAtlasCompatible, SphereSixComplex.Geometry.EstablishedComplexToRealManifold.establishedUnderlyingRealIsManifold, SphereSixComplex.PaperGluingData.gluedSecondCountable")
 Compatible atlases on the filling pieces transport to their topological gluing and make the glued
 space a manifold. A countable open gluing of second-countable pieces is second countable, and
-connected pieces with a connected overlap graph give a connected gluing. Compatibility of the
-paper's four biholomorphic pieces and restriction of its complex atlas to the underlying real
-manifold are the two explicit external gluing boundaries. Compactness is a separate construction
+connected pieces with a connected overlap graph give a connected gluing. Restriction of a complex atlas to
+the underlying real manifold is now proved from `ContDiffOn.restrict_scalars`, so compatibility of
+the paper's four biholomorphic pieces is the sole remaining explicit external gluing boundary. Compactness is a separate construction
 obligation, since the open punctured and filling pieces need not themselves be compact.
 :::
 


### PR DESCRIPTION
`sphere_six_admits_complex_structure` currently depends on five axioms. This PR removes one of them by proving it.

## What

`SphereSixComplex/Geometry/EstablishedComplexToRealManifold.lean` stated restriction of scalars — "the underlying real atlas of a complex three-manifold is a smooth real six-manifold atlas" — as `public axiom establishedUnderlyingRealIsManifold`. It is now a `public theorem` with the same name and the same statement, so every use site (`PaperGluingData.underlyingRealManifold`) is unchanged.

## How

`underlyingRealChartedSpace c` is `ChartedSpace.comp RealModel ComplexModel M`, i.e. the complex atlas `c` followed by the *single-chart* real coordinate system `complexModelRealChartedSpace` on `ℂ³`. Two supporting lemmas pin that second layer down:

* `complexModelRealChart_eq_on_source` — every chart in that atlas agrees with `complexToRealModel : ℂ³ ≃L[ℝ] ℝ⁶` on its source;
* `complexModelRealChart_symm_eq` — every such chart's inverse *is* `complexToRealModel.symm`.

So each transition map of the real atlas is a complex transition map conjugated by a real-linear homeomorphism, and `ContDiffOn.restrict_scalars` plus `ContinuousLinearMap.comp_contDiffOn` finish it via `isManifold_of_contDiffOn`.

## Verification

```
$ lake build SphereSixComplex.Final
warning: SphereSixComplex/Final.lean:20:15: declaration uses `sorry`
Build completed successfully (3485 jobs).

$ #print axioms SphereSixComplex.Geometry.EstablishedComplexToRealManifold.establishedUnderlyingRealIsManifold
... depends on axioms: [propext, Classical.choice, Quot.sound]
```

Axiom dependencies of the headline theorem, before → after:

```
 propext, sorryAx, Classical.choice, Quot.sound,
 establishedGeneralizedTopologicalPoincareSix,
 establishedHomologyToHomotopySixSphere,
 establishedMarkedSmoothSixSphereClassesTrivial,
 establishedFourPieceBiholomorphicGluingAtlasCompatible,
-establishedUnderlyingRealIsManifold
```

The blueprint sentence in `manifold-gluing` that called this one of "the two explicit external gluing boundaries" is updated: biholomorphic four-piece compatibility is now the only one.

Relates to #9 (axiom inventory). No new axiom, `sorry`, or `admit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)