### PR TITLE
Prove denseCuspExponentialCover_isLocalDiffeomorph instead of assuming it

### DIFF
--- a/SphereSixComplex/Geometry/CuspAnalyticFillingCollar.lean
+++ b/SphereSixComplex/Geometry/CuspAnalyticFillingCollar.lean
@@ -2,6 +2,7 @@ module
 
 public import SphereSixComplex.Geometry.CuspPuncturedCollarBridge
 public import SphereSixComplex.Geometry.PaperCentralFamilyTopology
+public import SphereSixComplex.Geometry.LocalDiffeomorphTransport
 import all Mathlib.Geometry.Manifold.LocalDiffeomorph
 
 /-!
@@ -474,16 +475,150 @@ private noncomputable def additiveCuspBundleDiffeomorph
       contMDiff_toFun := additiveCuspBundleHomeomorph_contMDiff W
       contMDiff_invFun := additiveCuspBundleHomeomorph_symm_contMDiff W }
 
+/-! ## The coordinatewise exponential is locally biholomorphic
+
+The dense torus is charted by its open embedding into `ℂ³`, so the exponential cover reads in
+coordinates as `(z₀, z₁, s) ↦ (e^{2πi z₀}, e^{2πi z₁}, e^{2πi s})`.  That map is holomorphic with
+everywhere invertible derivative — the diagonal scaling by the three nonzero numbers
+`2πi e^{2πi ·}` — so the inverse function theorem makes it a local biholomorphism, and the two
+transport lemmas move that back to the manifolds. -/
+
+/-- The scalar `2πi`, the frequency of the cusp exponential. -/
+private noncomputable def twoPiI : ℂ := 2 * Real.pi * Complex.I
+
+private theorem twoPiI_ne_zero : twoPiI ≠ 0 :=
+  mul_ne_zero (mul_ne_zero (by norm_num) (Complex.ofReal_ne_zero.mpr Real.pi_ne_zero))
+    Complex.I_ne_zero
+
+/-- The coordinate representative of the cusp exponential cover. -/
+private noncomputable def expCoords (p : AdditiveCuspCover) : ComplexModel :=
+  denseTorusComplexCoordinates (denseCuspExponentialCover p)
+
+/-- The linear identification of the additive cusp cover `ℂ² × ℂ` with `ℂ³`. -/
+private noncomputable def additiveCoordEquiv : AdditiveCuspCover ≃L[ℂ] ComplexModel :=
+  (ContinuousLinearEquiv.equivOfInverse
+      (ContinuousLinearMap.pi
+        ![(ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 2 ↦ ℂ) 0).comp
+            (ContinuousLinearMap.fst ℂ (Fin 2 → ℂ) ℂ),
+          (ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 2 ↦ ℂ) 1).comp
+            (ContinuousLinearMap.fst ℂ (Fin 2 → ℂ) ℂ),
+          ContinuousLinearMap.snd ℂ (Fin 2 → ℂ) ℂ])
+      ((ContinuousLinearMap.pi
+          ![ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 3 ↦ ℂ) 0,
+            ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 3 ↦ ℂ) 1]).prod
+        (ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 3 ↦ ℂ) 2))
+      (by
+        intro v
+        ext i
+        · fin_cases i <;> rfl
+        · rfl)
+      (by
+        intro v
+        funext i
+        fin_cases i <;> rfl)).trans
+    (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ)).symm
+
+/-- The exponential in the three coordinates of `ℂ³`. -/
+private noncomputable def expOnThree (x : ComplexModel) : ComplexModel :=
+  WithLp.toLp 2 (fun i ↦ Complex.exp (twoPiI * WithLp.ofLp x i))
+
+private theorem expCoords_eq : expCoords = expOnThree ∘ additiveCoordEquiv := by
+  funext p
+  apply congrArg (WithLp.toLp 2)
+  funext i
+  fin_cases i <;> rfl
+
+private theorem contDiff_expOnThree : ContDiff ℂ ∞ expOnThree := by
+  have h : ContDiff ℂ ∞
+      (fun x : ComplexModel ↦ (fun i ↦ Complex.exp (twoPiI * WithLp.ofLp x i))) := by
+    refine contDiff_pi.mpr fun i ↦ ?_
+    have hcoord : ContDiff ℂ ∞ (fun x : ComplexModel ↦ WithLp.ofLp x i) :=
+      (ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 3 ↦ ℂ) i).contDiff.comp
+        (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ)).contDiff
+    exact Complex.contDiff_exp.comp (contDiff_const.mul hcoord)
+  exact (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ)).symm.contDiff.comp h
+
+/-- Diagonal scaling of `ℂ³` by three nonzero factors. -/
+private noncomputable def diagScale (a : Fin 3 → ℂˣ) : ComplexModel ≃L[ℂ] ComplexModel :=
+  ((PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ)).trans
+    (ContinuousLinearEquiv.piCongrRight
+      (fun i ↦ ContinuousLinearEquiv.unitsEquivAut ℂ (a i)))).trans
+    (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ)).symm
+
+/-- The derivative of the coordinate exponential at a point of `ℂ³`. -/
+private noncomputable def expOnThreeDeriv (x : ComplexModel) : ComplexModel ≃L[ℂ] ComplexModel :=
+  diagScale (fun i ↦ Units.mk0 (twoPiI * Complex.exp (twoPiI * WithLp.ofLp x i))
+    (mul_ne_zero twoPiI_ne_zero (Complex.exp_ne_zero _)))
+
+set_option maxRecDepth 8000 in
+set_option maxHeartbeats 1000000 in
+private theorem hasFDerivAt_expOnThree (x : ComplexModel) :
+    HasFDerivAt expOnThree ((expOnThreeDeriv x : ComplexModel →L[ℂ] ComplexModel)) x := by
+  set c : Fin 3 → ℂ := fun i ↦ twoPiI * Complex.exp (twoPiI * WithLp.ofLp x i) with hc
+  have hpi : HasFDerivAt (fun y : ComplexModel ↦ (fun i ↦ Complex.exp (twoPiI * WithLp.ofLp y i)))
+      (ContinuousLinearMap.pi fun i ↦ (c i) •
+        ((ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 3 ↦ ℂ) i).comp
+          (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ) :
+            ComplexModel →L[ℂ] (Fin 3 → ℂ)))) x := by
+    refine hasFDerivAt_pi.mpr fun i ↦ ?_
+    set L : ComplexModel →L[ℂ] ℂ :=
+      (ContinuousLinearMap.proj (R := ℂ) (φ := fun _ : Fin 3 ↦ ℂ) i).comp
+        (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ) :
+          ComplexModel →L[ℂ] (Fin 3 → ℂ)) with hL
+    have hcoord : HasFDerivAt (fun y : ComplexModel ↦ WithLp.ofLp y i) L x := L.hasFDerivAt
+    have hmul := hcoord.const_mul twoPiI
+    have hexp := (Complex.hasDerivAt_exp (twoPiI * WithLp.ofLp x i)).comp_hasFDerivAt x hmul
+    have hsmul : Complex.exp (twoPiI * WithLp.ofLp x i) • (twoPiI • L) = c i • L := by
+      rw [smul_smul, hc]
+      congr 1
+      exact mul_comm _ _
+    rwa [hsmul] at hexp
+  have hcomp := (PiLp.continuousLinearEquiv 2 ℂ (fun _ : Fin 3 ↦ ℂ)).symm.hasFDerivAt.comp x hpi
+  refine hcomp.congr_fderiv ?_
+  ext y i
+  show c i * WithLp.ofLp y i = WithLp.ofLp y i * c i
+  exact mul_comm _ _
+
+set_option maxHeartbeats 1000000 in
+private theorem isLocalDiffeomorph_expCoords :
+    IsLocalDiffeomorph (modelWithCornersSelf ℂ AdditiveCuspCover)
+      (modelWithCornersSelf ℂ ComplexModel) ∞ expCoords := by
+  rw [expCoords_eq]
+  refine isLocalDiffeomorph_of_contDiff_of_hasFDerivAt_equiv
+    (contDiff_expOnThree.comp additiveCoordEquiv.contDiff) fun p ↦ ?_
+  refine ⟨additiveCoordEquiv.trans (expOnThreeDeriv (additiveCoordEquiv p)), ?_⟩
+  have hchain :=
+    (hasFDerivAt_expOnThree (additiveCoordEquiv p)).comp p additiveCoordEquiv.hasFDerivAt
+  refine hchain.congr_fderiv ?_
+  apply ContinuousLinearMap.ext
+  intro v
+  rfl
+
+private theorem isLocalDiffeomorph_denseCuspExponentialCover :
+    letI := denseTorusCharts
+    IsLocalDiffeomorph (modelWithCornersSelf ℂ AdditiveCuspCover)
+      (modelWithCornersSelf ℂ ComplexModel) ∞ denseCuspExponentialCover := by
+  refine isLocalDiffeomorph_of_comp_isOpenEmbedding
+    denseTorusComplexCoordinates_isOpenEmbedding ?_
+  exact isLocalDiffeomorph_expCoords
+
 namespace Established
 
 /-- The coordinatewise complex exponential is locally biholomorphic on every open radius
-restriction.  This is the standard finite-product exponential covering theorem. -/
-public axiom denseCuspExponentialCover_isLocalDiffeomorph (r : ℝ) :
+restriction: in the charts of both sides it is
+`(z₀, z₁, s) ↦ (e^{2πi z₀}, e^{2πi z₁}, e^{2πi s})`, whose derivative is the diagonal scaling by
+the nonzero numbers `2πi e^{2πi ·}`. -/
+public theorem denseCuspExponentialCover_isLocalDiffeomorph (r : ℝ) :
     letI := additiveCuspRadiusCoverCharts r
     letI := denseTorusCharts
     IsLocalDiffeomorph (modelWithCornersSelf ℂ AdditiveCuspCover)
       (modelWithCornersSelf ℂ ComplexModel) ∞
-      (fun p : additiveCuspRadiusCover r ↦ denseCuspExponentialCover p)
+      (fun p : additiveCuspRadiusCover r ↦ denseCuspExponentialCover p) := by
+  letI := additiveCuspRadiusCoverCharts r
+  letI := denseTorusCharts
+  exact isLocalDiffeomorph_comp isLocalDiffeomorph_denseCuspExponentialCover
+    (openSubtypeVal_isLocalDiffeomorph
+      ⟨additiveCuspRadiusCover r, additiveCuspRadiusCover_isOpen r⟩)
 
 end Established
 

--- a/SphereSixComplex/Geometry/LocalDiffeomorphTransport.lean
+++ b/SphereSixComplex/Geometry/LocalDiffeomorphTransport.lean
@@ -1,0 +1,200 @@
+module
+
+public import Mathlib.Geometry.Manifold.LocalDiffeomorph
+public import Mathlib.Geometry.Manifold.ContMDiff.Basic
+public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
+public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.ContDiff
+import all Mathlib.Geometry.Manifold.LocalDiffeomorph
+
+/-!
+# Transporting local diffeomorphisms
+
+Three general facts about `IsLocalDiffeomorph` that the analytic construction needs and Mathlib
+does not yet provide.
+
+* `isLocalDiffeomorph_of_contDiff_of_hasFDerivAt_equiv`: the inverse function theorem, packaged as
+  a local diffeomorphism between model spaces.  Mathlib has the normed-space statement
+  (`ContDiffAt.toOpenPartialHomeomorph`) but not its manifold consequence.
+* `isLocalDiffeomorph_of_comp_isOpenEmbedding`: if the charted-space structure on the target comes
+  from an open embedding, a map into it is a local diffeomorphism as soon as its composite with
+  that embedding is.
+* `isLocalDiffeomorph_comp`: local diffeomorphisms compose, across three different models.
+
+Together they reduce a local-biholomorphism claim about an explicitly coordinatized map to a
+derivative computation.
+-/
+
+@[expose] public section
+
+open Set Topology
+open scoped ContDiff Manifold
+
+namespace SphereSixComplex
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {H : Type*} [TopologicalSpace H] {H' : Type*} [TopologicalSpace H']
+  {I : ModelWithCorners 𝕜 E H} {J : ModelWithCorners 𝕜 F H'} {n : ℕ∞ω}
+
+/-! ## The inverse function theorem as a local diffeomorphism -/
+
+/-- Inverse function theorem: a `C^∞` map between model spaces whose derivative is everywhere a
+continuous linear equivalence is a local diffeomorphism. -/
+public theorem isLocalDiffeomorph_of_contDiff_of_hasFDerivAt_equiv
+    {𝕂 : Type*} [RCLike 𝕂]
+    {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕂 E'] [CompleteSpace E']
+    {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕂 F']
+    {f : E' → F'} (hf : ContDiff 𝕂 ∞ f)
+    (h : ∀ x, ∃ f' : E' ≃L[𝕂] F', HasFDerivAt f (f' : E' →L[𝕂] F') x) :
+    IsLocalDiffeomorph 𝓘(𝕂, E') 𝓘(𝕂, F') ∞ f := by
+  intro x
+  obtain ⟨f', hf'⟩ := h x
+  let Φ : OpenPartialHomeomorph E' F' :=
+    (hf.contDiffAt (x := x)).toOpenPartialHomeomorph f hf' (by simp)
+  refine ⟨{ toPartialEquiv := Φ.toPartialEquiv
+            open_source := Φ.open_source
+            open_target := Φ.open_target
+            contMDiffOn_toFun := ?_
+            contMDiffOn_invFun := ?_ }, ?_, ?_⟩
+  · exact contMDiffOn_iff_contDiffOn.mpr hf.contDiffOn
+  · refine contMDiffOn_iff_contDiffOn.mpr ?_
+    intro y hy
+    obtain ⟨g', hg'⟩ := h (Φ.symm y)
+    exact ((Φ.contDiffAt_symm hy hg' hf.contDiffAt).contDiffWithinAt)
+  · exact ContDiffAt.mem_toOpenPartialHomeomorph_source (n := ∞) hf.contDiffAt hf' (by simp)
+  · intro y _
+    rfl
+
+/-! ## Transport through an open-embedding chart -/
+
+section OfCompOpenEmbedding
+
+variable {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {N : Type*} [TopologicalSpace N] [Nonempty N] {g : N → H'} (hg : IsOpenEmbedding g)
+
+/-- If the charted-space structure on `N` is the one induced by an open embedding `g : N → H'`,
+then a map into `N` is a local diffeomorphism as soon as its composite with `g` is. -/
+public theorem isLocalDiffeomorph_of_comp_isOpenEmbedding {f : M → N}
+    (h : letI := hg.singletonChartedSpace; IsLocalDiffeomorph I J n (g ∘ f)) :
+    letI := hg.singletonChartedSpace
+    IsLocalDiffeomorph I J n f := by
+  letI := hg.singletonChartedSpace
+  intro x
+  obtain ⟨Φ, hxΦ, hΦ⟩ := h x
+  set e := hg.toOpenPartialHomeomorph g with he
+  have hetarget : e.target = range g := hg.toOpenPartialHomeomorph_target
+  set T : OpenPartialHomeomorph M N := Φ.toOpenPartialHomeomorph.trans e.symm with hT
+  have hTsource : T.source = Φ.source ∩ Φ ⁻¹' range g := by
+    rw [hT, OpenPartialHomeomorph.trans_source, OpenPartialHomeomorph.symm_source, hetarget]
+    rfl
+  have hmapsTarget : MapsTo g T.target Φ.target := by
+    intro y hy
+    rw [hT, OpenPartialHomeomorph.trans_target] at hy
+    have hy2 : e y ∈ Φ.target := hy.2
+    have hey : e y = g y := rfl
+    rwa [hey] at hy2
+  refine ⟨{ toPartialEquiv := T.toPartialEquiv
+            open_source := T.open_source
+            open_target := T.open_target
+            contMDiffOn_toFun := ?_
+            contMDiffOn_invFun := ?_ }, ?_, ?_⟩
+  · have hcomp : ContMDiffOn I J n (fun y => e.symm (Φ y)) T.source := by
+      refine (contMDiffOn_isOpenEmbedding_symm hg).comp
+        (Φ.contMDiffOn_toFun.mono (by rw [hTsource]; exact fun y hy => hy.1)) ?_
+      intro y hy
+      rw [hTsource] at hy
+      exact hy.2
+    exact hcomp
+  · have hcomp : ContMDiffOn J I n (fun y => Φ.symm (g y)) T.target :=
+      Φ.contMDiffOn_invFun.comp (contMDiff_isOpenEmbedding hg).contMDiffOn hmapsTarget
+    exact hcomp
+  · show x ∈ T.source
+    rw [hTsource]
+    refine ⟨hxΦ, ?_⟩
+    have hx : (Φ : M → H') x = g (f x) := (hΦ hxΦ).symm
+    show (Φ : M → H') x ∈ range g
+    rw [hx]
+    exact mem_range_self _
+  · intro y hy
+    rw [show T.source = Φ.source ∩ Φ ⁻¹' range g from hTsource] at hy
+    have hgy : (Φ : M → H') y = g (f y) := (hΦ hy.1).symm
+    show f y = e.symm ((Φ : M → H') y)
+    rw [hgy, hg.toOpenPartialHomeomorph_left_inv]
+
+end OfCompOpenEmbedding
+
+/-! ## Composition -/
+
+section Comp
+
+variable {G : Type*} [NormedAddCommGroup G] [NormedSpace 𝕜 G] {H'' : Type*} [TopologicalSpace H'']
+  {K : ModelWithCorners 𝕜 G H''}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  {P : Type*} [TopologicalSpace P] [ChartedSpace H'' P]
+
+/-- Local diffeomorphisms compose. -/
+public theorem isLocalDiffeomorph_comp {f : M → N} {g : N → P}
+    (hg : IsLocalDiffeomorph J K n g) (hf : IsLocalDiffeomorph I J n f) :
+    IsLocalDiffeomorph I K n (g ∘ f) := by
+  intro x
+  obtain ⟨Φ, hxΦ, hΦ⟩ := hf x
+  obtain ⟨Ψ, hyΨ, hΨ⟩ := hg (f x)
+  have hxsource : x ∈ (Φ.trans Ψ).source := by
+    refine ⟨hxΦ, ?_⟩
+    show (Φ : M → N) x ∈ Ψ.source
+    rw [← hΦ hxΦ]
+    exact hyΨ
+  refine ⟨Φ.trans Ψ, hxsource, ?_⟩
+  intro y hy
+  have hy1 : y ∈ Φ.source := hy.1
+  have hy2 : (Φ : M → N) y ∈ Ψ.source := hy.2
+  show g (f y) = Ψ ((Φ : M → N) y)
+  rw [hΦ hy1]
+  exact hΨ hy2
+
+end Comp
+
+/-! ## The inclusion of an open subset -/
+
+section OpenSubtype
+
+variable {X : Type*} [TopologicalSpace X] [ChartedSpace H X]
+
+/-- The inclusion of an open subset, as a partial diffeomorphism onto its image. -/
+public noncomputable def openSubtypeValPartialDiffeomorph
+    (U : TopologicalSpace.Opens X) [Nonempty U] : PartialDiffeomorph I I U X ∞ := by
+  let f : U → X := Subtype.val
+  let hopen : IsOpenEmbedding f := U.2.isOpenEmbedding_subtypeVal
+  exact {
+    toPartialEquiv := (hopen.toOpenPartialHomeomorph f).toPartialEquiv
+    open_source := isOpen_univ
+    open_target := by
+      rw [hopen.toOpenPartialHomeomorph_target]
+      change IsOpen (Set.range (Subtype.val : U → X))
+      rw [Subtype.range_val]
+      exact U.2
+    contMDiffOn_toFun := contMDiff_subtype_val.contMDiffOn
+    contMDiffOn_invFun := by
+      intro y hy
+      apply (ContMDiffWithinAt.subtypeVal_comp_iff U _ _ y).mp
+      apply contMDiffAt_id.contMDiffWithinAt.congr
+      · intro z hz
+        exact IsOpenEmbedding.toOpenPartialHomeomorph_right_inv f hopen
+          (by rwa [hopen.toOpenPartialHomeomorph_target] at hz)
+      · exact IsOpenEmbedding.toOpenPartialHomeomorph_right_inv f hopen
+          (by rwa [hopen.toOpenPartialHomeomorph_target] at hy)
+  }
+
+/-- The inclusion of an open subset is a local diffeomorphism. -/
+public theorem openSubtypeVal_isLocalDiffeomorph (U : TopologicalSpace.Opens X) :
+    IsLocalDiffeomorph I I ∞ (Subtype.val : U → X) := by
+  intro x
+  let _ : Nonempty U := ⟨x⟩
+  exact (openSubtypeValPartialDiffeomorph (I := I) U).isLocalDiffeomorphAt I I ∞
+    (show x ∈ Set.univ from Set.mem_univ x)
+
+end OpenSubtype
+
+end SphereSixComplex


### PR DESCRIPTION
Turns the last analytic axiom in `Geometry/CuspAnalyticFillingCollar.lean` into a proof, and adds the reusable manifold plumbing it needed.

## Reusable part: `Geometry/LocalDiffeomorphTransport.lean`

Three general facts Mathlib lacks:

* **`isLocalDiffeomorph_of_contDiff_of_hasFDerivAt_equiv`** — the inverse function theorem as an `IsLocalDiffeomorph` statement between model spaces. Mathlib has the normed-space form (`ContDiffAt.toOpenPartialHomeomorph` plus `OpenPartialHomeomorph.contDiffAt_symm` for the inverse's smoothness); its own `Geometry/Manifold/LocalDiffeomorph.lean` still lists the manifold consequence as missing. Given `ContDiff 𝕂 ∞ f` and a continuous linear equivalence as derivative at every point, this builds the `PartialDiffeomorph` at each point directly from the IFT chart.
* **`isLocalDiffeomorph_of_comp_isOpenEmbedding`** — if `N`'s charted-space structure is `hg.singletonChartedSpace` for an open embedding `g : N → H'`, then `f : M → N` is a local diffeomorphism as soon as `g ∘ f` is. Proved by composing the given `PartialDiffeomorph` with `g`'s chart, using Mathlib's `contMDiff_isOpenEmbedding` / `contMDiffOn_isOpenEmbedding_symm`.
* **`isLocalDiffeomorph_comp`** — local diffeomorphisms compose (three separate models, so it applies to the mixed-model situations here).

Plus `openSubtypeValPartialDiffeomorph` / `openSubtypeVal_isLocalDiffeomorph`, the same statement that `EllipticAnalyticFillingCollars` keeps private, exposed for reuse.

## The cusp exponential

With those, the axiom reduces to a derivative computation. The dense torus is charted by its open embedding into `ℂ³`, so in charts the cover is

```
(z₀, z₁, s) ↦ (exp (2πi z₀), exp (2πi z₁), exp (2πi s))
```

whose derivative is the diagonal scaling by the three nonzero numbers `2πi exp (2πi ·)`. The proof builds

* `additiveCoordEquiv : AdditiveCuspCover ≃L[ℂ] ComplexModel`, the linear identification of `ℂ² × ℂ` with `ℂ³`, via `ContinuousLinearEquiv.equivOfInverse`;
* `diagScale`, diagonal scaling by units, via `ContinuousLinearEquiv.piCongrRight` and `unitsEquivAut`;
* `hasFDerivAt_expOnThree`, the derivative of the coordinatewise exponential,

then applies the IFT lemma, transports along the dense-torus chart, and composes with the inclusion of the open radius domain.

## Verification

The declaration keeps its name, namespace, and statement, so every use site is unchanged, and

```
#print axioms …Established.denseCuspExponentialCover_isLocalDiffeomorph
-- depends on axioms: [propext, Classical.choice, Quot.sound]
```

Both changed files type-check (`lake env lean`); I have not run a full `lake build` of `Main` for this branch, so CI is the check that nothing downstream shifted — the statement is unchanged, so nothing should.

Relates to #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)