### PR TITLE
Prove establishedFourPieceBiholomorphicGluingAtlasCompatible instead of assuming it

### DIFF
--- a/SphereSixComplex/Geometry/EstablishedBiholomorphicStarGluing.lean
+++ b/SphereSixComplex/Geometry/EstablishedBiholomorphicStarGluing.lean
@@ -1,6 +1,7 @@
 module
 
 public import SphereSixComplex.Geometry.FourPieceStarGluing
+public import SphereSixComplex.Geometry.GluingCompatibility
 public import SphereSixComplex.ComplexStructure
 
 /-!
@@ -59,15 +60,122 @@ variable {A : FourPieceStarGluingData} (C : BiholomorphicFourPieceStarData A)
 
 end BiholomorphicFourPieceStarData
 
-/-- Standard atlas compatibility for gluing complex manifolds along biholomorphic open
-subsets. -/
-public axiom establishedFourPieceBiholomorphicGluingAtlasCompatible
+
+/-! ## Identifying the piece transitions with the collar data -/
+
+/-- The overlap of the central piece with the `k`th filling is the `k`th central collar. -/
+private theorem overlap_none_some (A : FourPieceStarGluingData) (k : Fin 3) :
+    Set.range (A.glueData.toGlueData.f none (some k)) = (A.centralCollar k : Set A.central) :=
+  TopologicalSpace.Opens.set_range_inclusion' _
+
+/-- The overlap of the `k`th filling with the central piece is the `k`th filling collar. -/
+private theorem overlap_some_none (A : FourPieceStarGluingData) (k : Fin 3) :
+    Set.range (A.glueData.toGlueData.f (some k) none) = (A.fillingCollar k : Set (A.filling k)) :=
+  TopologicalSpace.Opens.set_range_inclusion' _
+
+/-- Two distinct fillings never overlap, since the attaching collars are disjoint. -/
+private theorem overlap_some_some (A : FourPieceStarGluingData) {k l : Fin 3} (hkl : k ≠ l) :
+    Set.range (A.glueData.toGlueData.f (some k) (some l)) = (∅ : Set (A.filling k)) := by
+  refine (TopologicalSpace.Opens.set_range_inclusion' (A.overlap (some k) (some l))).trans ?_
+  simp only [FourPieceStarGluingData.overlap, hkl, ite_false]
+  rfl
+
+namespace BiholomorphicFourPieceStarData
+
+variable {A : FourPieceStarGluingData} (C : BiholomorphicFourPieceStarData A)
+
+/-- Each of the four pieces is a complex manifold in its own atlas. -/
+public theorem pieceManifold (hcollar : ∀ i, Nonempty (A.centralCollar i)) :
+    letI := A.nonemptyPieceOfCollars hcollar
+    letI := C.complexCharts
+    ∀ i, IsManifold (modelWithCornersSelf ℂ ComplexModel) ∞ (A.glueData.U i) := by
+  intro i
+  cases i with
+  | none => exact C.centralManifold
+  | some k => exact C.fillingManifold k
+
+end BiholomorphicFourPieceStarData
+
+/-- Standard atlas compatibility for gluing complex manifolds along biholomorphic open subsets.
+
+By `crossPieceGluingCompatible_of_pieceTransition_contMDiffOn` this reduces to smoothness of the
+six transitions between distinct pieces, and each of those is identified here with the analytic
+collar data: a central-to-filling transition is the given partial diffeomorphism, a
+filling-to-central transition is its inverse, and a transition between two distinct fillings has
+empty source because the attaching collars are disjoint. -/
+public theorem establishedFourPieceBiholomorphicGluingAtlasCompatible
     (A : FourPieceStarGluingData)
     (hcollar : ∀ i, Nonempty (A.centralCollar i))
     (C : BiholomorphicFourPieceStarData A) :
     letI := A.nonemptyPieceOfCollars hcollar
     letI := C.complexCharts
-    GluingAtlasCompatible (I := modelWithCornersSelf ℂ ComplexModel) (n := ∞) A.glueData
+    GluingAtlasCompatible (I := modelWithCornersSelf ℂ ComplexModel) (n := ∞) A.glueData := by
+  letI := C.centralCharts
+  letI (i : Fin 3) := C.fillingCharts i
+  letI := A.nonemptyPieceOfCollars hcollar
+  letI := C.complexCharts
+  letI := C.pieceManifold hcollar
+  refine gluingAtlasCompatible_of_crossPiece A.glueData ?_
+  refine crossPieceGluingCompatible_of_pieceTransition_contMDiffOn A.glueData ?_
+  intro i j hij
+  cases i with
+  | none =>
+      cases j with
+      | none => exact absurd rfl hij
+      | some k =>
+          have hsource : (pieceTransition A.glueData none (some k)).source =
+              (C.collar k).source :=
+            (pieceTransition_source A.glueData none (some k)).trans
+              ((overlap_none_some A k).trans (C.collar_source k).symm)
+          rw [hsource]
+          refine ((C.collar k).contMDiffOn_toFun).congr ?_
+          intro x hx
+          have hx' : x ∈ (A.centralCollar k : Set A.central) := by
+            rw [C.collar_source k] at hx
+            exact hx
+          have hpt : pieceTransition A.glueData none (some k) x =
+              ((A.collarEquiv k ⟨x, hx'⟩ : A.fillingCollar k) : A.filling k) :=
+            pieceTransition_apply A.glueData none (some k) (⟨x, hx'⟩ : A.centralCollar k)
+          exact hpt.trans (C.collar_apply k ⟨x, hx'⟩).symm
+  | some k =>
+      cases j with
+      | none =>
+          have hsource : (pieceTransition A.glueData (some k) none).source =
+              (C.collar k).target :=
+            (pieceTransition_source A.glueData (some k) none).trans
+              ((overlap_some_none A k).trans (C.collar_target k).symm)
+          rw [hsource]
+          refine ((C.collar k).contMDiffOn_invFun).congr ?_
+          intro x hx
+          have hx' : x ∈ (A.fillingCollar k : Set (A.filling k)) := by
+            rw [C.collar_target k] at hx
+            exact hx
+          have hz : (((A.collarEquiv k).symm ⟨x, hx'⟩ : A.centralCollar k) : A.central) ∈
+              (C.collar k).source := by
+            rw [C.collar_source k]
+            exact ((A.collarEquiv k).symm ⟨x, hx'⟩).2
+          have hcollarApply : (C.collar k).toOpenPartialHomeomorph
+              (((A.collarEquiv k).symm ⟨x, hx'⟩ : A.centralCollar k) : A.central) = x := by
+            show C.collar k (((A.collarEquiv k).symm ⟨x, hx'⟩ : A.centralCollar k) : A.central) = x
+            rw [C.collar_apply k ((A.collarEquiv k).symm ⟨x, hx'⟩)]
+            change ((A.collarEquiv k) ((A.collarEquiv k).symm ⟨x, hx'⟩) : A.filling k) = x
+            rw [Homeomorph.apply_symm_apply]
+          have hinv : (C.collar k).toOpenPartialHomeomorph.symm x =
+              (((A.collarEquiv k).symm ⟨x, hx'⟩ : A.centralCollar k) : A.central) := by
+            have hleft := (C.collar k).toOpenPartialHomeomorph.left_inv hz
+            rwa [hcollarApply] at hleft
+          have hpt : pieceTransition A.glueData (some k) none x =
+              (((A.collarEquiv k).symm ⟨x, hx'⟩ : A.centralCollar k) : A.central) :=
+            pieceTransition_apply A.glueData (some k) none (⟨x, hx'⟩ : A.fillingCollar k)
+          exact hpt.trans hinv.symm
+      | some l =>
+          have hkl : k ≠ l := fun h => hij (by rw [h])
+          have hsource : (pieceTransition A.glueData (some k) (some l)).source = ∅ :=
+            (pieceTransition_source A.glueData (some k) (some l)).trans
+              (overlap_some_some A hkl)
+          rw [hsource]
+          intro y hy
+          exact hy.elim
 
 end
 

--- a/SphereSixComplex/Geometry/GluingCompatibility.lean
+++ b/SphereSixComplex/Geometry/GluingCompatibility.lean
@@ -7,6 +7,7 @@ module
 
 public import SphereSixComplex.Geometry.Gluing
 public import Mathlib.Topology.OpenPartialHomeomorph.Constructions
+public import Mathlib.Geometry.Manifold.ContMDiff.Atlas
 
 /-!
 # Cross-piece compatibility for gluing atlases
@@ -140,5 +141,111 @@ public theorem isManifold_gluedChartedSpace_of_crossPiece
       (GluedSpace D) inferInstance (gluedChartedSpace D) :=
   isManifold_gluedChartedSpace D
     (gluingAtlasCompatible_of_crossPiece D hcross)
+
+/-! ## Piece transitions
+
+The transition between two pieces of a gluing is the partial homeomorphism obtained by passing
+through the glued space.  Cross-piece chart compatibility reduces to smoothness of those
+transitions, which is where the analytic content of a gluing actually lives. -/
+
+/-- The transition partial homeomorphism from the `i`th piece of a gluing to its `j`th piece. -/
+public noncomputable def pieceTransition (D : TopCat.GlueData.{w}) [∀ i, Nonempty (D.U i)]
+    (i j : D.J) : OpenPartialHomeomorph (D.U i) (D.U j) :=
+  (pieceOpenPartialHomeomorph D i).trans (pieceOpenPartialHomeomorph D j).symm
+
+/-- The transition between two pieces is defined exactly on their overlap. -/
+public theorem pieceTransition_source (D : TopCat.GlueData.{w}) [∀ i, Nonempty (D.U i)]
+    (i j : D.J) :
+    (pieceTransition D i j).source = Set.range (D.toGlueData.f i j) := by
+  unfold pieceTransition pieceOpenPartialHomeomorph
+  rw [OpenPartialHomeomorph.trans_source, OpenPartialHomeomorph.symm_source,
+    Topology.IsOpenEmbedding.toOpenPartialHomeomorph_source,
+    Topology.IsOpenEmbedding.toOpenPartialHomeomorph_target, Set.univ_inter]
+  exact D.preimage_range j i
+
+/-- Reversing a piece transition exchanges the two pieces. -/
+public theorem pieceTransition_symm (D : TopCat.GlueData.{w}) [∀ i, Nonempty (D.U i)]
+    (i j : D.J) : (pieceTransition D i j).symm = pieceTransition D j i := by
+  unfold pieceTransition
+  rw [OpenPartialHomeomorph.trans_symm_eq_symm_trans_symm, OpenPartialHomeomorph.symm_symm]
+
+/-- On the overlap, the piece transition is the gluing datum's own transition map. -/
+public theorem pieceTransition_apply (D : TopCat.GlueData.{w}) [∀ i, Nonempty (D.U i)]
+    (i j : D.J) (y : D.toGlueData.V (i, j)) :
+    pieceTransition D i j (D.toGlueData.f i j y) =
+      D.toGlueData.f j i (D.toGlueData.t i j y) := by
+  have hglue : D.toGlueData.ι j (D.toGlueData.f j i (D.toGlueData.t i j y)) =
+      D.toGlueData.ι i (D.toGlueData.f i j y) := by
+    have h := D.toGlueData.glue_condition i j
+    exact congrFun (congrArg (fun g => ⇑(TopCat.Hom.hom g)) h) y
+  change (pieceOpenPartialHomeomorph D j).symm
+    (pieceOpenPartialHomeomorph D i (D.toGlueData.f i j y)) = _
+  have h1 : pieceOpenPartialHomeomorph D i (D.toGlueData.f i j y)
+      = D.toGlueData.ι i (D.toGlueData.f i j y) := rfl
+  rw [h1, ← hglue]
+  exact Topology.IsOpenEmbedding.toOpenPartialHomeomorph_left_inv _ _
+
+/-- The transition between charts transported from two pieces is the piece transition read in
+those charts. -/
+public theorem transportedPieceChart_symm_trans (D : TopCat.GlueData.{w}) [∀ i, Nonempty (D.U i)]
+    (i j : D.J) (c : OpenPartialHomeomorph (D.U i) H) (c' : OpenPartialHomeomorph (D.U j) H) :
+    (transportedPieceChart D i c).symm.trans (transportedPieceChart D j c') =
+      (c.symm.trans (pieceTransition D i j)).trans c' := by
+  unfold transportedPieceChart pieceTransition
+  rw [OpenPartialHomeomorph.trans_symm_eq_symm_trans_symm, OpenPartialHomeomorph.symm_symm,
+    OpenPartialHomeomorph.trans_assoc, OpenPartialHomeomorph.trans_assoc,
+    OpenPartialHomeomorph.trans_assoc]
+
+section ContMDiff
+
+variable {𝕜 : Type u} [NontriviallyNormedField 𝕜]
+variable {E : Type v} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {I : ModelWithCorners 𝕜 E H} {n : ℕ∞ω}
+variable {M N : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I n M]
+  [TopologicalSpace N] [ChartedSpace H N] [IsManifold I n N]
+
+/-- A partial homeomorphism that is `C^n` in both directions carries any pair of atlas charts of
+its two manifolds into the `C^n` groupoid. -/
+public theorem mem_contDiffGroupoid_of_contMDiffOn {Φ : OpenPartialHomeomorph M N}
+    (h : ContMDiffOn I I n Φ Φ.source) (h' : ContMDiffOn I I n Φ.symm Φ.target)
+    {c : OpenPartialHomeomorph M H} {c' : OpenPartialHomeomorph N H}
+    (hc : c ∈ atlas H M) (hc' : c' ∈ atlas H N) :
+    (c.symm.trans Φ).trans c' ∈ contDiffGroupoid n I := by
+  have hc'M : ContMDiffOn I I n c' c'.source :=
+    contMDiffOn_of_mem_maximalAtlas (IsManifold.subset_maximalAtlas (I := I) (n := n) hc')
+  have hc'S : ContMDiffOn I I n c'.symm c'.target :=
+    contMDiffOn_symm_of_mem_maximalAtlas (IsManifold.subset_maximalAtlas (I := I) (n := n) hc')
+  have hΨ : Φ.trans c' ∈ IsManifold.maximalAtlas I n M := by
+    rw [IsManifold.mem_maximalAtlas_iff_contMDiffOn]
+    constructor
+    · have hcomp : ContMDiffOn I I n (c' ∘ Φ) (Φ.trans c').source :=
+        hc'M.comp (h.mono (fun x hx => hx.1)) (fun x hx => hx.2)
+      simpa [OpenPartialHomeomorph.coe_trans] using hcomp
+    · have hcomp : ContMDiffOn I I n (Φ.symm ∘ c'.symm) (Φ.trans c').target :=
+        h'.comp (hc'S.mono (fun x hx => hx.1)) (fun x hx => hx.2)
+      simpa [OpenPartialHomeomorph.coe_trans_symm] using hcomp
+  have := StructureGroupoid.compatible_of_mem_maximalAtlas
+    (IsManifold.subset_maximalAtlas (I := I) (n := n) hc) hΨ
+  rwa [← OpenPartialHomeomorph.trans_assoc] at this
+
+/-- Smooth piece transitions give the cross-piece chart compatibility of a gluing. -/
+public theorem crossPieceGluingCompatible_of_pieceTransition_contMDiffOn
+    (D : TopCat.GlueData.{w}) [Nonempty H] [∀ i, Nonempty (D.U i)]
+    [∀ i, ChartedSpace H (D.U i)] [∀ i, IsManifold I n (D.U i)]
+    (h : ∀ i j : D.J, i ≠ j →
+      ContMDiffOn I I n (pieceTransition D i j) (pieceTransition D i j).source) :
+    CrossPieceGluingCompatible D (contDiffGroupoid n I) := by
+  intro i j hij c c' hc hc'
+  rw [show (transportedPieceChart D i c).symm.trans (transportedPieceChart D j c') =
+      (c.symm.trans (pieceTransition D i j)).trans c' from
+    transportedPieceChart_symm_trans D i j c c']
+  refine mem_contDiffGroupoid_of_contMDiffOn (h i j hij) ?_ hc hc'
+  have hsymm : (pieceTransition D i j).symm = pieceTransition D j i := pieceTransition_symm D i j
+  have htarget : (pieceTransition D i j).target = (pieceTransition D j i).source := by
+    rw [← hsymm, OpenPartialHomeomorph.symm_source]
+  rw [hsymm, htarget]
+  exact h j i (Ne.symm hij)
+
+end ContMDiff
 
 end SphereSixComplex

--- a/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
+++ b/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
@@ -411,8 +411,10 @@ Glue {uses "cusp-filling"}[the cusp filling] and
 Compatible atlases on the filling pieces transport to their topological gluing and make the glued
 space a manifold. A countable open gluing of second-countable pieces is second countable, and
 connected pieces with a connected overlap graph give a connected gluing. Restriction of a complex atlas to
-the underlying real manifold is now proved from `ContDiffOn.restrict_scalars`, so compatibility of
-the paper's four biholomorphic pieces is the sole remaining explicit external gluing boundary. Compactness is a separate construction
+the underlying real manifold is proved from `ContDiffOn.restrict_scalars`, and compatibility of the
+paper's four biholomorphic pieces is proved by identifying the six piece transitions with the collar
+partial diffeomorphisms, their inverses, and the empty transitions between distinct fillings. The
+gluing step therefore has no remaining external boundary. Compactness is a separate construction
 obligation, since the open punctured and filling pieces need not themselves be compact.
 :::
 


### PR DESCRIPTION
Stacked on #33 (its commit is the first of the two here; review only the second, or merge #33 first). Together they leave `sphere_six_admits_complex_structure` depending on **no gluing axiom at all**:

```
before:  propext, sorryAx, Classical.choice, Quot.sound,
         establishedGeneralizedTopologicalPoincareSix,
         establishedHomologyToHomotopySixSphere,
         establishedMarkedSmoothSixSphereClassesTrivial,
         establishedFourPieceBiholomorphicGluingAtlasCompatible,
         establishedUnderlyingRealIsManifold

after:   propext, sorryAx, Classical.choice, Quot.sound,
         establishedGeneralizedTopologicalPoincareSix,
         establishedHomologyToHomotopySixSphere,
         establishedMarkedSmoothSixSphereClassesTrivial
```

i.e. the single `exists_paperGluingData` sorry, the standard logical axioms, and the three recognition inputs — nothing else.

## Reusable part (`Geometry/GluingCompatibility.lean`)

The analytic content of any gluing lives in its **piece transitions**, so this PR gives them a name and an API for an arbitrary `TopCat.GlueData`:

```lean
noncomputable def pieceTransition (D : TopCat.GlueData) [∀ i, Nonempty (D.U i)] (i j : D.J) :
    OpenPartialHomeomorph (D.U i) (D.U j) :=
  (pieceOpenPartialHomeomorph D i).trans (pieceOpenPartialHomeomorph D j).symm
```

* `pieceTransition_source` : `.source = Set.range (D.f i j)` — from `GlueData.preimage_range`;
* `pieceTransition_symm` : `(pieceTransition D i j).symm = pieceTransition D j i`;
* `pieceTransition_apply` : on the overlap it is the gluing datum's own `t i j` — from `glue_condition`;
* `transportedPieceChart_symm_trans` : `(transportedPieceChart D i c).symm ≫ₕ transportedPieceChart D j c' = (c.symm ≫ₕ pieceTransition D i j) ≫ₕ c'`;
* `mem_contDiffGroupoid_of_contMDiffOn` : if `Φ` is `C^n` both ways then `(c.symm ≫ₕ Φ) ≫ₕ c' ∈ contDiffGroupoid n I` for atlas charts `c`, `c'` — proved by showing `Φ ≫ₕ c'` lies in the maximal atlas (`IsManifold.mem_maximalAtlas_iff_contMDiffOn`) and applying `compatible_of_mem_maximalAtlas`;
* `crossPieceGluingCompatible_of_pieceTransition_contMDiffOn` : smooth piece transitions ⟹ `CrossPieceGluingCompatible`.

This composes with the existing `gluingAtlasCompatible_of_crossPiece`, so no gluing needs to touch charts by hand again.

## Paper-specific part (`Geometry/EstablishedBiholomorphicStarGluing.lean`)

Only the six transitions between distinct pieces of the star remain, and each is read off `BiholomorphicFourPieceStarData`:

| transition | identification | smoothness |
|---|---|---|
| central → filling `k` | `C.collar k` on `centralCollar k` | `contMDiffOn_toFun` |
| filling `k` → central | its inverse on `fillingCollar k` | `contMDiffOn_invFun` |
| filling `k` → filling `l`, `k ≠ l` | empty source | vacuous |

The first uses `collar_source`/`collar_apply` directly; the second inverts pointwise through the collar homeomorphism (`(collar k).symm x = (collarEquiv k).symm x` by `left_inv`); the third is where `centralCollar_disjoint` enters, via `A.overlap (some k) (some l) = ⊥`.

Supporting: `BiholomorphicFourPieceStarData.pieceManifold`, packaging `centralManifold`/`fillingManifold` as the four `IsManifold` instances.

## Verification

All 76 modules depending on the two changed files — including `SphereSixComplex.Main` — compile, with no new `sorry` or axiom, and

```
#print axioms SphereSixComplex.Geometry.EstablishedBiholomorphicStarGluing.establishedFourPieceBiholomorphicGluingAtlasCompatible
-- depends on axioms: [propext, Classical.choice, Quot.sound]
```

(Type-checked with `lake env lean` in dependency order rather than a full `lake build`; CI will do the full build.) The declaration keeps its name and statement, so `PaperGluingData.complexCompatible` is unchanged. The blueprint's `manifold-gluing` paragraph now records that the gluing step has no remaining external boundary.

Relates to #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)