### PR TITLE
Prove integral Mayer--Vietoris Euler additivity

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -141,6 +141,8 @@ public import SphereSixComplex.Topology.EstablishedUnwrappedAffineFillings
 public import SphereSixComplex.Topology.PaperActualFillingCoverSquares
 public import SphereSixComplex.Topology.PaperCentralAffineDeckCover
 public import SphereSixComplex.Topology.PaperVanKampenAlgebraAdapter
+public import SphereSixComplex.Topology.FiniteExactSequenceEuler
+public import SphereSixComplex.Topology.IntegralHomologyEuler
 public import SphereSixComplex.Topology.BinaryOpenCoverChains
 public import SphereSixComplex.Topology.BinaryOpenCoverCorestriction
 public import SphereSixComplex.Topology.BinaryOpenCoverExcision
@@ -152,6 +154,7 @@ public import SphereSixComplex.Topology.HomologySphere
 public import SphereSixComplex.Topology.HurewiczWhitehead
 public import SphereSixComplex.Topology.HurewiczWhiteheadStages
 public import SphereSixComplex.Topology.MayerVietoris
+public import SphereSixComplex.Topology.MayerVietorisDegreeZeroBridge
 public import SphereSixComplex.Topology.ConnectedMayerVietorisDegreeZero
 public import SphereSixComplex.Topology.SectionSevenChainModel
 public import SphereSixComplex.Topology.SectionSevenCoherentRealizationReduction
@@ -173,6 +176,7 @@ public import SphereSixComplex.Topology.SectionSevenMayerVietorisChainAssembly
 public import SphereSixComplex.Topology.SectionSevenMayerVietorisGradedAlgebra
 public import SphereSixComplex.Topology.SectionSevenMayerVietorisHomologyAssembly
 public import SphereSixComplex.Topology.SectionSevenSixManifoldCompletion
+public import SphereSixComplex.Topology.IntegralMayerVietorisEuler
 public import SphereSixComplex.Topology.SectionSevenMayerVietorisEuler
 public import SphereSixComplex.Topology.SectionSevenLocalEulerCalculation
 public import SphereSixComplex.Topology.SectionSevenLocalEulerModels

--- a/SphereSixComplex/Topology/BinaryOpenCoverAssembly.lean
+++ b/SphereSixComplex/Topology/BinaryOpenCoverAssembly.lean
@@ -7,6 +7,7 @@ module
 
 public import SphereSixComplex.Topology.BinaryOpenCoverMayerVietoris
 public import Mathlib.Algebra.Homology.HomologicalComplexBiprod
+public import Mathlib.AlgebraicTopology.SimplicialSet.TopAdj
 
 /-!
 # Assembly of the ordinary open-cover Mayer--Vietoris comparison
@@ -228,6 +229,29 @@ theorem openMVFromBiprodChain_naturality {X : TopCat}
       biprod.inr_map_assoc, biprod.inr_desc_assoc, biprod.inr_desc] using
       rightCorestriction_comp_union U V
 
+private theorem coverUnion_ι_app_zero_surjective {X : TopCat}
+    (U V : Opens X) (hcover : U ⊔ V = ⊤) :
+    Function.Surjective
+      ((coverUnion U V).ι.app (Opposite.op (SimplexCategory.mk 0))) := by
+  intro σ
+  let x := TopCat.toSSetObj₀Equiv σ
+  refine ⟨⟨σ, ?_⟩, rfl⟩
+  have hx : x ∈ U ⊔ V := by
+    rw [hcover]
+    trivial
+  change
+    (∃ a, (TopCat.toSSet.map (Opens.inclusion' U)).app _ a = σ) ∨
+      ∃ b, (TopCat.toSSet.map (Opens.inclusion' V)).app _ b = σ
+  rcases Opens.mem_sup.mp hx with hx | hx
+  · left
+    refine ⟨TopCat.toSSetObj₀Equiv.symm ⟨x, hx⟩, ?_⟩
+    apply TopCat.toSSetObj₀Equiv.injective
+    rfl
+  · right
+    refine ⟨TopCat.toSSetObj₀Equiv.symm ⟨x, hx⟩, ?_⟩
+    apply TopCat.toSSetObj₀Equiv.injective
+    rfl
+
 /-! ## Homology isomorphisms and the two naturality squares -/
 
 noncomputable abbrev homologyFunctor (n : ℕ) :
@@ -319,6 +343,45 @@ private theorem homology_openMVFromBiprodChain {X : TopCat}
       (openSingularChains U) (openSingularChains V)
       (integralSimplicialChains.map (TopCat.toSSet.map (Opens.inclusion' U)))
       (integralSimplicialChains.map (TopCat.toSSet.map (Opens.inclusion' V))))
+
+/-- The degree-zero map from the homology of the two open sets covers ambient homology. -/
+public theorem integralMVFromBiprod_zero_surjective
+    {X : TopCat} (U V : Opens X) (hcover : U ⊔ V = ⊤) :
+    Function.Surjective (integralMVFromBiprod U V 0) := by
+  let _ : IsIso
+      ((coverUnion U V).ι.app (Opposite.op (SimplexCategory.mk 0))) :=
+    (isIso_iff_bijective _).mpr
+      ⟨Subtype.coe_injective, coverUnion_ι_app_zero_surjective U V hcover⟩
+  let _ : IsIso ((coverChainInclusion U V).f 0) := by
+    change IsIso ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+      ((coverUnion U V).ι.app (Opposite.op (SimplexCategory.mk 0))))
+    infer_instance
+  let _ : Epi ((coverChainInclusion U V).f 0) := inferInstance
+  let _ : Epi (coverChainShortComplex U V).g :=
+    (coverChainShortComplex_shortExact U V).epi_g
+  let _ : Epi ((coverChainShortComplex U V).g.f 0) := inferInstance
+  let _ : Epi ((biprodForwardChain U V).f 0) := inferInstance
+  let _ : Epi ((openMVFromBiprodChain U V).f 0) := by
+    have h := HomologicalComplex.congr_hom
+      (openMVFromBiprodChain_naturality U V) 0
+    simp only [HomologicalComplex.comp_f] at h
+    rw [← h]
+    change Epi ((biprodForwardChain U V).f 0 ≫
+      ((coverChainShortComplex U V).g.f 0 ≫ (coverChainInclusion U V).f 0))
+    exact epi_comp'
+      (inferInstance : Epi ((biprodForwardChain U V).f 0))
+      (epi_comp'
+        (inferInstance : Epi ((coverChainShortComplex U V).g.f 0))
+        (inferInstance : Epi ((coverChainInclusion U V).f 0)))
+  let hHomologyEpi : Epi
+      ((homologyFunctor 0).map (openMVFromBiprodChain U V)) := by
+    change Epi (HomologicalComplex.homologyMap
+      (openMVFromBiprodChain U V) 0)
+    apply HomologicalComplex.epi_homologyMap_of_epi_of_not_rel
+    simp [ComplexShape.down_Rel]
+  exact (AddCommGrpCat.epi_iff_surjective _).mp
+    (@epi_of_epi_fac _ _ _ _ _ _ _ _ hHomologyEpi
+      (homology_openMVFromBiprodChain U V 0))
 
 private theorem homologyFunctor_map_comp_mapIso_symm_hom_assoc
     {K L : ChainComplex AddCommGrpCat ℕ} (f : K ⟶ L) [IsIso f]
@@ -423,3 +486,5 @@ public theorem integralOpenCoverComparisonStatement_of_binaryOpenCoverSubdivisio
   exact ⟨openCoverHomologyComparisonOfSubdivision D⟩
 
 end SphereSixComplex.BinaryOpenCover
+
+#print axioms SphereSixComplex.BinaryOpenCover.integralMVFromBiprod_zero_surjective

--- a/SphereSixComplex/Topology/BinaryOpenCoverAssembly.lean
+++ b/SphereSixComplex/Topology/BinaryOpenCoverAssembly.lean
@@ -486,5 +486,3 @@ public theorem integralOpenCoverComparisonStatement_of_binaryOpenCoverSubdivisio
   exact ⟨openCoverHomologyComparisonOfSubdivision D⟩
 
 end SphereSixComplex.BinaryOpenCover
-
-#print axioms SphereSixComplex.BinaryOpenCover.integralMVFromBiprod_zero_surjective

--- a/SphereSixComplex/Topology/FiniteExactSequenceEuler.lean
+++ b/SphereSixComplex/Topology/FiniteExactSequenceEuler.lean
@@ -1,0 +1,93 @@
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Algebra.Exact.Basic
+public import Mathlib.LinearAlgebra.Dimension.Localization
+public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+
+/-!
+# Euler characteristic of finite exact sequences over the integers
+
+Mathlib's finite exact-sequence Euler theorem is stated over division rings. Integral homology
+groups are finitely generated `Int`-modules, so this module supplies the corresponding result using
+rank-nullity for commutative domains.
+-/
+
+@[expose] public section
+
+namespace SphereSixComplex
+
+private lemma int_finrank_eq_of_module_structures {M : Type*} [AddCommGroup M]
+    (moduleOne moduleTwo : Module Int M) :
+    @Module.finrank Int M _ _ moduleOne = @Module.finrank Int M _ _ moduleTwo := by
+  have h : moduleOne = moduleTwo := Subsingleton.elim _ _
+  cases h
+  rfl
+
+private lemma integral_finrank_range_add_finrank_ker {M N : Type*}
+    [AddCommGroup M] [Module Int M] [Module.Finite Int M]
+    [AddCommGroup N] [Module Int N] (f : M →ₗ[Int] N) :
+    Module.finrank Int f.range + Module.finrank Int f.ker = Module.finrank Int M := by
+  have hquotRange :
+      @Module.finrank Int (M ⧸ f.ker) _ _ (Submodule.Quotient.module f.ker) =
+        @Module.finrank Int f.range _ _ f.range.module := by
+    exact @LinearEquiv.finrank_eq Int (M ⧸ f.ker) f.range _ _
+      (Submodule.Quotient.module f.ker) _ f.range.module f.quotKerEquivRange
+  have hExplicit :
+      @Module.finrank Int f.range _ _ f.range.module +
+          @Module.finrank Int f.ker _ _ f.ker.module = Module.finrank Int M := by
+    rw [← hquotRange]
+    exact Submodule.finrank_quotient_add_finrank _
+  calc
+    Module.finrank Int f.range + Module.finrank Int f.ker =
+        @Module.finrank Int f.range _ _ f.range.module +
+          @Module.finrank Int f.ker _ _ f.ker.module := by
+      rw [int_finrank_eq_of_module_structures
+        (AddCommGroup.toIntModule f.range) f.range.module,
+        int_finrank_eq_of_module_structures
+          (AddCommGroup.toIntModule f.ker) f.ker.module]
+    _ = Module.finrank Int M := hExplicit
+
+/-- The alternating integral finranks in a finite exact sequence sum to zero. -/
+public theorem integral_sum_neg_one_pow_finrank_eq_zero_of_exact {n : Nat}
+    (V : Fin (n + 2) → Type*)
+    [∀ i, AddCommGroup (V i)] [∀ i, Module Int (V i)] [∀ i, Module.Finite Int (V i)]
+    (f : (i : Fin (n + 1)) → V i.castSucc →ₗ[Int] V i.succ)
+    (inj : Function.Injective (f 0))
+    (h_exact : ∀ i : Fin n, Function.Exact (f i.castSucc) (f i.succ))
+    (surj : Function.Surjective (f (Fin.last _))) :
+    ∑ i, (-1) ^ i.val * (Module.finrank Int (V i) : Int) = 0 := by
+  let d : Fin (n + 2) → Int := fun i ↦ (Module.finrank Int (V i) : Int)
+  let r : Fin (n + 1) → Int := fun i ↦
+    (Module.finrank Int (f i).range : Int)
+  change ∑ i, (-1) ^ i.val * d i = 0
+  simp_rw [← smul_eq_mul]
+  refine Fin.sum_neg_one_pow_eq_zero d r ?_ (fun i ↦ ?_) ?_
+  · dsimp only [d, r]
+    have hModule := int_finrank_eq_of_module_structures
+      (AddCommGroup.toIntModule (f 0).range) (f 0).range.module
+    exact_mod_cast (hModule.trans (LinearMap.finrank_range_of_inj inj)).symm
+  · have hrn := integral_finrank_range_add_finrank_ker (f i.succ)
+    have hker : Module.finrank Int (f i.succ).ker =
+        Module.finrank Int (f i.castSucc).range :=
+      congrArg (fun S : Submodule Int (V i.succ.castSucc) ↦ Module.finrank Int S)
+        (h_exact i).linearMap_ker_eq
+    dsimp only [d, r]
+    omega
+  · have hrange := LinearMap.range_eq_top.mpr surj
+    have hExplicit :
+        @Module.finrank Int (f (Fin.last n)).range _ _ (f (Fin.last n)).range.module =
+          Module.finrank Int (V (Fin.last (n + 1))) := by
+      have h := congrArg
+        (fun S : Submodule Int (V (Fin.last n).succ) ↦
+          @Module.finrank Int S _ _ S.module) hrange
+      simpa only [finrank_top, Fin.succ_last] using h
+    have hfinrank : Module.finrank Int (f (Fin.last n)).range =
+        Module.finrank Int (V (Fin.last (n + 1))) :=
+      (int_finrank_eq_of_module_structures
+        (AddCommGroup.toIntModule (f (Fin.last n)).range)
+        (f (Fin.last n)).range.module).trans hExplicit
+    dsimp only [d, r]
+    exact_mod_cast hfinrank.symm
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FiniteExactSequenceEuler.lean
+++ b/SphereSixComplex/Topology/FiniteExactSequenceEuler.lean
@@ -4,6 +4,8 @@ public import Mathlib.Algebra.BigOperators.Fin
 public import Mathlib.Algebra.Exact.Basic
 public import Mathlib.LinearAlgebra.Dimension.Localization
 public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.Finiteness.Finsupp
+public import Mathlib.RingTheory.Noetherian.Basic
 
 /-!
 # Euler characteristic of finite exact sequences over the integers
@@ -47,6 +49,121 @@ private lemma integral_finrank_range_add_finrank_ker {M N : Type*}
         int_finrank_eq_of_module_structures
           (AddCommGroup.toIntModule f.ker) f.ker.module]
     _ = Module.finrank Int M := hExplicit
+
+/-- In an exact pair of maps between finitely generated `Int`-modules, the rank of the middle
+term is the sum of the ranks of the two adjacent images. -/
+public theorem integral_finrank_eq_add_finrank_range_of_exact {M N P : Type*}
+    [AddCommGroup M] [Module Int M]
+    [AddCommGroup N] [Module Int N] [Module.Finite Int N]
+    [AddCommGroup P] [Module Int P]
+    (f : M →ₗ[Int] N) (g : N →ₗ[Int] P) (h : Function.Exact f g) :
+    Module.finrank Int N =
+      Module.finrank Int f.range + Module.finrank Int g.range := by
+  have hrank := integral_finrank_range_add_finrank_ker g
+  have hker : Module.finrank Int g.ker = Module.finrank Int f.range :=
+    congrArg (fun S : Submodule Int N ↦ Module.finrank Int S) h.linearMap_ker_eq
+  omega
+
+/-- A surjective map of `Int`-modules has an image of the same finrank as its codomain. -/
+public theorem integral_finrank_range_eq_of_surjective {M N : Type*}
+    [AddCommGroup M] [Module Int M] [AddCommGroup N] [Module Int N]
+    (f : M →ₗ[Int] N) (h : Function.Surjective f) :
+    Module.finrank Int f.range = Module.finrank Int N := by
+  have hrange : f.range = ⊤ := LinearMap.range_eq_top.mpr h
+  have hExplicit :
+      @Module.finrank Int f.range _ _ f.range.module = Module.finrank Int N := by
+    have h' := congrArg
+      (fun S : Submodule Int N ↦ @Module.finrank Int S _ _ S.module) hrange
+    simpa only [finrank_top] using h'
+  exact (int_finrank_eq_of_module_structures
+    (AddCommGroup.toIntModule f.range) f.range.module).trans hExplicit
+
+/-- An injective map from a finitely generated `Int`-module has an image of the same finrank as
+its domain. -/
+public theorem integral_finrank_range_eq_of_injective {M N : Type*}
+    [AddCommGroup M] [Module Int M] [Module.Finite Int M]
+    [AddCommGroup N] [Module Int N]
+    (f : M →ₗ[Int] N) (h : Function.Injective f) :
+    Module.finrank Int f.range = Module.finrank Int M := by
+  have hModule := int_finrank_eq_of_module_structures
+    (AddCommGroup.toIntModule f.range) f.range.module
+  exact hModule.trans (LinearMap.finrank_range_of_inj h)
+
+/-- Three consecutive exactness assertions telescope the three interior ranks to the ranks of the
+two endpoint images. -/
+public theorem integral_finrank_alternating_step_of_exact
+    {V₀ V₁ V₂ V₃ V₄ : Type*}
+    [AddCommGroup V₀] [Module Int V₀]
+    [AddCommGroup V₁] [Module Int V₁] [Module.Finite Int V₁]
+    [AddCommGroup V₂] [Module Int V₂] [Module.Finite Int V₂]
+    [AddCommGroup V₃] [Module Int V₃] [Module.Finite Int V₃]
+    [AddCommGroup V₄] [Module Int V₄]
+    (f₀ : V₀ →ₗ[Int] V₁) (f₁ : V₁ →ₗ[Int] V₂)
+    (f₂ : V₂ →ₗ[Int] V₃) (f₃ : V₃ →ₗ[Int] V₄)
+    (h₁ : Function.Exact f₀ f₁) (h₂ : Function.Exact f₁ f₂)
+    (h₃ : Function.Exact f₂ f₃) :
+    (Module.finrank Int V₁ : Int) - Module.finrank Int V₂ +
+        Module.finrank Int V₃ =
+      Module.finrank Int f₀.range + Module.finrank Int f₃.range := by
+  have hRank₁ := integral_finrank_eq_add_finrank_range_of_exact f₀ f₁ h₁
+  have hRank₂ := integral_finrank_eq_add_finrank_range_of_exact f₁ f₂ h₂
+  have hRank₃ := integral_finrank_eq_add_finrank_range_of_exact f₂ f₃ h₃
+  have hRank₁' : (Module.finrank Int V₁ : Int) =
+      Module.finrank Int f₀.range + Module.finrank Int f₁.range := by
+    exact_mod_cast hRank₁
+  have hRank₂' : (Module.finrank Int V₂ : Int) =
+      Module.finrank Int f₁.range + Module.finrank Int f₂.range := by
+    exact_mod_cast hRank₂
+  have hRank₃' : (Module.finrank Int V₃ : Int) =
+      Module.finrank Int f₂.range + Module.finrank Int f₃.range := by
+    exact_mod_cast hRank₃
+  omega
+
+/-- Finrank is additive on products of finitely generated `Int`-modules.  Unlike Mathlib's
+free-module result, this applies when either module has torsion. -/
+public theorem integral_finrank_prod {M N : Type*}
+    [AddCommGroup M] [Module Int M] [Module.Finite Int M]
+    [AddCommGroup N] [Module Int N] [Module.Finite Int N] :
+    Module.finrank Int (M × N) =
+      Module.finrank Int M + Module.finrank Int N := by
+  let prodModule : Module Int (M × N) := Prod.instModule
+  have hProduct : @Module.finrank Int (M × N) _ _ prodModule =
+      Module.finrank Int M + Module.finrank Int N := by
+    let _ : Module Int (M × N) := prodModule
+    let f := LinearMap.inl Int M N
+    let g := LinearMap.snd Int M N
+    have hmiddle := integral_finrank_eq_add_finrank_range_of_exact f g
+      Function.Exact.inl_snd
+    have hleft : Module.finrank Int f.range = Module.finrank Int M :=
+      integral_finrank_range_eq_of_injective f LinearMap.inl_injective
+    have hright : Module.finrank Int g.range = Module.finrank Int N :=
+      integral_finrank_range_eq_of_surjective g LinearMap.snd_surjective
+    omega
+  exact (int_finrank_eq_of_module_structures
+    (AddCommGroup.toIntModule (M × N)) prodModule).trans hProduct
+
+/-- Exactness with finitely generated outer terms makes the middle term finitely generated over
+`Int`, without requiring the second map to be onto its original codomain. -/
+public theorem integral_module_finite_of_exact {M N P : Type*}
+    [AddCommGroup M] [Module Int M] [Module.Finite Int M]
+    [AddCommGroup N] [Module Int N]
+    [AddCommGroup P] [Module Int P] [Module.Finite Int P]
+    (f : M →ₗ[Int] N) (g : N →ₗ[Int] P) (h : Function.Exact f g) :
+    Module.Finite Int N := by
+  let _ : IsNoetherian Int P := by infer_instance
+  let _ : Module Int g.range := g.range.module
+  let _ : IsNoetherian Int g.range := isNoetherian_submodule' g.range
+  let _ : Module.Finite Int g.range := by infer_instance
+  apply Module.Finite.of_exact (f := f) (g := g.rangeRestrict)
+  · intro y
+    constructor
+    · intro hy
+      apply (h y).mp
+      exact congrArg Subtype.val hy
+    · intro hy
+      apply Subtype.ext
+      exact (h y).mpr hy
+  · exact LinearMap.surjective_rangeRestrict g
 
 /-- The alternating integral finranks in a finite exact sequence sum to zero. -/
 public theorem integral_sum_neg_one_pow_finrank_eq_zero_of_exact {n : Nat}

--- a/SphereSixComplex/Topology/IntegralHomologyEuler.lean
+++ b/SphereSixComplex/Topology/IntegralHomologyEuler.lean
@@ -1,0 +1,114 @@
+module
+
+public import SphereSixComplex.Topology.IntegralPoincareUCT
+public import Mathlib.LinearAlgebra.Dimension.Localization
+public import Mathlib.RingTheory.Finiteness.Finsupp
+
+/-!
+# Truncated integral-homology Euler characteristics
+
+This file packages the finite-generation and dimension hypotheses used by the integral-homology
+Euler characteristics through degrees six and seven.  The definitions are independent of the
+paper-specific Section 7 geometry and of Mayer--Vietoris exactness.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology
+
+namespace SphereSixComplex
+
+/-- Finiteness and dimension support sufficient for the six-dimensional integral-homology Euler
+characteristic. -/
+public structure IntegralHomologyFiniteSix
+    (X : Type) [TopologicalSpace X] : Prop where
+  /-- Every integral homology group is finitely generated. -/
+  finiteHomology : ∀ k, Module.Finite ℤ (IntegralSingularHomology k X)
+  /-- Homology vanishes above degree six. -/
+  homologyAboveDimension : ∀ k, 6 < k → Subsingleton (IntegralSingularHomology k X)
+
+namespace IntegralHomologyFiniteSix
+
+/-- Homological finiteness and the dimension bound transport through a homeomorphism. -/
+public theorem homeomorph {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (hX : IntegralHomologyFiniteSix X) (e : X ≃ₜ Y) : IntegralHomologyFiniteSix Y where
+  finiteHomology k := by
+    let _ : Module.Finite ℤ (IntegralSingularHomology k X) := hX.finiteHomology k
+    exact Module.Finite.equiv (integralSingularHomologyEquiv k e).toIntLinearEquiv
+  homologyAboveDimension k hk := by
+    let h := hX.homologyAboveDimension k hk
+    let eH := integralSingularHomologyEquiv k e
+    exact ⟨fun x y ↦ eH.symm.injective (@Subsingleton.elim _ h _ _)⟩
+
+end IntegralHomologyFiniteSix
+
+/-- Finiteness and dimension support through degree seven. -/
+public structure IntegralHomologyFiniteSeven
+    (X : Type) [TopologicalSpace X] : Prop where
+  /-- Every integral homology group is finitely generated. -/
+  finiteHomology : ∀ k, Module.Finite ℤ (IntegralSingularHomology k X)
+  /-- Homology vanishes above degree seven. -/
+  homologyAboveDimension : ∀ k, 7 < k → Subsingleton (IntegralSingularHomology k X)
+
+namespace IntegralHomologyFiniteSeven
+
+/-- A six-dimensional finiteness package is also a seven-dimensional one. -/
+public theorem ofFiniteSix {X : Type} [TopologicalSpace X]
+    (hX : IntegralHomologyFiniteSix X) : IntegralHomologyFiniteSeven X where
+  finiteHomology := hX.finiteHomology
+  homologyAboveDimension k hk := hX.homologyAboveDimension k (by omega)
+
+/-- Seven-dimensional homological finiteness transports through a homeomorphism. -/
+public theorem homeomorph {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (hX : IntegralHomologyFiniteSeven X) (e : X ≃ₜ Y) : IntegralHomologyFiniteSeven Y where
+  finiteHomology k := by
+    let _ : Module.Finite ℤ (IntegralSingularHomology k X) := hX.finiteHomology k
+    exact Module.Finite.equiv (integralSingularHomologyEquiv k e).toIntLinearEquiv
+  homologyAboveDimension k hk := by
+    let h := hX.homologyAboveDimension k hk
+    let eH := integralSingularHomologyEquiv k e
+    exact ⟨fun x y ↦ eH.symm.injective (@Subsingleton.elim _ h _ _)⟩
+
+end IntegralHomologyFiniteSeven
+
+/-- The degree-seven truncated integral-homology Euler characteristic. -/
+public noncomputable def integralHomologyEulerCharacteristicSeven
+    (X : Type) [TopologicalSpace X] : ℤ :=
+  integralHomologyEulerCharacteristicSix X -
+    Module.finrank ℤ (IntegralSingularHomology 7 X)
+
+/-- The six-dimensional integral-homology Euler characteristic is invariant under homeomorphism. -/
+public theorem integralHomologyEulerCharacteristicSix_homeomorph
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y] (e : X ≃ₜ Y) :
+    integralHomologyEulerCharacteristicSix X =
+      integralHomologyEulerCharacteristicSix Y := by
+  unfold integralHomologyEulerCharacteristicSix
+  rw [(integralSingularHomologyEquiv 0 e).toIntLinearEquiv.finrank_eq,
+    (integralSingularHomologyEquiv 1 e).toIntLinearEquiv.finrank_eq,
+    (integralSingularHomologyEquiv 2 e).toIntLinearEquiv.finrank_eq,
+    (integralSingularHomologyEquiv 3 e).toIntLinearEquiv.finrank_eq,
+    (integralSingularHomologyEquiv 4 e).toIntLinearEquiv.finrank_eq,
+    (integralSingularHomologyEquiv 5 e).toIntLinearEquiv.finrank_eq,
+    (integralSingularHomologyEquiv 6 e).toIntLinearEquiv.finrank_eq]
+
+/-- The degree-seven truncated Euler characteristic is invariant under homeomorphism. -/
+public theorem integralHomologyEulerCharacteristicSeven_homeomorph
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y] (e : X ≃ₜ Y) :
+    integralHomologyEulerCharacteristicSeven X =
+      integralHomologyEulerCharacteristicSeven Y := by
+  unfold integralHomologyEulerCharacteristicSeven
+  rw [integralHomologyEulerCharacteristicSix_homeomorph e,
+    (integralSingularHomologyEquiv 7 e).toIntLinearEquiv.finrank_eq]
+
+/-- Vanishing in degree seven identifies the two truncated Euler characteristics. -/
+public theorem integralHomologyEulerCharacteristicSeven_eq_six_of_finiteSix
+    {X : Type} [TopologicalSpace X] (hX : IntegralHomologyFiniteSix X) :
+    integralHomologyEulerCharacteristicSeven X =
+      integralHomologyEulerCharacteristicSix X := by
+  let _ := hX.homologyAboveDimension 7 (by omega)
+  unfold integralHomologyEulerCharacteristicSeven
+  simp only [Module.finrank_zero_of_subsingleton, Nat.cast_zero, sub_zero]
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/IntegralMayerVietorisEuler.lean
+++ b/SphereSixComplex/Topology/IntegralMayerVietorisEuler.lean
@@ -1,0 +1,198 @@
+module
+
+public import SphereSixComplex.Topology.FiniteExactSequenceEuler
+public import SphereSixComplex.Topology.IntegralHomologyEuler
+public import SphereSixComplex.Topology.MayerVietoris
+
+/-!
+# Integral Mayer--Vietoris Euler additivity
+
+This file contains the dimensionally sound form of Euler additivity needed by Section 7.  If the
+two open pieces and their intersection have no homology above degree six, their union can acquire
+degree-seven homology.  We therefore propagate finiteness through degree seven and use the
+degree-seven truncated Euler characteristic.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology Set
+
+namespace SphereSixComplex
+
+private noncomputable abbrev mvDifferenceLinearMap
+    {X : Type} [TopologicalSpace X] (U V : Set X) (k : ℕ) :=
+  (IntegralMayerVietoris.differenceMap U V k).toIntLinearMap
+
+private noncomputable abbrev mvSumLinearMap
+    {X : Type} [TopologicalSpace X] (U V : Set X) (k : ℕ) :=
+  (IntegralMayerVietoris.sumMap U V k).toIntLinearMap
+
+private theorem linearMap_eq_zero_of_subsingleton_domain
+    {M N : Type*} [AddCommGroup M] [Module ℤ M] [Subsingleton M]
+    [AddCommGroup N] [Module ℤ N] (f : M →ₗ[ℤ] N) : f = 0 := by
+  apply LinearMap.ext
+  intro x
+  rw [show x = 0 from Subsingleton.elim x 0]
+  simp only [map_zero]
+
+/-- Exact Mayer--Vietoris data and the degree-zero endpoint propagate finite generation to the
+union and show that no homology above degree seven can be created. -/
+public theorem integralHomologyFiniteSeven_union_of_mayerVietoris
+    {X : Type} [TopologicalSpace X] (U V : Set X)
+    (hUFinite : IntegralHomologyFiniteSeven U)
+    (hVFinite : IntegralHomologyFiniteSix V)
+    (hInterFinite : IntegralHomologyFiniteSix (U ∩ V : Set X))
+    (hExact : IntegralMayerVietoris.ExactSequence U V)
+    (hZero : Function.Surjective (IntegralMayerVietoris.sumMap U V 0)) :
+    IntegralHomologyFiniteSeven (U ∪ V : Set X) := by
+  obtain ⟨boundary, hExactAt⟩ := hExact
+  constructor
+  · intro k
+    by_cases hk : k = 0
+    · subst k
+      let _ : Module.Finite ℤ (IntegralSingularHomology 0 U) :=
+        hUFinite.finiteHomology 0
+      let _ : Module.Finite ℤ (IntegralSingularHomology 0 V) :=
+        hVFinite.finiteHomology 0
+      exact Module.Finite.of_surjective (mvSumLinearMap U V 0) hZero
+    · obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk
+      let _ : Module.Finite ℤ (IntegralSingularHomology (j + 1) U) :=
+        hUFinite.finiteHomology (j + 1)
+      let _ : Module.Finite ℤ (IntegralSingularHomology (j + 1) V) :=
+        hVFinite.finiteHomology (j + 1)
+      let _ : Module.Finite ℤ (IntegralSingularHomology j (U ∩ V : Set X)) :=
+        hInterFinite.finiteHomology j
+      apply integral_module_finite_of_exact (mvSumLinearMap U V (j + 1))
+        (boundary j).toIntLinearMap
+      simpa only [AddMonoidHom.coe_toIntLinearMap] using (hExactAt j).1
+  · intro k hk
+    obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : k ≠ 0)
+    let _ : Subsingleton (IntegralSingularHomology (j + 1) U) :=
+      hUFinite.homologyAboveDimension (j + 1) (by omega)
+    let _ : Subsingleton (IntegralSingularHomology (j + 1) V) :=
+      hVFinite.homologyAboveDimension (j + 1) (by omega)
+    let _ : Subsingleton (IntegralSingularHomology j (U ∩ V : Set X)) :=
+      hInterFinite.homologyAboveDimension j (by omega)
+    have hSumZero : mvSumLinearMap U V (j + 1) = 0 :=
+      linearMap_eq_zero_of_subsingleton_domain (mvSumLinearMap U V (j + 1))
+    have hExactLinear : Function.Exact (mvSumLinearMap U V (j + 1))
+        (boundary j).toIntLinearMap := by
+      simpa only [AddMonoidHom.coe_toIntLinearMap] using (hExactAt j).1
+    have hBoundaryInjective : Function.Injective (boundary j).toIntLinearMap :=
+      (LinearMap.injective_iff_eq_zero_of_exact hExactLinear).2 hSumZero
+    exact ⟨fun x y ↦ hBoundaryInjective (Subsingleton.elim _ _)⟩
+
+/-- The sound Mayer--Vietoris Euler formula.  The union is allowed to have degree-seven homology;
+the three other spaces vanish above degree six. -/
+public theorem integralMayerVietorisEulerAdditivitySeven
+    {X : Type} [TopologicalSpace X] (U V : Set X)
+    (hUFinite : IntegralHomologyFiniteSeven U)
+    (hVFinite : IntegralHomologyFiniteSix V)
+    (hInterFinite : IntegralHomologyFiniteSix (U ∩ V : Set X))
+    (hExact : IntegralMayerVietoris.ExactSequence U V)
+    (hZero : Function.Surjective (IntegralMayerVietoris.sumMap U V 0)) :
+    IntegralHomologyFiniteSeven (U ∪ V : Set X) ∧
+      integralHomologyEulerCharacteristicSeven (U ∪ V : Set X) =
+        integralHomologyEulerCharacteristicSeven U +
+        integralHomologyEulerCharacteristicSix V -
+        integralHomologyEulerCharacteristicSix (U ∩ V : Set X) := by
+  obtain ⟨boundary, hExactAt⟩ := hExact
+  have hUnionFinite : IntegralHomologyFiniteSeven (U ∪ V : Set X) :=
+    integralHomologyFiniteSeven_union_of_mayerVietoris U V hUFinite hVFinite
+      hInterFinite ⟨boundary, hExactAt⟩ hZero
+  refine ⟨hUnionFinite, ?_⟩
+  let _ (k : ℕ) : Module.Finite ℤ (IntegralSingularHomology k U) :=
+    hUFinite.finiteHomology k
+  let _ (k : ℕ) : Module.Finite ℤ (IntegralSingularHomology k V) :=
+    hVFinite.finiteHomology k
+  let _ (k : ℕ) : Module.Finite ℤ
+      (IntegralSingularHomology k (U ∩ V : Set X)) :=
+    hInterFinite.finiteHomology k
+  let _ (k : ℕ) : Module.Finite ℤ
+      (IntegralSingularHomology k (U ∪ V : Set X)) :=
+    hUnionFinite.finiteHomology k
+  have hStep (k : ℕ) :
+      (Module.finrank ℤ (IntegralSingularHomology (k + 1) (U ∪ V : Set X)) : ℤ) -
+          Module.finrank ℤ (IntegralSingularHomology k (U ∩ V : Set X)) +
+          Module.finrank ℤ
+            (IntegralSingularHomology k U × IntegralSingularHomology k V) =
+        Module.finrank ℤ (mvSumLinearMap U V (k + 1)).range +
+          Module.finrank ℤ (mvSumLinearMap U V k).range := by
+    apply integral_finrank_alternating_step_of_exact
+      (mvSumLinearMap U V (k + 1)) (boundary k).toIntLinearMap
+      (mvDifferenceLinearMap U V k) (mvSumLinearMap U V k)
+    · simpa only [AddMonoidHom.coe_toIntLinearMap] using (hExactAt k).1
+    · simpa only [AddMonoidHom.coe_toIntLinearMap] using (hExactAt k).2.1
+    · simpa only [AddMonoidHom.coe_toIntLinearMap] using (hExactAt k).2.2
+  have hStep₀ := hStep 0
+  have hStep₁ := hStep 1
+  have hStep₂ := hStep 2
+  have hStep₃ := hStep 3
+  have hStep₄ := hStep 4
+  have hStep₅ := hStep 5
+  have hStep₆ := hStep 6
+  rw [integral_finrank_prod] at hStep₀ hStep₁ hStep₂ hStep₃ hStep₄ hStep₅ hStep₆
+  have hRangeZero : Module.finrank ℤ (mvSumLinearMap U V 0).range =
+      Module.finrank ℤ (IntegralSingularHomology 0 (U ∪ V : Set X)) :=
+    integral_finrank_range_eq_of_surjective (mvSumLinearMap U V 0) hZero
+  have hRangeSeven : Module.finrank ℤ (mvSumLinearMap U V 7).range =
+      Module.finrank ℤ (IntegralSingularHomology 7 U) := by
+    let _ : Subsingleton (IntegralSingularHomology 7 V) :=
+      hVFinite.homologyAboveDimension 7 (by omega)
+    let _ : Subsingleton (IntegralSingularHomology 7 (U ∩ V : Set X)) :=
+      hInterFinite.homologyAboveDimension 7 (by omega)
+    have hDifferenceZero : mvDifferenceLinearMap U V 7 = 0 :=
+      linearMap_eq_zero_of_subsingleton_domain (mvDifferenceLinearMap U V 7)
+    have hExactLinear : Function.Exact (mvDifferenceLinearMap U V 7)
+        (mvSumLinearMap U V 7) := by
+      simpa only [AddMonoidHom.coe_toIntLinearMap] using (hExactAt 7).2.2
+    have hSumInjective : Function.Injective (mvSumLinearMap U V 7) :=
+      (LinearMap.injective_iff_eq_zero_of_exact hExactLinear).2 hDifferenceZero
+    rw [integral_finrank_range_eq_of_injective _ hSumInjective,
+      integral_finrank_prod]
+    simp only [Module.finrank_zero_of_subsingleton, Nat.add_zero]
+  have hRangeZeroInt :
+      (Module.finrank ℤ (mvSumLinearMap U V 0).range : ℤ) =
+        (Module.finrank ℤ (IntegralSingularHomology 0 (U ∪ V : Set X)) : ℤ) := by
+    exact_mod_cast hRangeZero
+  have hRangeSevenInt :
+      (Module.finrank ℤ (mvSumLinearMap U V 7).range : ℤ) =
+        (Module.finrank ℤ (IntegralSingularHomology 7 U) : ℤ) := by
+    exact_mod_cast hRangeSeven
+  simp only [Nat.cast_add] at hStep₀ hStep₁ hStep₂ hStep₃ hStep₄ hStep₅ hStep₆
+  unfold integralHomologyEulerCharacteristicSeven
+  unfold integralHomologyEulerCharacteristicSix
+  linear_combination -hStep₀ + hStep₁ - hStep₂ + hStep₃ - hStep₄ + hStep₅ -
+    hStep₆ - hRangeZeroInt - hRangeSevenInt
+
+/-- When both pieces and their intersection vanish above degree six, the asymmetric theorem starts
+with the ordinary six-dimensional Euler characteristic on the left piece. -/
+public theorem integralMayerVietorisEulerAdditivitySeven_of_finiteSix
+    {X : Type} [TopologicalSpace X] (U V : Set X)
+    (hUFinite : IntegralHomologyFiniteSix U)
+    (hVFinite : IntegralHomologyFiniteSix V)
+    (hInterFinite : IntegralHomologyFiniteSix (U ∩ V : Set X))
+    (hExact : IntegralMayerVietoris.ExactSequence U V)
+    (hZero : Function.Surjective (IntegralMayerVietoris.sumMap U V 0)) :
+    IntegralHomologyFiniteSeven (U ∪ V : Set X) ∧
+      integralHomologyEulerCharacteristicSeven (U ∪ V : Set X) =
+        integralHomologyEulerCharacteristicSix U +
+        integralHomologyEulerCharacteristicSix V -
+        integralHomologyEulerCharacteristicSix (U ∩ V : Set X) := by
+  have hSevenZero : Module.finrank ℤ (IntegralSingularHomology 7 U) = 0 := by
+    let _ := hUFinite.homologyAboveDimension 7 (by omega)
+    exact Module.finrank_zero_of_subsingleton
+  have hEulerU : integralHomologyEulerCharacteristicSeven U =
+      integralHomologyEulerCharacteristicSix U := by
+    unfold integralHomologyEulerCharacteristicSeven
+    rw [hSevenZero]
+    omega
+  obtain ⟨hUnionFinite, hAdd⟩ :=
+    integralMayerVietorisEulerAdditivitySeven U V
+      (IntegralHomologyFiniteSeven.ofFiniteSix hUFinite)
+      hVFinite hInterFinite hExact hZero
+  exact ⟨hUnionFinite, by simpa only [hEulerU] using hAdd⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/MayerVietorisDegreeZeroBridge.lean
+++ b/SphereSixComplex/Topology/MayerVietorisDegreeZeroBridge.lean
@@ -1,0 +1,306 @@
+module
+
+public import SphereSixComplex.Topology.BinaryOpenCoverAssembly
+public import SphereSixComplex.Topology.MayerVietoris
+public import Mathlib.Algebra.Category.Grp.Biproducts
+
+/-!
+# Degree-zero endpoint for the Set-based Mayer--Vietoris map
+
+The binary-open-cover chain model proves surjectivity of its degree-zero map without invoking full
+subdivision.  This file transports that result to the Set/subtype presentation used by the
+project's long exact sequence.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory Limits Set TopologicalSpace
+
+namespace SphereSixComplex.IntegralMayerVietoris
+
+private def leftOpenInUnion
+    {X : Type} [TopologicalSpace X] (A B : Set X) (hA : IsOpen A) :
+    Opens (A ∪ B : Set X) :=
+  ⟨Subtype.val ⁻¹' A, hA.preimage continuous_subtype_val⟩
+
+private def rightOpenInUnion
+    {X : Type} [TopologicalSpace X] (A B : Set X) (hB : IsOpen B) :
+    Opens (A ∪ B : Set X) :=
+  ⟨Subtype.val ⁻¹' B, hB.preimage continuous_subtype_val⟩
+
+private theorem leftOpenInUnion_sup_rightOpenInUnion
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hA : IsOpen A) (hB : IsOpen B) :
+    leftOpenInUnion A B hA ⊔ rightOpenInUnion A B hB = ⊤ := by
+  apply Opens.ext
+  ext x
+  change (x.1 ∈ A ∨ x.1 ∈ B) ↔ True
+  exact iff_true_intro x.2
+
+private def leftOpenInUnionToLeft
+    {X : Type} [TopologicalSpace X] (A B : Set X) (hA : IsOpen A) :
+    (Opens.toTopCat (TopCat.of (A ∪ B : Set X))).obj
+        (leftOpenInUnion A B hA) ⟶ TopCat.of A :=
+  TopCat.ofHom
+    { toFun x := ⟨x.1.1, x.2⟩
+      continuous_toFun :=
+        (continuous_subtype_val.comp continuous_subtype_val).subtype_mk _ }
+
+private def rightOpenInUnionToRight
+    {X : Type} [TopologicalSpace X] (A B : Set X) (hB : IsOpen B) :
+    (Opens.toTopCat (TopCat.of (A ∪ B : Set X))).obj
+        (rightOpenInUnion A B hB) ⟶ TopCat.of B :=
+  TopCat.ofHom
+    { toFun x := ⟨x.1.1, x.2⟩
+      continuous_toFun :=
+        (continuous_subtype_val.comp continuous_subtype_val).subtype_mk _ }
+
+private theorem leftOpenInUnion_inclusion_fac
+    {X : Type} [TopologicalSpace X] (A B : Set X) (hA : IsOpen A) :
+    leftOpenInUnionToLeft A B hA ≫
+        TopCat.ofHom (leftToUnion A B) =
+      @Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+        (leftOpenInUnion A B hA) := by
+  ext x
+  rfl
+
+private theorem rightOpenInUnion_inclusion_fac
+    {X : Type} [TopologicalSpace X] (A B : Set X) (hB : IsOpen B) :
+    rightOpenInUnionToRight A B hB ≫
+        TopCat.ofHom (rightToUnion A B) =
+      @Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+        (rightOpenInUnion A B hB) := by
+  ext x
+  rfl
+
+private theorem leftOpenInUnion_homology_fac
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hA : IsOpen A) (n : ℕ) :
+    (BinaryOpenCover.integralHomologyFunctor n).map
+          (leftOpenInUnionToLeft A B hA) ≫
+        (BinaryOpenCover.integralHomologyFunctor n).map
+          (TopCat.ofHom (leftToUnion A B)) =
+      (BinaryOpenCover.integralHomologyFunctor n).map
+        (@Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+          (leftOpenInUnion A B hA)) := by
+  rw [← (BinaryOpenCover.integralHomologyFunctor n).map_comp]
+  exact congrArg (BinaryOpenCover.integralHomologyFunctor n).map
+    (leftOpenInUnion_inclusion_fac A B hA)
+
+private theorem rightOpenInUnion_homology_fac
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hB : IsOpen B) (n : ℕ) :
+    (BinaryOpenCover.integralHomologyFunctor n).map
+          (rightOpenInUnionToRight A B hB) ≫
+        (BinaryOpenCover.integralHomologyFunctor n).map
+          (TopCat.ofHom (rightToUnion A B)) =
+      (BinaryOpenCover.integralHomologyFunctor n).map
+        (@Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+          (rightOpenInUnion A B hB)) := by
+  rw [← (BinaryOpenCover.integralHomologyFunctor n).map_comp]
+  exact congrArg (BinaryOpenCover.integralHomologyFunctor n).map
+    (rightOpenInUnion_inclusion_fac A B hB)
+
+private noncomputable def pairToBiprod
+    {Y : TopCat} (U V : Opens Y) (n : ℕ)
+    (uv :
+      (BinaryOpenCover.integralHomologyFunctor n).obj
+          ((Opens.toTopCat Y).obj U) ×
+        (BinaryOpenCover.integralHomologyFunctor n).obj
+          ((Opens.toTopCat Y).obj V)) :
+    ((BinaryOpenCover.integralHomologyFunctor n).obj
+          ((Opens.toTopCat Y).obj U) ⊞
+        (BinaryOpenCover.integralHomologyFunctor n).obj
+          ((Opens.toTopCat Y).obj V) : AddCommGrpCat) :=
+  (AddCommGrpCat.biprodIsoProd _ _).inv uv
+
+private noncomputable def biprodToPair
+    {Y : TopCat} (U V : Opens Y) (n : ℕ)
+    (z :
+      ((BinaryOpenCover.integralHomologyFunctor n).obj
+            ((Opens.toTopCat Y).obj U) ⊞
+          (BinaryOpenCover.integralHomologyFunctor n).obj
+            ((Opens.toTopCat Y).obj V) : AddCommGrpCat)) :
+    (BinaryOpenCover.integralHomologyFunctor n).obj
+          ((Opens.toTopCat Y).obj U) ×
+        (BinaryOpenCover.integralHomologyFunctor n).obj
+          ((Opens.toTopCat Y).obj V) :=
+  (AddCommGrpCat.biprodIsoProd _ _).hom z
+
+private theorem pairToBiprod_biprodToPair
+    {Y : TopCat} (U V : Opens Y) (n : ℕ)
+    (z :
+      ((BinaryOpenCover.integralHomologyFunctor n).obj
+            ((Opens.toTopCat Y).obj U) ⊞
+          (BinaryOpenCover.integralHomologyFunctor n).obj
+            ((Opens.toTopCat Y).obj V) : AddCommGrpCat)) :
+    pairToBiprod U V n (biprodToPair U V n z) = z := by
+  exact (AddCommGrpCat.biprodIsoProd
+    ((BinaryOpenCover.integralHomologyFunctor n).obj
+      ((Opens.toTopCat Y).obj U))
+    ((BinaryOpenCover.integralHomologyFunctor n).obj
+      ((Opens.toTopCat Y).obj V))).hom_inv_id_apply z
+
+private theorem pairToBiprod_surjective
+    {Y : TopCat} (U V : Opens Y) (n : ℕ) :
+    Function.Surjective (pairToBiprod U V n) := by
+  intro z
+  exact ⟨biprodToPair U V n z, pairToBiprod_biprodToPair U V n z⟩
+
+private noncomputable def integralMVFromProduct
+    {Y : TopCat} (U V : Opens Y)
+    (uv :
+      (BinaryOpenCover.integralHomologyFunctor 0).obj
+            ((Opens.toTopCat Y).obj U) ×
+          (BinaryOpenCover.integralHomologyFunctor 0).obj
+            ((Opens.toTopCat Y).obj V)) :
+    (BinaryOpenCover.integralHomologyFunctor 0).obj Y :=
+  BinaryOpenCover.integralMVFromBiprod U V 0 (pairToBiprod U V 0 uv)
+
+private theorem integralMV_comp_pairToBiprod_zero_surjective
+    {Y : TopCat} (U V : Opens Y) (hcover : U ⊔ V = ⊤) :
+    Function.Surjective
+      (integralMVFromProduct U V) :=
+  (BinaryOpenCover.integralMVFromBiprod_zero_surjective U V hcover).comp
+    (pairToBiprod_surjective U V 0)
+
+private theorem integralMVFromBiprod_biprodIsoProd_inv_apply
+    {Y : TopCat} (U V : Opens Y) (n : ℕ)
+    (u : (BinaryOpenCover.integralHomologyFunctor n).obj
+      ((Opens.toTopCat Y).obj U))
+    (v : (BinaryOpenCover.integralHomologyFunctor n).obj
+      ((Opens.toTopCat Y).obj V)) :
+    BinaryOpenCover.integralMVFromBiprod U V n
+        (pairToBiprod U V n ⟨u, v⟩) =
+      (BinaryOpenCover.integralHomologyFunctor n).map
+          (Opens.inclusion' U) u +
+        (BinaryOpenCover.integralHomologyFunctor n).map
+          (Opens.inclusion' V) v := by
+  dsimp [pairToBiprod, BinaryOpenCover.integralMVFromBiprod]
+  rw [← ConcreteCategory.comp_apply]
+  simp [AddCommGrpCat.biprodIsoProd_inv_comp_desc]
+
+private theorem integralMVFromProduct_pair_apply
+    {Y : TopCat} (U V : Opens Y)
+    (u : (BinaryOpenCover.integralHomologyFunctor 0).obj
+      ((Opens.toTopCat Y).obj U))
+    (v : (BinaryOpenCover.integralHomologyFunctor 0).obj
+      ((Opens.toTopCat Y).obj V)) :
+    integralMVFromProduct U V ⟨u, v⟩ =
+      (BinaryOpenCover.integralHomologyFunctor 0).map
+          (Opens.inclusion' U) u +
+        (BinaryOpenCover.integralHomologyFunctor 0).map
+          (Opens.inclusion' V) v := by
+  change BinaryOpenCover.integralMVFromBiprod U V 0
+      (pairToBiprod U V 0 ⟨u, v⟩) = _
+  exact integralMVFromBiprod_biprodIsoProd_inv_apply U V 0 u v
+
+private theorem sumMap_flattenPair_zero
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hA : IsOpen A) (hB : IsOpen B)
+    (u : (BinaryOpenCover.integralHomologyFunctor 0).obj
+      ((Opens.toTopCat (TopCat.of (A ∪ B : Set X))).obj
+        (leftOpenInUnion A B hA)))
+    (v : (BinaryOpenCover.integralHomologyFunctor 0).obj
+      ((Opens.toTopCat (TopCat.of (A ∪ B : Set X))).obj
+        (rightOpenInUnion A B hB))) :
+    sumMap A B 0
+        ((BinaryOpenCover.integralHomologyFunctor 0).map
+            (leftOpenInUnionToLeft A B hA) u,
+          (BinaryOpenCover.integralHomologyFunctor 0).map
+            (rightOpenInUnionToRight A B hB) v) =
+      (BinaryOpenCover.integralHomologyFunctor 0).map
+          (@Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+            (leftOpenInUnion A B hA)) u +
+        (BinaryOpenCover.integralHomologyFunctor 0).map
+          (@Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+            (rightOpenInUnion A B hB)) v := by
+  have hLeft := ConcreteCategory.congr_hom
+    (leftOpenInUnion_homology_fac A B hA 0) u
+  have hRight := ConcreteCategory.congr_hom
+    (rightOpenInUnion_homology_fac A B hB 0) v
+  have hLeft' :
+      (BinaryOpenCover.integralHomologyFunctor 0).map
+          (TopCat.ofHom (leftToUnion A B))
+          ((BinaryOpenCover.integralHomologyFunctor 0).map
+            (leftOpenInUnionToLeft A B hA) u) =
+        (BinaryOpenCover.integralHomologyFunctor 0).map
+          (@Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+            (leftOpenInUnion A B hA)) u := by
+    rw [← ConcreteCategory.comp_apply]
+    exact hLeft
+  have hRight' :
+      (BinaryOpenCover.integralHomologyFunctor 0).map
+          (TopCat.ofHom (rightToUnion A B))
+          ((BinaryOpenCover.integralHomologyFunctor 0).map
+            (rightOpenInUnionToRight A B hB) v) =
+        (BinaryOpenCover.integralHomologyFunctor 0).map
+          (@Opens.inclusion' (TopCat.of (A ∪ B : Set X))
+            (rightOpenInUnion A B hB)) v := by
+    rw [← ConcreteCategory.comp_apply]
+    exact hRight
+  change
+    (BinaryOpenCover.integralHomologyFunctor 0).map
+          (TopCat.ofHom (leftToUnion A B))
+          ((BinaryOpenCover.integralHomologyFunctor 0).map
+            (leftOpenInUnionToLeft A B hA) u) +
+        (BinaryOpenCover.integralHomologyFunctor 0).map
+          (TopCat.ofHom (rightToUnion A B))
+          ((BinaryOpenCover.integralHomologyFunctor 0).map
+            (rightOpenInUnionToRight A B hB) v) = _
+  rw [hLeft', hRight']
+
+set_option maxHeartbeats 600000 in
+private theorem sumMap_flattenPair_eq_integralMVFromProduct
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hA : IsOpen A) (hB : IsOpen B)
+    (u : (BinaryOpenCover.integralHomologyFunctor 0).obj
+      ((Opens.toTopCat (TopCat.of (A ∪ B : Set X))).obj
+        (leftOpenInUnion A B hA)))
+    (v : (BinaryOpenCover.integralHomologyFunctor 0).obj
+      ((Opens.toTopCat (TopCat.of (A ∪ B : Set X))).obj
+        (rightOpenInUnion A B hB))) :
+    sumMap A B 0
+        ((BinaryOpenCover.integralHomologyFunctor 0).map
+            (leftOpenInUnionToLeft A B hA) u,
+          (BinaryOpenCover.integralHomologyFunctor 0).map
+            (rightOpenInUnionToRight A B hB) v) =
+      integralMVFromProduct (Y := TopCat.of (A ∪ B : Set X))
+        (leftOpenInUnion A B hA)
+        (rightOpenInUnion A B hB) ⟨u, v⟩ := by
+  exact (sumMap_flattenPair_zero A B hA hB u v).trans
+    (integralMVFromProduct_pair_apply (Y := TopCat.of (A ∪ B : Set X))
+      (leftOpenInUnion A B hA) (rightOpenInUnion A B hB) u v).symm
+
+set_option maxHeartbeats 600000 in
+private theorem sumMap_zero_has_preimage
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hA : IsOpen A) (hB : IsOpen B)
+    (y : IntegralSingularHomology 0 (A ∪ B : Set X)) :
+    ∃ x : IntegralSingularHomology 0 A × IntegralSingularHomology 0 B,
+      sumMap A B 0 x = y := by
+  have hcover :
+      leftOpenInUnion A B hA ⊔ rightOpenInUnion A B hB = ⊤ :=
+    leftOpenInUnion_sup_rightOpenInUnion A B hA hB
+  obtain ⟨uv, huv⟩ := integralMV_comp_pairToBiprod_zero_surjective
+    (Y := TopCat.of (A ∪ B : Set X))
+    (leftOpenInUnion A B hA) (rightOpenInUnion A B hB) hcover y
+  obtain ⟨u, v⟩ := uv
+  exact ⟨
+    ((BinaryOpenCover.integralHomologyFunctor 0).map
+        (leftOpenInUnionToLeft A B hA) u,
+      (BinaryOpenCover.integralHomologyFunctor 0).map
+        (rightOpenInUnionToRight A B hB) v),
+    (sumMap_flattenPair_eq_integralMVFromProduct A B hA hB u v).trans huv⟩
+
+/-- The degree-zero sum of the two inclusion maps in the Set-based Mayer--Vietoris sequence is
+surjective for open subsets. -/
+public theorem sumMap_zero_surjective
+    {X : Type} [TopologicalSpace X] (A B : Set X)
+    (hA : IsOpen A) (hB : IsOpen B) :
+    Function.Surjective (sumMap A B 0) :=
+  sumMap_zero_has_preimage A B hA hB
+
+end SphereSixComplex.IntegralMayerVietoris

--- a/SphereSixComplex/Topology/SectionSevenMayerVietorisEuler.lean
+++ b/SphereSixComplex/Topology/SectionSevenMayerVietorisEuler.lean
@@ -1,5 +1,7 @@
 module
 
+public import SphereSixComplex.Topology.IntegralMayerVietorisEuler
+public import SphereSixComplex.Topology.MayerVietorisDegreeZeroBridge
 public import SphereSixComplex.Topology.SectionSevenSixManifoldCompletion
 
 /-!
@@ -9,9 +11,9 @@ This file reduces the Euler characteristic of the glued star to finite-rank calc
 central piece, the three fillings, and the three collar sources.  The numerical value `2` is not
 part of the general Mayer--Vietoris package and is not stored in any structure.
 
-Mathlib does not currently provide Euler additivity for singular homology.  The general open-cover
-theorem is therefore isolated below with its exact homological-finiteness hypotheses.  Everything
-after that theorem is a source-faithful application to the actual four-piece star.
+The general degree-seven Mayer--Vietoris formula below is proved from the project's established
+long exact sequence.  The Section 7 calculation can either supply top-degree vanishing at every
+stage or retain degree-seven homology until the final six-manifold truncation.
 -/
 
 @[expose] public section
@@ -22,44 +24,6 @@ open AlgebraicTopology CategoryTheory Set
 open scoped ContDiff Manifold
 
 namespace SphereSixComplex
-
-/-- Finiteness and dimension support sufficient for the six-dimensional integral-homology Euler
-characteristic.  This records no ranks and no value of the Euler characteristic. -/
-public structure IntegralHomologyFiniteSix
-    (X : Type) [TopologicalSpace X] : Prop where
-  /-- Every integral homology group is finitely generated. -/
-  finiteHomology : ∀ k, Module.Finite ℤ (IntegralSingularHomology k X)
-  /-- Homology vanishes above degree six. -/
-  homologyAboveDimension : ∀ k, 6 < k → Subsingleton (IntegralSingularHomology k X)
-
-namespace IntegralHomologyFiniteSix
-
-/-- Homological finiteness and the dimension bound transport through a homeomorphism. -/
-public theorem homeomorph {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
-    (hX : IntegralHomologyFiniteSix X) (e : X ≃ₜ Y) : IntegralHomologyFiniteSix Y where
-  finiteHomology k := by
-    let _ : Module.Finite ℤ (IntegralSingularHomology k X) := hX.finiteHomology k
-    exact Module.Finite.equiv (integralSingularHomologyEquiv k e).toIntLinearEquiv
-  homologyAboveDimension k hk := by
-    let h := hX.homologyAboveDimension k hk
-    let eH := integralSingularHomologyEquiv k e
-    exact ⟨fun x y ↦ eH.symm.injective (@Subsingleton.elim _ h _ _)⟩
-
-end IntegralHomologyFiniteSix
-
-/-- The six-dimensional integral-homology Euler characteristic is invariant under homeomorphism. -/
-public theorem integralHomologyEulerCharacteristicSix_homeomorph
-    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y] (e : X ≃ₜ Y) :
-    integralHomologyEulerCharacteristicSix X =
-      integralHomologyEulerCharacteristicSix Y := by
-  unfold integralHomologyEulerCharacteristicSix
-  rw [(integralSingularHomologyEquiv 0 e).toIntLinearEquiv.finrank_eq,
-    (integralSingularHomologyEquiv 1 e).toIntLinearEquiv.finrank_eq,
-    (integralSingularHomologyEquiv 2 e).toIntLinearEquiv.finrank_eq,
-    (integralSingularHomologyEquiv 3 e).toIntLinearEquiv.finrank_eq,
-    (integralSingularHomologyEquiv 4 e).toIntLinearEquiv.finrank_eq,
-    (integralSingularHomologyEquiv 5 e).toIntLinearEquiv.finrank_eq,
-    (integralSingularHomologyEquiv 6 e).toIntLinearEquiv.finrank_eq]
 
 /-- Euler additivity for an open binary cover, together with the finite-generation consequence of
 the Mayer--Vietoris long exact sequence.  This is a standard general singular-homology theorem;
@@ -79,7 +43,7 @@ intersection is homotopy equivalent to `S⁶` gives pieces satisfying every hypo
 `H₇(S⁷) = ℤ`: both the truncated dimension bound and the uncorrected identity
 `1 = 1 + 1 - 2` fail for that cover.  See `integralMayerVietorisEulerAdditivitySix_of_topDegreeVanishing`
 for the truncated form, which is available exactly when the union has no seventh homology. -/
-public axiom establishedIntegralMayerVietorisEulerAdditivitySeven
+public theorem establishedIntegralMayerVietorisEulerAdditivitySeven
     {X : Type} [TopologicalSpace X] (U V : Set X)
     (hUOpen : IsOpen U) (hVOpen : IsOpen V)
     (hUFinite : IntegralHomologyFiniteSix U)
@@ -91,7 +55,15 @@ public axiom establishedIntegralMayerVietorisEulerAdditivitySeven
         integralHomologyEulerCharacteristicSix U +
         integralHomologyEulerCharacteristicSix V -
         integralHomologyEulerCharacteristicSix (U ∩ V : Set X) +
-        (Module.finrank ℤ (IntegralSingularHomology 7 (U ∪ V : Set X)) : ℤ)
+        (Module.finrank ℤ (IntegralSingularHomology 7 (U ∪ V : Set X)) : ℤ) := by
+  obtain ⟨hUnionFinite, hEuler⟩ :=
+    integralMayerVietorisEulerAdditivitySeven_of_finiteSix U V
+      hUFinite hVFinite hInterFinite
+      (establishedIntegralMayerVietorisExactSequence U V hUOpen hVOpen)
+      (IntegralMayerVietoris.sumMap_zero_surjective U V hUOpen hVOpen)
+  refine ⟨hUnionFinite.finiteHomology, hUnionFinite.homologyAboveDimension, ?_⟩
+  unfold integralHomologyEulerCharacteristicSeven at hEuler
+  omega
 
 /-- The degree-six truncated form of Mayer--Vietoris Euler additivity, available exactly when the
 union has no seventh integral homology.  Every use in the Section 7 calculation goes through this
@@ -121,6 +93,40 @@ public theorem integralMayerVietorisEulerAdditivitySix_of_topDegreeVanishing
     · exact hAbove k hk7
   · rw [hEuler, hTopRank]
     simp
+
+/-- A structure-valued form of the sound open-cover specialization. -/
+public theorem establishedIntegralMayerVietorisEulerAdditivitySeven_structured
+    {X : Type} [TopologicalSpace X] (U V : Set X)
+    (hUOpen : IsOpen U) (hVOpen : IsOpen V)
+    (hUFinite : IntegralHomologyFiniteSix U)
+    (hVFinite : IntegralHomologyFiniteSix V)
+    (hInterFinite : IntegralHomologyFiniteSix (U ∩ V : Set X)) :
+    IntegralHomologyFiniteSeven (U ∪ V : Set X) ∧
+      integralHomologyEulerCharacteristicSeven (U ∪ V : Set X) =
+        integralHomologyEulerCharacteristicSix U +
+        integralHomologyEulerCharacteristicSix V -
+        integralHomologyEulerCharacteristicSix (U ∩ V : Set X) :=
+  integralMayerVietorisEulerAdditivitySeven_of_finiteSix U V
+    hUFinite hVFinite hInterFinite
+    (establishedIntegralMayerVietorisExactSequence U V hUOpen hVOpen)
+    (IntegralMayerVietoris.sumMap_zero_surjective U V hUOpen hVOpen)
+
+/-- The asymmetric form used to adjoin successive six-dimensional pieces to a partial union that
+may already carry degree-seven homology. -/
+public theorem establishedIntegralMayerVietorisEulerAdditivitySeven_asymmetric
+    {X : Type} [TopologicalSpace X] (U V : Set X)
+    (hUOpen : IsOpen U) (hVOpen : IsOpen V)
+    (hUFinite : IntegralHomologyFiniteSeven U)
+    (hVFinite : IntegralHomologyFiniteSix V)
+    (hInterFinite : IntegralHomologyFiniteSix (U ∩ V : Set X)) :
+    IntegralHomologyFiniteSeven (U ∪ V : Set X) ∧
+      integralHomologyEulerCharacteristicSeven (U ∪ V : Set X) =
+        integralHomologyEulerCharacteristicSeven U +
+        integralHomologyEulerCharacteristicSix V -
+        integralHomologyEulerCharacteristicSix (U ∩ V : Set X) :=
+  integralMayerVietorisEulerAdditivitySeven U V hUFinite hVFinite hInterFinite
+    (establishedIntegralMayerVietorisExactSequence U V hUOpen hVOpen)
+    (IntegralMayerVietoris.sumMap_zero_surjective U V hUOpen hVOpen)
 
 namespace OpenEmbeddingStarData
 
@@ -189,8 +195,9 @@ public noncomputable def sectionSevenLocalEulerExpression : ℤ :=
   integralHomologyEulerCharacteristicSix (A.collarSource 1) -
   integralHomologyEulerCharacteristicSix (A.collarSource 2)
 
-/-- Mayer--Vietoris additivity reduces the Euler characteristic of the actual glued star to the
-seven local source spaces.  No numerical local rank is assumed by this theorem. -/
+/-- Degree-six derivation with explicit top-degree vanishing at every partial union.  The theorem
+`integralHomologyEulerCharacteristicSeven_eq_localExpression` avoids those intermediate
+hypotheses by retaining degree-seven homology until the completed space. -/
 public theorem integralHomologyEulerCharacteristicSix_eq_localExpression
     (hCentralFinite : IntegralHomologyFiniteSix A.central)
     (hFillingFinite : ∀ i, IntegralHomologyFiniteSix (A.filling i))
@@ -310,8 +317,161 @@ public theorem integralHomologyEulerCharacteristicSix_eq_localExpression
   unfold sectionSevenLocalEulerExpression
   ring
 
-/-- An explicit local finite-rank calculation of value `2` supplies the separate Euler hypothesis
-needed by the closed-six-manifold completion theorem. -/
+/-- The sound Mayer--Vietoris iteration retains possible degree-seven homology throughout the
+three partial unions. -/
+public theorem integralHomologyEulerCharacteristicSeven_eq_localExpression
+    (hCentralFinite : IntegralHomologyFiniteSix A.central)
+    (hFillingFinite : ∀ i, IntegralHomologyFiniteSix (A.filling i))
+    (hCollarFinite : ∀ i, IntegralHomologyFiniteSix (A.collarSource i)) :
+    integralHomologyEulerCharacteristicSeven
+        (GluedSpace A.toFourPieceStarGluingData.glueData) =
+      A.sectionSevenLocalEulerExpression := by
+  let C := A.SectionSevenEulerCover
+  let eCentralStage : A.central ≃ₜ C.stage 0 := by
+    simpa only [C] using A.centralToSectionSevenEulerStageZeroHomeomorph
+  let ePiece (i : Fin 3) : A.filling i ≃ₜ C.piece i.succ := by
+    simpa only [C] using A.fillingToSectionSevenEulerPieceHomeomorph i
+  let eOverlap (i : Fin 3) : A.collarSource i ≃ₜ
+      (C.stage i.castSucc ∩ C.piece i.succ : Set
+        (GluedSpace A.toFourPieceStarGluingData.glueData)) := by
+    simpa only [C] using A.collarToMayerVietorisOverlapHomeomorph i
+  let eNext (i : Fin 3) :
+      (C.stage i.castSucc ∪ C.piece i.succ : Set
+        (GluedSpace A.toFourPieceStarGluingData.glueData)) ≃ₜ C.stage i.succ := by
+    simpa only [C] using A.sectionSevenEulerStageNextHomeomorph i
+  let eLast : C.stage (3 : Fin 4) ≃ₜ
+      GluedSpace A.toFourPieceStarGluingData.glueData := by
+    simpa only [C] using A.sectionSevenEulerStageLastHomeomorph
+  have hPiece : ∀ (i : Fin 3), IntegralHomologyFiniteSix (C.piece i.succ) := fun i ↦
+    (hFillingFinite i).homeomorph (ePiece i)
+  have hOverlap : ∀ (i : Fin 3), IntegralHomologyFiniteSix
+      (C.stage i.castSucc ∩ C.piece i.succ : Set
+        (GluedSpace A.toFourPieceStarGluingData.glueData)) := fun i ↦
+    (hCollarFinite i).homeomorph (eOverlap i)
+  have hStageZeroSix : IntegralHomologyFiniteSix (C.stage (0 : Fin 4)) :=
+    hCentralFinite.homeomorph eCentralStage
+  have hStageZero : IntegralHomologyFiniteSeven (C.stage (0 : Fin 4)) :=
+    IntegralHomologyFiniteSeven.ofFiniteSix hStageZeroSix
+  obtain ⟨hUnionZero, hAddZero⟩ :=
+    establishedIntegralMayerVietorisEulerAdditivitySeven_asymmetric
+      (C.stage (0 : Fin 4)) (C.piece 1)
+      (C.isOpen_stage 0) (C.isOpen_piece 1) hStageZero (hPiece 0) (hOverlap 0)
+  have hStageOne : IntegralHomologyFiniteSeven (C.stage (1 : Fin 4)) :=
+    hUnionZero.homeomorph (eNext 0)
+  have hAddZero' :
+      integralHomologyEulerCharacteristicSeven (C.stage (1 : Fin 4)) =
+        integralHomologyEulerCharacteristicSeven (C.stage (0 : Fin 4)) +
+        integralHomologyEulerCharacteristicSix (C.piece 1) -
+        integralHomologyEulerCharacteristicSix (C.stage (0 : Fin 4) ∩ C.piece 1 :
+          Set (GluedSpace A.toFourPieceStarGluingData.glueData)) := by
+    simpa using
+      (integralHomologyEulerCharacteristicSeven_homeomorph (eNext 0)).symm.trans hAddZero
+  obtain ⟨hUnionOne, hAddOne⟩ :=
+    establishedIntegralMayerVietorisEulerAdditivitySeven_asymmetric
+      (C.stage (1 : Fin 4)) (C.piece 2)
+      (C.isOpen_stage 1) (C.isOpen_piece 2) hStageOne (hPiece 1) (hOverlap 1)
+  have hStageTwo : IntegralHomologyFiniteSeven (C.stage (2 : Fin 4)) :=
+    hUnionOne.homeomorph (eNext 1)
+  have hAddOne' :
+      integralHomologyEulerCharacteristicSeven (C.stage (2 : Fin 4)) =
+        integralHomologyEulerCharacteristicSeven (C.stage (1 : Fin 4)) +
+        integralHomologyEulerCharacteristicSix (C.piece 2) -
+        integralHomologyEulerCharacteristicSix (C.stage (1 : Fin 4) ∩ C.piece 2 :
+          Set (GluedSpace A.toFourPieceStarGluingData.glueData)) := by
+    simpa using
+      (integralHomologyEulerCharacteristicSeven_homeomorph (eNext 1)).symm.trans hAddOne
+  obtain ⟨-, hAddTwo⟩ :=
+    establishedIntegralMayerVietorisEulerAdditivitySeven_asymmetric
+      (C.stage (2 : Fin 4)) (C.piece 3)
+      (C.isOpen_stage 2) (C.isOpen_piece 3) hStageTwo (hPiece 2) (hOverlap 2)
+  have hAddTwo' :
+      integralHomologyEulerCharacteristicSeven (C.stage (3 : Fin 4)) =
+        integralHomologyEulerCharacteristicSeven (C.stage (2 : Fin 4)) +
+        integralHomologyEulerCharacteristicSix (C.piece 3) -
+        integralHomologyEulerCharacteristicSix (C.stage (2 : Fin 4) ∩ C.piece 3 :
+          Set (GluedSpace A.toFourPieceStarGluingData.glueData)) := by
+    simpa using
+      (integralHomologyEulerCharacteristicSeven_homeomorph (eNext 2)).symm.trans hAddTwo
+  have hCentralEuler :
+      integralHomologyEulerCharacteristicSeven (C.stage (0 : Fin 4)) =
+        integralHomologyEulerCharacteristicSix A.central := by
+    exact (integralHomologyEulerCharacteristicSeven_homeomorph eCentralStage).symm.trans
+      (integralHomologyEulerCharacteristicSeven_eq_six_of_finiteSix hCentralFinite)
+  have hPieceEuler : ∀ (i : Fin 3),
+      integralHomologyEulerCharacteristicSix (C.piece i.succ) =
+        integralHomologyEulerCharacteristicSix (A.filling i) := fun i ↦
+    (integralHomologyEulerCharacteristicSix_homeomorph (ePiece i)).symm
+  have hOverlapEuler : ∀ (i : Fin 3),
+      integralHomologyEulerCharacteristicSix
+          (C.stage i.castSucc ∩ C.piece i.succ : Set
+            (GluedSpace A.toFourPieceStarGluingData.glueData)) =
+        integralHomologyEulerCharacteristicSix (A.collarSource i) := fun i ↦
+    (integralHomologyEulerCharacteristicSix_homeomorph (eOverlap i)).symm
+  rw [← integralHomologyEulerCharacteristicSeven_homeomorph eLast]
+  rw [hAddTwo', hAddOne', hAddZero', hCentralEuler]
+  have hPieceEuler0 :
+      integralHomologyEulerCharacteristicSix (C.piece (1 : Fin 4)) =
+        integralHomologyEulerCharacteristicSix (A.filling (0 : Fin 3)) := by
+    simpa using hPieceEuler (0 : Fin 3)
+  have hPieceEuler1 :
+      integralHomologyEulerCharacteristicSix (C.piece (2 : Fin 4)) =
+        integralHomologyEulerCharacteristicSix (A.filling (1 : Fin 3)) := by
+    simpa using hPieceEuler (1 : Fin 3)
+  have hPieceEuler2 :
+      integralHomologyEulerCharacteristicSix (C.piece (3 : Fin 4)) =
+        integralHomologyEulerCharacteristicSix (A.filling (2 : Fin 3)) := by
+    simpa using hPieceEuler (2 : Fin 3)
+  have hOverlapEuler0 :
+      integralHomologyEulerCharacteristicSix
+          (C.stage (0 : Fin 4) ∩ C.piece (1 : Fin 4) : Set
+            (GluedSpace A.toFourPieceStarGluingData.glueData)) =
+        integralHomologyEulerCharacteristicSix (A.collarSource (0 : Fin 3)) := by
+    simpa using hOverlapEuler (0 : Fin 3)
+  have hOverlapEuler1 :
+      integralHomologyEulerCharacteristicSix
+          (C.stage (1 : Fin 4) ∩ C.piece (2 : Fin 4) : Set
+            (GluedSpace A.toFourPieceStarGluingData.glueData)) =
+        integralHomologyEulerCharacteristicSix (A.collarSource (1 : Fin 3)) := by
+    simpa using hOverlapEuler (1 : Fin 3)
+  have hOverlapEuler2 :
+      integralHomologyEulerCharacteristicSix
+          (C.stage (2 : Fin 4) ∩ C.piece (3 : Fin 4) : Set
+            (GluedSpace A.toFourPieceStarGluingData.glueData)) =
+        integralHomologyEulerCharacteristicSix (A.collarSource (2 : Fin 3)) := by
+    simpa using hOverlapEuler (2 : Fin 3)
+  rw [hPieceEuler0, hPieceEuler1, hPieceEuler2,
+    hOverlapEuler0, hOverlapEuler1, hOverlapEuler2]
+  unfold sectionSevenLocalEulerExpression
+  ring
+
+/-- Six-manifold dimensionality removes the final degree-seven correction from the sound
+Mayer--Vietoris iteration. -/
+public theorem integralHomologyEulerCharacteristicSix_eq_localExpression_of_homologyTheory
+    (T : ClosedOrientedSixManifoldHomologyTheory
+      (GluedSpace A.toFourPieceStarGluingData.glueData))
+    (hCentralFinite : IntegralHomologyFiniteSix A.central)
+    (hFillingFinite : ∀ i, IntegralHomologyFiniteSix (A.filling i))
+    (hCollarFinite : ∀ i, IntegralHomologyFiniteSix (A.collarSource i)) :
+    integralHomologyEulerCharacteristicSix
+        (GluedSpace A.toFourPieceStarGluingData.glueData) =
+      A.sectionSevenLocalEulerExpression := by
+  have hSeven : Subsingleton (IntegralSingularHomology 7
+      (GluedSpace A.toFourPieceStarGluingData.glueData)) :=
+    T.homologyAboveDimension 7 (by omega)
+  have hTruncation : integralHomologyEulerCharacteristicSeven
+      (GluedSpace A.toFourPieceStarGluingData.glueData) =
+        integralHomologyEulerCharacteristicSix
+          (GluedSpace A.toFourPieceStarGluingData.glueData) := by
+    let _ := hSeven
+    unfold integralHomologyEulerCharacteristicSeven
+    simp only [Module.finrank_zero_of_subsingleton, Nat.cast_zero, sub_zero]
+  rw [← hTruncation]
+  exact A.integralHomologyEulerCharacteristicSeven_eq_localExpression
+    hCentralFinite hFillingFinite hCollarFinite
+
+/-- Compatibility corollary through explicit top-degree vanishing at every partial union.  The
+final endpoint below uses
+`integralHomologyEulerCharacteristicSix_eq_localExpression_of_homologyTheory`. -/
 public theorem integralHomologyEulerCharacteristicSix_eq_two_of_localCalculation
     (hCentralFinite : IntegralHomologyFiniteSix A.central)
     (hFillingFinite : ∀ i, IntegralHomologyFiniteSix (A.filling i))
@@ -339,13 +499,17 @@ public theorem hasIntegralHomologyOfSixSphere_of_localEulerCalculation
     (hCentralFinite : IntegralHomologyFiniteSix A.central)
     (hFillingFinite : ∀ i, IntegralHomologyFiniteSix (A.filling i))
     (hCollarFinite : ∀ i, IntegralHomologyFiniteSix (A.collarSource i))
-    (hTop : A.SectionSevenStageTopDegreeVanishing)
+    (_hTop : A.SectionSevenStageTopDegreeVanishing)
     (hLocal : A.sectionSevenLocalEulerExpression = 2) :
     HasIntegralHomologyOfSixSphere (A.SectionSevenMayerVietorisSpace) :=
+  let T := establishedCompactComplexThreefoldHomologyTheory
+    (A.SectionSevenMayerVietorisSpace) hManifold hCompact
+  have hEuler : integralHomologyEulerCharacteristicSix
+      (A.SectionSevenMayerVietorisSpace) = 2 := by
+    rw [A.integralHomologyEulerCharacteristicSix_eq_localExpression_of_homologyTheory
+      T hCentralFinite hFillingFinite hCollarFinite, hLocal]
   H.hasIntegralHomologyOfSixSphere_of_closedComplexThreefold
-    hManifold hCompact hConnected
-      (A.integralHomologyEulerCharacteristicSix_eq_two_of_localCalculation
-        hCentralFinite hFillingFinite hCollarFinite hTop hLocal)
+    hManifold hCompact hConnected hEuler
 
 end SectionSevenMayerVietorisHomologyAssembly
 

--- a/SphereSixComplex/Topology/SectionSevenSixManifoldCompletion.lean
+++ b/SphereSixComplex/Topology/SectionSevenSixManifoldCompletion.lean
@@ -2,6 +2,7 @@ module
 
 public import SphereSixComplex.Topology.EstablishedCompactSmoothOrientedManifoldHomology
 public import SphereSixComplex.Topology.EstablishedSphereHomology
+public import SphereSixComplex.Topology.IntegralHomologyEuler
 public import SphereSixComplex.Topology.SectionSevenMayerVietorisHomologyAssembly
 public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
 


### PR DESCRIPTION
## Summary

- Prove the corrected degree-seven integral Mayer--Vietoris Euler formula from `establishedIntegralMayerVietorisExactSequence`.
- Prove degree-zero surjectivity for open binary covers.
- Add finite-rank exact-sequence lemmas and a sound degree-seven iteration for Section 7.
- Keep the public top-degree-vanishing API from #34. The final six-manifold result uses the dimension bound only at the completed space.

This removes the Euler-additivity axiom. It adds no `sorry`, `admit`, `unsafe`, or new axiom. The full Mayer--Vietoris exact sequence remains an established input.

Follow-up to #34. Resolves #26.

Please use PR CI for the integrated build check.