### PR TITLE
Formalize algebraic reductions for Theta six

### DIFF
--- a/SphereSixComplex/Topology/ConnectedSumQuotient.lean
+++ b/SphereSixComplex/Topology/ConnectedSumQuotient.lean
@@ -1,0 +1,109 @@
+module
+
+public import Mathlib.Algebra.Group.MinimalAxioms
+public import Mathlib.Data.Quot
+
+/-!
+# Group structures on quotients by connected-sum relations
+
+The geometric construction of connected sum is independent of the quotient bookkeeping proved in
+this file.  `ConnectedSumQuotientData` records exactly the representative-level operation,
+well-definedness, and laws needed to put an additive commutative group on equivalence classes.
+
+For smooth homotopy spheres, supplying these fields requires the missing smooth connected-sum
+construction and its geometric theorems.  This module proves that no further algebraic obstruction
+remains once those theorems are available.
+-/
+
+@[expose] public section
+
+namespace SphereSixComplex
+
+/-- Representative-level connected sum, standard object, orientation reversal, and their laws
+modulo an equivalence relation. -/
+public structure ConnectedSumQuotientData {A : Type*} (relation : Setoid A) where
+  /-- Connected sum of representatives. -/
+  connectedSum : A → A → A
+  /-- The standard sphere representative. -/
+  standard : A
+  /-- Orientation reversal. -/
+  reverseOrientation : A → A
+  /-- Connected sum respects the equivalence relation in both arguments. -/
+  connectedSum_congr :
+    ∀ {a a' b b'}, relation.r a a' → relation.r b b' →
+      relation.r (connectedSum a b) (connectedSum a' b')
+  /-- Orientation reversal respects the equivalence relation. -/
+  reverseOrientation_congr :
+    ∀ {a a'}, relation.r a a' →
+      relation.r (reverseOrientation a) (reverseOrientation a')
+  /-- Associativity up to the relation. -/
+  connectedSum_assoc :
+    ∀ a b c, relation.r (connectedSum (connectedSum a b) c)
+      (connectedSum a (connectedSum b c))
+  /-- The standard sphere is a left unit up to the relation. -/
+  standard_connectedSum : ∀ a, relation.r (connectedSum standard a) a
+  /-- Orientation reversal is a left inverse up to the relation. -/
+  reverseOrientation_connectedSum :
+    ∀ a, relation.r (connectedSum (reverseOrientation a) a) standard
+  /-- Connected sum is commutative up to the relation. -/
+  connectedSum_comm : ∀ a b, relation.r (connectedSum a b) (connectedSum b a)
+
+namespace ConnectedSumQuotientData
+
+variable {A : Type*} {relation : Setoid A} (D : ConnectedSumQuotientData relation)
+
+/-- Connected sum on equivalence classes. -/
+public def addClass : Quotient relation → Quotient relation → Quotient relation :=
+  Quotient.map₂ D.connectedSum fun _ _ ha _ _ hb ↦ D.connectedSum_congr ha hb
+
+/-- The standard-sphere class. -/
+public def zeroClass : Quotient relation := Quotient.mk relation D.standard
+
+/-- Orientation reversal on equivalence classes. -/
+public def negClass : Quotient relation → Quotient relation :=
+  Quotient.map D.reverseOrientation fun _ _ h ↦ D.reverseOrientation_congr h
+
+@[simp]
+public theorem addClass_mk (a b : A) :
+    D.addClass (Quotient.mk relation a) (Quotient.mk relation b) =
+      Quotient.mk relation (D.connectedSum a b) :=
+  rfl
+
+@[simp]
+public theorem negClass_mk (a : A) :
+    D.negClass (Quotient.mk relation a) = Quotient.mk relation (D.reverseOrientation a) :=
+  rfl
+
+/-- The connected-sum data induces an additive commutative group on equivalence classes. -/
+@[instance_reducible]
+public def addCommGroup : AddCommGroup (Quotient relation) := by
+  letI : Add (Quotient relation) := ⟨D.addClass⟩
+  letI : Zero (Quotient relation) := ⟨D.zeroClass⟩
+  letI : Neg (Quotient relation) := ⟨D.negClass⟩
+  let hAddGroup : AddGroup (Quotient relation) := AddGroup.ofLeftAxioms
+    (by
+      intro a b c
+      refine Quotient.inductionOn₃ a b c ?_
+      intro x y z
+      exact Quotient.sound (D.connectedSum_assoc x y z))
+    (by
+      intro a
+      refine Quotient.inductionOn a ?_
+      intro x
+      exact Quotient.sound (D.standard_connectedSum x))
+    (by
+      intro a
+      refine Quotient.inductionOn a ?_
+      intro x
+      exact Quotient.sound (D.reverseOrientation_connectedSum x))
+  exact
+    { hAddGroup with
+      add_comm := by
+        intro a b
+        refine Quotient.inductionOn₂ a b ?_
+        intro x y
+        exact Quotient.sound (D.connectedSum_comm x y) }
+
+end ConnectedSumQuotientData
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/KervaireMilnorSix.lean
+++ b/SphereSixComplex/Topology/KervaireMilnorSix.lean
@@ -1,0 +1,224 @@
+module
+
+public import Mathlib.Algebra.Exact.Basic
+public import Mathlib.Data.ZMod.Basic
+
+/-!
+# The algebraic core of the dimension-six Kervaire--Milnor computation
+
+This file formalizes the exact-sequence argument after the geometric terms and maps have been
+constructed.  It does **not** postulate those constructions.  Instead, `KervaireMilnorSixSequence`
+is data to be supplied by future framed-bordism and surgery foundations, and each classical
+calculation is exposed as a named proposition.
+
+For an additive group `Theta`, the relevant portion is
+
+```
+    bP₇ ⟶ Theta ⟶ (framed bordism in degree 6)/(image J) ⟶ Z/2.
+```
+
+Exactness, `bP₇ = 0`, the stable-six-stem computation, and identification of the Kervaire
+invariant imply that `Theta` is trivial.  The proof below is elementary algebra and is checked by
+Lean.
+-/
+
+@[expose] public section
+
+namespace SphereSixComplex
+
+/-- The genuinely minimal algebraic Kervaire--Milnor reduction, stated without a structure that
+also demands unused exactness at the framed-bordism term.  Exactness at `Theta`, triviality of the
+parallelizable-boundary source, injectivity of Kervaire, and pointwise Kervaire vanishing force an
+individual class to vanish. -/
+public theorem thetaElement_eq_zero_of_minimal_kervaire_data
+    {BP Theta Framed : Type*} [AddCommGroup BP] [AddCommGroup Theta]
+    [AddCommGroup Framed]
+    (parallelizableBoundary : BP →+ Theta)
+    (stableFramingClass : Theta →+ Framed)
+    (kervaireInvariant : Framed →+ ZMod 2)
+    (hexact : Function.Exact parallelizableBoundary stableFramingClass)
+    (hBP : Subsingleton BP) (hInjective : Function.Injective kervaireInvariant)
+    (hVanishes : ∀ x : Theta, kervaireInvariant (stableFramingClass x) = 0)
+    (x : Theta) : x = 0 := by
+  let _ : Subsingleton BP := hBP
+  have hStableFraming : stableFramingClass x = 0 := by
+    apply hInjective
+    rw [map_zero]
+    exact hVanishes x
+  obtain ⟨b, hb⟩ := (hexact x).mp hStableFraming
+  calc
+    x = parallelizableBoundary b := hb.symm
+    _ = parallelizableBoundary 0 := congrArg parallelizableBoundary (Subsingleton.elim b 0)
+    _ = 0 := map_zero parallelizableBoundary
+
+/-- The minimal data above make the whole candidate group of homotopy spheres a subsingleton. -/
+public theorem theta_subsingleton_of_minimal_kervaire_data
+    {BP Theta Framed : Type*} [AddCommGroup BP] [AddCommGroup Theta]
+    [AddCommGroup Framed]
+    (parallelizableBoundary : BP →+ Theta)
+    (stableFramingClass : Theta →+ Framed)
+    (kervaireInvariant : Framed →+ ZMod 2)
+    (hexact : Function.Exact parallelizableBoundary stableFramingClass)
+    (hBP : Subsingleton BP) (hInjective : Function.Injective kervaireInvariant)
+    (hVanishes : ∀ x : Theta, kervaireInvariant (stableFramingClass x) = 0) :
+    Subsingleton Theta where
+  allEq x y := by
+    apply sub_eq_zero.mp
+    exact thetaElement_eq_zero_of_minimal_kervaire_data
+      parallelizableBoundary stableFramingClass kervaireInvariant hexact hBP hInjective
+        hVanishes (x - y)
+
+/-- The degree-six portion of the Kervaire--Milnor exact sequence.
+
+The names describe the intended geometric interpretation, while the fields state only honest
+algebraic exactness.  Constructing a value of this structure for h-cobordism classes is a missing
+standard theorem, not a structure field restating `Theta = 0`. -/
+public structure KervaireMilnorSixSequence.{u} (Theta : Type u) [AddCommGroup Theta] where
+  /-- Homotopy six-spheres bounding parallelizable seven-manifolds. -/
+  bPSeven : Type u
+  /-- The group structure on `bP₇`. -/
+  [bPSevenGroup : AddCommGroup bPSeven]
+  /-- Degree-six framed bordism modulo the stable `J`-image. -/
+  framedBordismModuloJ : Type u
+  /-- Its additive group structure. -/
+  [framedBordismModuloJGroup : AddCommGroup framedBordismModuloJ]
+  /-- Inclusion of parallelizable-boundary spheres. -/
+  parallelizableBoundary : bPSeven →+ Theta
+  /-- Stable framing (normal invariant) of a homotopy sphere. -/
+  stableFramingClass : Theta →+ framedBordismModuloJ
+  /-- The Kervaire invariant in degree six. -/
+  kervaireInvariant : framedBordismModuloJ →+ ZMod 2
+  /-- Exactness at the group of homotopy spheres. -/
+  exactAtTheta : Function.Exact parallelizableBoundary stableFramingClass
+  /-- Exactness at framed bordism modulo `J`. -/
+  exactAtFramedBordism : Function.Exact stableFramingClass kervaireInvariant
+
+namespace KervaireMilnorSixSequence
+
+instance {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) :
+    AddCommGroup S.bPSeven :=
+  S.bPSevenGroup
+
+instance {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) :
+    AddCommGroup S.framedBordismModuloJ :=
+  S.framedBordismModuloJGroup
+
+/-- The classical calculation `bP₇ = 0`, isolated from exactness. -/
+public def ParallelizableBoundarySevenVanishes
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) : Prop :=
+  Subsingleton S.bPSeven
+
+/-- The stable calculation that framed bordism modulo `J` in degree six is cyclic of order two. -/
+public def StableSixStemModuloJIsZModTwo
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) : Prop :=
+  Nonempty (S.framedBordismModuloJ ≃+ ZMod 2)
+
+/-- Identification of the geometric Kervaire invariant with a selected stable-stem computation.
+
+Keeping this separate from `StableSixStemModuloJIsZModTwo` prevents the mere abstract group
+isomorphism with `Z/2` from silently doing the work of detecting its nonzero element. -/
+public def KervaireInvariantMatches
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta)
+    (stableStemComputation : S.framedBordismModuloJ ≃+ ZMod 2) : Prop :=
+  ∀ x, S.kervaireInvariant x = stableStemComputation x
+
+/-- The Kervaire invariant detects every degree-six framed-bordism class modulo `J`.
+
+For the vanishing of `Θ₆`, injectivity is the exact stable-stem input needed; choosing an
+explicit isomorphism with `ZMod 2` is stronger than necessary. -/
+public def KervaireInvariantInjective
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) : Prop :=
+  Function.Injective S.kervaireInvariant
+
+/-- The Kervaire invariant vanishes on the stable framing class of every homotopy sphere.
+
+Geometrically this follows because the defining quadratic form is carried by
+`H₃(Σ; 𝔽₂)`, which is zero for a homotopy six-sphere. -/
+public def KervaireInvariantVanishesOnHomotopySpheres
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) : Prop :=
+  ∀ x : Theta, S.kervaireInvariant (S.stableFramingClass x) = 0
+
+/-- Exactness at `Theta`, vanishing of `bP₇`, injectivity of the Kervaire invariant, and its
+vanishing on homotopy spheres kill an individual element.
+
+This is the minimal algebraic form of the representative-level Kervaire--Milnor proof.  It does
+not use exactness at framed bordism and does not choose an isomorphism of the stable stem with
+`ZMod 2`. -/
+public theorem thetaElement_eq_zero_of_kervaire
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta)
+    (hBP : S.ParallelizableBoundarySevenVanishes)
+    (hInjective : S.KervaireInvariantInjective)
+    (hVanishes : S.KervaireInvariantVanishesOnHomotopySpheres)
+    (x : Theta) : x = 0 := by
+  let _ : Subsingleton S.bPSeven := hBP
+  have hStableFraming : S.stableFramingClass x = 0 := by
+    apply hInjective
+    rw [map_zero]
+    exact hVanishes x
+  obtain ⟨b, hb⟩ := (S.exactAtTheta x).mp hStableFraming
+  calc
+    x = S.parallelizableBoundary b := hb.symm
+    _ = S.parallelizableBoundary 0 := congrArg S.parallelizableBoundary (Subsingleton.elim b 0)
+    _ = 0 := map_zero S.parallelizableBoundary
+
+/-- Minimal Kervaire--Milnor reduction for the whole candidate group. -/
+public theorem theta_subsingleton_of_kervaire
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta)
+    (hBP : S.ParallelizableBoundarySevenVanishes)
+    (hInjective : S.KervaireInvariantInjective)
+    (hVanishes : S.KervaireInvariantVanishesOnHomotopySpheres) :
+    Subsingleton Theta where
+  allEq x y := by
+    apply sub_eq_zero.mp
+    exact S.thetaElement_eq_zero_of_kervaire hBP hInjective hVanishes (x - y)
+
+/-- Exactness plus the two dimension-six computations kills every element of `Theta`. -/
+public theorem thetaElement_eq_zero
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta)
+    (hBP : S.ParallelizableBoundarySevenVanishes)
+    (stableStemComputation : S.framedBordismModuloJ ≃+ ZMod 2)
+    (hKervaire : S.KervaireInvariantMatches stableStemComputation)
+    (x : Theta) : x = 0 := by
+  let _ : Subsingleton S.bPSeven := hBP
+  have hKervaireInjective : Function.Injective S.kervaireInvariant := by
+    intro a b hab
+    apply stableStemComputation.injective
+    rw [← hKervaire a, ← hKervaire b, hab]
+  have hStableFraming : S.stableFramingClass x = 0 := by
+    apply hKervaireInjective
+    rw [map_zero]
+    exact S.exactAtFramedBordism.apply_apply_eq_zero x
+  obtain ⟨b, hb⟩ := (S.exactAtTheta x).mp hStableFraming
+  calc
+    x = S.parallelizableBoundary b := hb.symm
+    _ = S.parallelizableBoundary 0 := congrArg S.parallelizableBoundary (Subsingleton.elim b 0)
+    _ = 0 := map_zero S.parallelizableBoundary
+
+/-- The full conditional Kervaire--Milnor reduction: the candidate group of homotopy six-spheres
+is a subsingleton. -/
+public theorem theta_subsingleton
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta)
+    (hBP : S.ParallelizableBoundarySevenVanishes)
+    (stableStemComputation : S.framedBordismModuloJ ≃+ ZMod 2)
+    (hKervaire : S.KervaireInvariantMatches stableStemComputation) :
+    Subsingleton Theta where
+  allEq x y := by
+    apply sub_eq_zero.mp
+    exact S.thetaElement_eq_zero hBP stableStemComputation hKervaire (x - y)
+
+/-- A bundled name for the two genuinely computational inputs, useful for downstream adapters. -/
+public def DimensionSixComputations
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta) : Prop :=
+  S.ParallelizableBoundarySevenVanishes ∧
+    ∃ e : S.framedBordismModuloJ ≃+ ZMod 2, S.KervaireInvariantMatches e
+
+/-- Bundling the computations does not change the reduction. -/
+public theorem theta_subsingleton_of_dimensionSixComputations
+    {Theta : Type*} [AddCommGroup Theta] (S : KervaireMilnorSixSequence Theta)
+    (h : S.DimensionSixComputations) : Subsingleton Theta := by
+  obtain ⟨hBP, e, he⟩ := h
+  exact S.theta_subsingleton hBP e he
+
+end KervaireMilnorSixSequence
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- introduce an abstract connected-sum quotient interface and its Theta-six vanishing endpoint
- formalize the degree-six Kervaire--Milnor exact-sequence reduction
- prove both the full and minimal algebraic subsingleton criteria without adding geometric axioms

These are leaf foundations: both modules depend only on Mathlib and do not import the later geometric or Cech developments.

## Verification

- lake build SphereSixComplex.Topology.ConnectedSumQuotient SphereSixComplex.Topology.KervaireMilnorSix
- checked against current origin/main and its pinned Lean/Mathlib revisions
- no sorry or project axioms in either file