### PR TITLE
Promote affine subdivision prism and iteration stack

### DIFF
--- a/SphereSixComplex/Topology/SingularAffineSubdivisionIteration.lean
+++ b/SphereSixComplex/Topology/SingularAffineSubdivisionIteration.lean
@@ -1,0 +1,150 @@
+module
+
+public import SphereSixComplex.Topology.SingularAffineSubdivisionSmallPrism
+
+/-!
+# Iterated affine subdivision on singular chains
+
+This file packages finite iterates of geometric affine subdivision on full and cover-small
+singular chains.  Every iterate is chain homotopic to the identity, and the small/full iterates
+commute with the canonical inclusion.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory
+
+namespace SphereSixComplex
+
+/-- Finite iteration of affine subdivision on all integral singular chains. -/
+public noncomputable def affineSingularSubdivisionIterate (X : TopCat.{0}) :
+    ℕ → ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      (TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ))
+  | 0 => 𝟙 _
+  | m + 1 => affineSingularSubdivisionIterate X m ≫
+      affineSingularSubdivisionChainMap X
+
+@[simp]
+public theorem affineSingularSubdivisionIterate_zero (X : TopCat.{0}) :
+    affineSingularSubdivisionIterate X 0 = 𝟙 _ :=
+  rfl
+
+public theorem affineSingularSubdivisionIterate_succ
+    (X : TopCat.{0}) (m : ℕ) :
+    affineSingularSubdivisionIterate X (m + 1) =
+      affineSingularSubdivisionIterate X m ≫
+        affineSingularSubdivisionChainMap X :=
+  rfl
+
+/-- Every affine-subdivision iterate is natural in the target space. -/
+public theorem affineSingularSubdivisionIterate_naturality
+    {X Y : TopCat.{0}} (f : X ⟶ Y) : ∀ m : ℕ,
+    SSet.chainComplexMap (TopCat.toSSet.map f) (AddCommGrpCat.of ℤ) ≫
+        affineSingularSubdivisionIterate Y m =
+      affineSingularSubdivisionIterate X m ≫
+        SSet.chainComplexMap (TopCat.toSSet.map f) (AddCommGrpCat.of ℤ)
+  | 0 => by simp
+  | m + 1 => by
+      rw [affineSingularSubdivisionIterate_succ,
+        affineSingularSubdivisionIterate_succ, ← Category.assoc,
+        affineSingularSubdivisionIterate_naturality f m,
+        Category.assoc, affineSingularSubdivisionChainMap_naturality,
+        ← Category.assoc]
+
+/-- Every finite affine-subdivision iterate is chain homotopic to the identity. -/
+public noncomputable def affineSingularSubdivisionIterateHomotopy
+    (X : TopCat.{0}) : ∀ m : ℕ,
+    Homotopy (affineSingularSubdivisionIterate X m)
+      (𝟙 ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)))
+  | 0 => Homotopy.refl _
+  | m + 1 => by
+      simpa [affineSingularSubdivisionIterate_succ] using
+        (affineSingularSubdivisionIterateHomotopy X m).comp
+          (affineSingularSubdivisionHomotopy X)
+
+/-- Every affine-subdivision iterate induces the identity on integral singular homology. -/
+public theorem affineSingularSubdivisionIterate_homologyMap
+    (X : TopCat.{0}) (m n : ℕ) :
+    HomologicalComplex.homologyMap
+        (affineSingularSubdivisionIterate X m) n =
+      𝟙 (((TopCat.toSSet.obj X).chainComplex
+        (AddCommGrpCat.of ℤ)).homology n) := by
+  rw [(affineSingularSubdivisionIterateHomotopy X m).homologyMap_eq]
+  exact HomologicalComplex.homologyMap_id _ _
+
+section Small
+
+variable {iota : Type} (X : TopCat) (U : iota → Set X)
+
+/-- Finite iteration of affine subdivision on cover-small chains. -/
+public noncomputable def coverSmallAffineSubdivisionIterate :
+    ℕ → (CoverSmallIntegralSingularChainComplex X U ⟶
+      CoverSmallIntegralSingularChainComplex X U)
+  | 0 => 𝟙 _
+  | m + 1 => coverSmallAffineSubdivisionIterate m ≫
+      coverSmallAffineSubdivisionChainMap X U
+
+@[simp]
+public theorem coverSmallAffineSubdivisionIterate_zero :
+    coverSmallAffineSubdivisionIterate X U 0 = 𝟙 _ :=
+  rfl
+
+public theorem coverSmallAffineSubdivisionIterate_succ (m : ℕ) :
+    coverSmallAffineSubdivisionIterate X U (m + 1) =
+      coverSmallAffineSubdivisionIterate X U m ≫
+        coverSmallAffineSubdivisionChainMap X U :=
+  rfl
+
+/-- Every cover-small affine-subdivision iterate is chain homotopic to the identity. -/
+public noncomputable def coverSmallAffineSubdivisionIterateHomotopy :
+    ∀ m : ℕ, Homotopy (coverSmallAffineSubdivisionIterate X U m)
+      (𝟙 (CoverSmallIntegralSingularChainComplex X U))
+  | 0 => Homotopy.refl _
+  | m + 1 => by
+      simpa [coverSmallAffineSubdivisionIterate_succ] using
+        (coverSmallAffineSubdivisionIterateHomotopy m).comp
+          (coverSmallAffineSubdivisionHomotopy X U)
+
+/-- Every cover-small affine-subdivision iterate induces the identity on small-chain homology. -/
+public theorem coverSmallAffineSubdivisionIterate_homologyMap
+    (m n : ℕ) :
+    HomologicalComplex.homologyMap
+        (coverSmallAffineSubdivisionIterate X U m) n =
+      𝟙 ((CoverSmallIntegralSingularChainComplex X U).homology n) := by
+  rw [(coverSmallAffineSubdivisionIterateHomotopy X U m).homologyMap_eq]
+  exact HomologicalComplex.homologyMap_id _ _
+
+/-- Small and full affine-subdivision iterates commute with the small-chain inclusion. -/
+public theorem coverSmallAffineSubdivisionIterate_comp_inclusion : ∀ m : ℕ,
+    coverSmallAffineSubdivisionIterate X U m ≫
+        coverSmallIntegralSingularChainInclusion X U =
+      coverSmallIntegralSingularChainInclusion X U ≫
+        affineSingularSubdivisionIterate X m
+  | 0 => by
+      change (SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+        (AddCommGrpCat.of ℤ)) =
+        SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+          (AddCommGrpCat.of ℤ) ≫ 𝟙 _
+      simp
+  | m + 1 => by
+      let I := SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+        (AddCommGrpCat.of ℤ)
+      have hm := coverSmallAffineSubdivisionIterate_comp_inclusion m
+      change coverSmallAffineSubdivisionIterate X U m ≫ I =
+        I ≫ affineSingularSubdivisionIterate X m at hm
+      have hA := coverSmallAffineSubdivisionChainMap_comp_inclusion X U
+      change coverSmallAffineSubdivisionChainMap X U ≫ I =
+        I ≫ affineSingularSubdivisionChainMap X at hA
+      rw [coverSmallAffineSubdivisionIterate_succ,
+        affineSingularSubdivisionIterate_succ]
+      change (coverSmallAffineSubdivisionIterate X U m ≫
+          coverSmallAffineSubdivisionChainMap X U) ≫ I =
+        I ≫ (affineSingularSubdivisionIterate X m ≫
+          affineSingularSubdivisionChainMap X)
+      rw [Category.assoc, hA, ← Category.assoc, hm, Category.assoc]
+
+end Small
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularAffineSubdivisionPrism.lean
+++ b/SphereSixComplex/Topology/SingularAffineSubdivisionPrism.lean
@@ -1,0 +1,870 @@
+module
+
+public import SphereSixComplex.Topology.SingularAffineSubdivisionSmall
+public import SphereSixComplex.Topology.SmoothRecognition
+public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
+public import Mathlib.Analysis.Convex.Contractible
+public import Mathlib.Algebra.Homology.ShortComplex.Ab
+
+/-!
+# A universal prism for affine singular subdivision
+
+The singular chain complex of every topological standard simplex is exact in positive degrees.
+This supplies fillers for the universal subdivision discrepancies and hence the acyclic-models
+prism between affine barycentric subdivision and the identity.  The first part of this file
+establishes the exactness and packages a selected filler for every positive-degree cycle.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set
+
+namespace SphereSixComplex
+
+/-- A real topological standard simplex is contractible because it is nonempty and convex. -/
+public theorem standardTopologicalSimplex_contractibleSpace (m : ℕ) :
+    ContractibleSpace (stdSimplex ℝ (Fin (m + 1))) := by
+  exact (convex_stdSimplex ℝ (Fin (m + 1))).contractibleSpace
+    ⟨stdSimplex.vertex 0, stdSimplex.vertex 0 |>.2⟩
+
+/-- Positive-degree integral singular homology of a topological standard simplex vanishes. -/
+public theorem standardTopologicalSimplex_integralSingularHomology_isZero
+    (m k : ℕ) (hk : k ≠ 0) :
+    IsZero (((TopCat.toSSet.obj
+      (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+        (AddCommGrpCat.of ℤ)).homology k) := by
+  change IsZero (((singularHomologyFunctor AddCommGrpCat k).obj
+    (AddCommGrpCat.of ℤ)).obj
+      (TopCat.of (stdSimplex ℝ (Fin (m + 1)))))
+  let _ : ContractibleSpace (stdSimplex ℝ (Fin (m + 1))) :=
+    standardTopologicalSimplex_contractibleSpace m
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (stdSimplex ℝ (Fin (m + 1)))
+  have hunit :=
+    AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+      AddCommGrpCat k (AddCommGrpCat.of ℤ) (TopCat.of Unit) hk
+  let _ : Subsingleton (IntegralSingularHomology k Unit) :=
+    AddCommGrpCat.subsingleton_of_isZero hunit
+  let he := integralSingularHomologyEquivOfHomotopyEquiv k e
+  let _ : Subsingleton
+      (IntegralSingularHomology k (stdSimplex ℝ (Fin (m + 1)))) :=
+    ⟨fun x y ↦ he.injective (Subsingleton.elim _ _)⟩
+  exact AddCommGrpCat.isZero_of_subsingleton _
+
+/-- The singular chain complex of a standard simplex is exact in every positive degree. -/
+public theorem standardTopologicalSimplex_singularChainExactAt
+    (m k : ℕ) (hk : k ≠ 0) :
+    ((TopCat.toSSet.obj
+      (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+        (AddCommGrpCat.of ℤ)).ExactAt k := by
+  let K := (TopCat.toSSet.obj
+    (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+      (AddCommGrpCat.of ℤ)
+  rw [K.exactAt_iff_isZero_homology]
+  exact standardTopologicalSimplex_integralSingularHomology_isZero m k hk
+
+/-- Every positive-degree cycle in a topological standard simplex bounds.  This is stated for
+morphisms from `ℤ`, matching the chain representation used throughout the subdivision files. -/
+public theorem exists_standardTopologicalSimplex_cycleFiller
+    (m n : ℕ)
+    (z : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (hz : z ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n = 0) :
+    ∃ p : AddCommGrpCat.of ℤ ⟶
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+            (AddCommGrpCat.of ℤ)).X (n + 2),
+      p ≫
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) = z := by
+  let K := (TopCat.toSSet.obj
+    (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+      (AddCommGrpCat.of ℤ)
+  have hexact : (K.sc' (n + 2) (n + 1) n).Exact :=
+    (K.exactAt_iff' (i := n + 2) (j := n + 1) (k := n)
+      (by simp) (by simp)).mp
+        (standardTopologicalSimplex_singularChainExactAt m (n + 1)
+          (by omega))
+  have hz1 : K.d (n + 1) n (z 1) = 0 := by
+    have h := CategoryTheory.congr_fun hz 1
+    simpa using h
+  obtain ⟨p, hp⟩ := (ShortComplex.ab_exact_iff _).mp hexact (z 1) hz1
+  change K.X (n + 2) at p
+  change K.d (n + 2) (n + 1) p = z 1 at hp
+  refine ⟨AddCommGrpCat.asHom p, ?_⟩
+  apply AddCommGrpCat.int_hom_ext
+  change K.d (n + 2) (n + 1) ((AddCommGrpCat.asHom p) 1) = z 1
+  rw [AddCommGrpCat.asHom_hom_apply, one_zsmul]
+  exact hp
+
+/-- A selected filler of a positive-degree cycle in a topological standard simplex. -/
+public noncomputable def standardTopologicalSimplexCycleFiller
+    (m n : ℕ)
+    (z : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (hz : z ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n = 0) :
+    AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 2) :=
+  (exists_standardTopologicalSimplex_cycleFiller m n z hz).choose
+
+/-- The selected filler has the prescribed boundary. -/
+public theorem standardTopologicalSimplexCycleFiller_boundary
+    (m n : ℕ)
+    (z : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (hz : z ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n = 0) :
+    standardTopologicalSimplexCycleFiller m n z hz ≫
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) = z :=
+  (exists_standardTopologicalSimplex_cycleFiller m n z hz).choose_spec
+
+/-- A total version of the positive-degree filler.  It is the selected filler when its input
+is a cycle and zero otherwise; this form can be used in a structurally recursive definition
+before the cycle condition has been proved. -/
+public noncomputable def standardTopologicalSimplexTotalCycleFiller
+    (m n : ℕ)
+    (z : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1)) :
+    AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 2) := by
+  classical
+  exact if hz : z ≫
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 1) n = 0 then
+      standardTopologicalSimplexCycleFiller m n z hz
+    else 0
+
+/-- The total filler has the prescribed boundary whenever its input is a cycle. -/
+public theorem standardTopologicalSimplexTotalCycleFiller_boundary
+    (m n : ℕ)
+    (z : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (hz : z ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n = 0) :
+    standardTopologicalSimplexTotalCycleFiller m n z ≫
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (m + 1))))).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) = z := by
+  rw [standardTopologicalSimplexTotalCycleFiller, dite_eq_left hz]
+  exact standardTopologicalSimplexCycleFiller_boundary m n z hz
+
+/-- The identity map of the topological standard simplex, regarded as its universal singular
+simplex. -/
+public noncomputable def standardTopologicalSimplexIdentitySimplex (n : ℕ) :
+    (TopCat.toSSet.obj
+      (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).obj
+        (Opposite.op (SimplexCategory.mk n)) :=
+  (TopCat.toSSetObjEquiv _ _).symm (ContinuousMap.id _)
+
+/-- Mapping the universal identity simplex along the map represented by a singular simplex
+recovers that singular simplex. -/
+@[simp]
+public theorem standardTopologicalSimplexIdentitySimplex_map
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    (TopCat.toSSet.map (singularSimplexTopCatMap X n x)).app _
+        (standardTopologicalSimplexIdentitySimplex n) = x := by
+  apply (TopCat.toSSetObjEquiv _ _).injective
+  apply ContinuousMap.ext
+  intro w
+  rfl
+
+/-- Affine singular subdivision minus the identity, as a natural chain endomorphism. -/
+public noncomputable def affineSingularSubdivisionDiscrepancyChainMap
+    (X : TopCat.{0}) :
+    (TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      (TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ) :=
+  affineSingularSubdivisionChainMap X - 𝟙 _
+
+/-- The universal degree-`n` affine-subdivision discrepancy on the topological standard
+`n`-simplex. -/
+public noncomputable def standardAffineSubdivisionDiscrepancy (n : ℕ) :
+    AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X n :=
+  (TopCat.toSSet.obj
+      (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+        (standardTopologicalSimplexIdentitySimplex n) ≫
+    (affineSingularSubdivisionDiscrepancyChainMap
+      (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).f n
+
+/-- Evaluating the discrepancy on a singular simplex transports the universal discrepancy
+along the continuous map represented by that simplex. -/
+public theorem iota_affineSingularSubdivisionDiscrepancyChainMap
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    (TopCat.toSSet.obj X).ιChainComplex x ≫
+        (affineSingularSubdivisionDiscrepancyChainMap X).f n =
+      standardAffineSubdivisionDiscrepancy n ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+          (AddCommGrpCat.of ℤ)).f n := by
+  unfold standardAffineSubdivisionDiscrepancy
+  change (TopCat.toSSet.obj X).ιChainComplex x ≫
+        ((affineSingularSubdivisionChainMap X).f n - 𝟙 _) =
+      ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+            (standardTopologicalSimplexIdentitySimplex n) ≫
+          ((affineSingularSubdivisionChainMap
+            (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).f n - 𝟙 _)) ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+          (AddCommGrpCat.of ℤ)).f n
+  simp only [Preadditive.comp_sub, Category.comp_id]
+  simp only [Preadditive.sub_comp]
+  let F := SSet.chainComplexMap
+    (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+    (AddCommGrpCat.of ℤ)
+  have htop :
+      (TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+            (standardTopologicalSimplexIdentitySimplex n) ≫ F.f n =
+        (TopCat.toSSet.obj X).ιChainComplex x := by
+    dsimp [F]
+    rw [SSet.ι_chainComplexMap_f,
+      standardTopologicalSimplexIdentitySimplex_map]
+  have hnat := congrArg (fun K ↦ K.f n)
+    (affineSingularSubdivisionChainMap_naturality
+      (singularSimplexTopCatMap X n x))
+  change F.f n ≫ (affineSingularSubdivisionChainMap X).f n =
+    (affineSingularSubdivisionChainMap
+      (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).f n ≫ F.f n at hnat
+  have hA :
+      (TopCat.toSSet.obj X).ιChainComplex x ≫
+          (affineSingularSubdivisionChainMap X).f n =
+        ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+              (standardTopologicalSimplexIdentitySimplex n) ≫
+            (affineSingularSubdivisionChainMap
+              (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).f n) ≫ F.f n := by
+    calc
+      _ = ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+              (standardTopologicalSimplexIdentitySimplex n) ≫ F.f n) ≫
+            (affineSingularSubdivisionChainMap X).f n := by rw [htop]
+      _ = (TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+              (standardTopologicalSimplexIdentitySimplex n) ≫
+            (F.f n ≫ (affineSingularSubdivisionChainMap X).f n) :=
+        Category.assoc _ _ _
+      _ = (TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+              (standardTopologicalSimplexIdentitySimplex n) ≫
+            ((affineSingularSubdivisionChainMap
+              (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).f n ≫ F.f n) := by
+        rw [hnat]
+      _ = _ := (Category.assoc _ _ _).symm
+  change _ = _ - _
+  rw [hA, htop]
+
+/-- Affine subdivision fixes every singular zero-simplex. -/
+public theorem affineSubdivisionSingularSimplexChain_zero
+    (X : TopCat.{0})
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk 0))) :
+    affineSubdivisionSingularSimplexChain X 0 x =
+      (TopCat.toSSet.obj X).ιChainComplex x := by
+  rw [affineSubdivisionSingularSimplexChain,
+    affineSubdividedSimplexFundamentalChain,
+    subdividedSimplexFundamentalChain]
+  classical
+  have hperm : (Finset.univ : Finset (Equiv.Perm (Fin 1))) = {1} := by
+    ext σ
+    simp [Subsingleton.elim σ 1]
+  rw [hperm, Finset.sum_singleton]
+  simp only [permutationSignInteger, Equiv.Perm.sign_one, Units.val_one,
+    one_zsmul, affineFlagChainMap_f]
+  rw [iota_affineFlagChainComponent]
+  rw [SSet.ι_chainComplexMap_f]
+  congr 1
+  apply (TopCat.toSSetObjEquiv _ _).injective
+  apply ContinuousMap.ext
+  intro w
+  rw [toSSetObjEquiv_map_apply]
+  change X.toSSetObjEquiv _ x
+      (affineFlagContinuousMap 0 0 (permutationMaximalFlagSimplex 1) w) =
+    X.toSSetObjEquiv _ x w
+  rw [Subsingleton.elim
+    (affineFlagContinuousMap 0 0 (permutationMaximalFlagSimplex 1) w) w]
+
+/-- The universal affine-subdivision discrepancy vanishes in degree zero. -/
+@[simp]
+public theorem standardAffineSubdivisionDiscrepancy_zero :
+    standardAffineSubdivisionDiscrepancy 0 = 0 := by
+  rw [standardAffineSubdivisionDiscrepancy,
+    affineSingularSubdivisionDiscrepancyChainMap]
+  simp only [HomologicalComplex.sub_f_apply, HomologicalComplex.id_f,
+    Preadditive.comp_sub, Category.comp_id]
+  rw [affineSingularSubdivisionChainMap_f,
+    iota_affineSingularSubdivisionComponent,
+    affineSubdivisionSingularSimplexChain_zero]
+  exact sub_self _
+
+/-- The map represented by a face of the universal identity simplex is the standard affine
+coface inclusion. -/
+public theorem singularSimplexTopCatMap_identity_delta
+    (n : ℕ) (p : Fin (n + 2)) :
+    singularSimplexTopCatMap
+        (TopCat.of (stdSimplex ℝ (Fin (n + 2)))) n
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).δ p
+            (standardTopologicalSimplexIdentitySimplex (n + 1))) =
+      standardSimplexFaceTopCatMap n p := by
+  ext w
+  rfl
+
+/-- The boundary of the universal discrepancy is the alternating transport of the lower
+dimensional universal discrepancy over all affine coface inclusions. -/
+public theorem standardAffineSubdivisionDiscrepancy_boundary
+    (n : ℕ) :
+    standardAffineSubdivisionDiscrepancy (n + 1) ≫
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 1) n =
+      ∑ p : Fin (n + 2), (-1 : ℤ) ^ p.val •
+        (standardAffineSubdivisionDiscrepancy n ≫
+          (SSet.chainComplexMap
+            (TopCat.toSSet.map (standardSimplexFaceTopCatMap n p))
+            (AddCommGrpCat.of ℤ)).f n) := by
+  rw [standardAffineSubdivisionDiscrepancy, Category.assoc]
+  rw [(affineSingularSubdivisionDiscrepancyChainMap
+    (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).comm]
+  rw [← Category.assoc, SSet.ιChainComplex_d, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp]
+  apply Finset.sum_congr rfl
+  intro p _
+  apply congrArg (fun k ↦ ((-1 : ℤ) ^ p.val) • k)
+  rw [iota_affineSingularSubdivisionDiscrepancyChainMap,
+    singularSimplexTopCatMap_identity_delta]
+
+/-- Transport one universal degree-raising singular chain along every singular simplex of an
+arbitrary topological space. -/
+public noncomputable def universalAffinePrismComponent
+    (n : ℕ)
+    (p : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (X : TopCat.{0}) :
+    ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)).X n ⟶
+      ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)).X (n + 1) :=
+  Sigma.desc (fun x ↦ p ≫
+    (SSet.chainComplexMap
+      (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+      (AddCommGrpCat.of ℤ)).f (n + 1))
+
+@[reassoc (attr := simp)]
+public theorem iota_universalAffinePrismComponent
+    (n : ℕ)
+    (p : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (X : TopCat.{0})
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    (TopCat.toSSet.obj X).ιChainComplex x ≫
+        universalAffinePrismComponent n p X =
+      p ≫ (SSet.chainComplexMap
+        (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+        (AddCommGrpCat.of ℤ)).f (n + 1) := by
+  apply Sigma.ι_desc
+
+/-- The raw sum of the already constructed prisms over the faces of a standard simplex. -/
+public noncomputable def standardAffinePrismFaceChain
+    (prism : ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1)) :
+    ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X n
+  | 0 => 0
+  | n + 1 =>
+      ∑ p : Fin (n + 2), (-1 : ℤ) ^ p.val •
+        (prism n ≫
+          (SSet.chainComplexMap
+            (TopCat.toSSet.map (standardSimplexFaceTopCatMap n p))
+            (AddCommGrpCat.of ℤ)).f (n + 1))
+
+@[simp]
+public theorem standardAffinePrismFaceChain_zero
+    (prism : ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1)) :
+    standardAffinePrismFaceChain prism 0 = 0 :=
+  rfl
+
+/-- The face-prism sum is the boundary of the universal identity simplex followed by the
+transported lower-dimensional prism operator. -/
+public theorem standardAffinePrismFaceChain_eq_identity_boundary_comp
+    (prism : ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (n : ℕ) :
+    standardAffinePrismFaceChain prism (n + 1) =
+      (TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).ιChainComplex
+          (standardTopologicalSimplexIdentitySimplex (n + 1)) ≫
+        ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 1) n ≫
+        universalAffinePrismComponent n (prism n)
+          (TopCat.of (stdSimplex ℝ (Fin (n + 2)))) := by
+  rw [standardAffinePrismFaceChain, ← Category.assoc,
+    SSet.ιChainComplex_d, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp,
+    iota_universalAffinePrismComponent]
+  apply Finset.sum_congr rfl
+  intro p _
+  apply congrArg (fun k ↦ ((-1 : ℤ) ^ p.val) • k)
+  rw [singularSimplexTopCatMap_identity_delta]
+
+/-- Transporting the raw face-prism sum along a singular simplex is its source boundary
+followed by the transported lower-dimensional prism operator. -/
+public theorem standardAffinePrismFaceChain_transport_raw
+    (prism : ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk (n + 1)))) :
+    standardAffinePrismFaceChain prism (n + 1) ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map (singularSimplexTopCatMap X (n + 1) x))
+          (AddCommGrpCat.of ℤ)).f (n + 1) =
+      (TopCat.toSSet.obj X).ιChainComplex x ≫
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n ≫
+        universalAffinePrismComponent n (prism n) X := by
+  rw [standardAffinePrismFaceChain, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp, Category.assoc]
+  rw [← Category.assoc, SSet.ιChainComplex_d, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp,
+    iota_universalAffinePrismComponent]
+  apply Finset.sum_congr rfl
+  intro p _
+  apply congrArg (fun k ↦ ((-1 : ℤ) ^ p.val) • k)
+  let G := (SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)
+  have hsset :
+      TopCat.toSSet.map (standardSimplexFaceTopCatMap n p) ≫
+          TopCat.toSSet.map (singularSimplexTopCatMap X (n + 1) x) =
+        TopCat.toSSet.map
+          (singularSimplexTopCatMap X n ((TopCat.toSSet.obj X).δ p x)) := by
+    rw [← Functor.map_comp, singularSimplexTopCatMap_delta]
+  have hmap := G.congr_map hsset
+  rw [Functor.map_comp] at hmap
+  have hn := congrArg (fun K ↦ K.f (n + 1)) hmap
+  change (SSet.chainComplexMap
+        (TopCat.toSSet.map (standardSimplexFaceTopCatMap n p))
+        (AddCommGrpCat.of ℤ)).f (n + 1) ≫
+      (SSet.chainComplexMap
+        (TopCat.toSSet.map (singularSimplexTopCatMap X (n + 1) x))
+        (AddCommGrpCat.of ℤ)).f (n + 1) =
+    (SSet.chainComplexMap
+      (TopCat.toSSet.map
+        (singularSimplexTopCatMap X n ((TopCat.toSSet.obj X).δ p x)))
+      (AddCommGrpCat.of ℤ)).f (n + 1) at hn
+  calc
+    _ = prism n ≫
+        ((SSet.chainComplexMap
+            (TopCat.toSSet.map (standardSimplexFaceTopCatMap n p))
+            (AddCommGrpCat.of ℤ)).f (n + 1) ≫
+          (SSet.chainComplexMap
+            (TopCat.toSSet.map (singularSimplexTopCatMap X (n + 1) x))
+            (AddCommGrpCat.of ℤ)).f (n + 1)) := Category.assoc _ _ _
+    _ = _ := congrArg (fun k ↦ prism n ≫ k) hn
+
+/-- A universal prism equation induces the corresponding operator equation on every
+topological space in that degree. -/
+public theorem universalAffinePrismComponent_boundary_succ
+    (prism : ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (n : ℕ)
+    (h : standardAffineSubdivisionDiscrepancy (n + 1) =
+      prism (n + 1) ≫
+          ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) +
+        standardAffinePrismFaceChain prism (n + 1))
+    (X : TopCat.{0}) :
+    (affineSingularSubdivisionDiscrepancyChainMap X).f (n + 1) =
+      universalAffinePrismComponent (n + 1) (prism (n + 1)) X ≫
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) +
+      ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n ≫
+        universalAffinePrismComponent n (prism n) X := by
+  apply (TopCat.toSSet.obj X).chainComplex_hom_ext
+  intro x
+  simp only [Preadditive.comp_add]
+  rw [iota_affineSingularSubdivisionDiscrepancyChainMap, h,
+    Preadditive.add_comp]
+  apply congrArg₂ (fun a b ↦ a + b)
+  · rw [← Category.assoc, iota_universalAffinePrismComponent]
+    simp only [Category.assoc]
+    congr 1
+    symm
+    exact (SSet.chainComplexMap
+      (TopCat.toSSet.map (singularSimplexTopCatMap X (n + 1) x))
+      (AddCommGrpCat.of ℤ)).comm (n + 2) (n + 1)
+  · exact standardAffinePrismFaceChain_transport_raw prism X n x
+
+/-- Once the prism equation is known in degree `n+1`, the residual used to define the next
+prism is a cycle.  The cancellation is the chain identity `∂² = 0`. -/
+public theorem standardAffinePrismResidual_cycle_succ
+    (prism : ∀ n : ℕ, AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1))
+    (n : ℕ)
+    (h : standardAffineSubdivisionDiscrepancy (n + 1) =
+      prism (n + 1) ≫
+          ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) +
+        standardAffinePrismFaceChain prism (n + 1)) :
+    (standardAffineSubdivisionDiscrepancy (n + 2) -
+        standardAffinePrismFaceChain prism (n + 2)) ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 3))))).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) = 0 := by
+  let X : TopCat := TopCat.of (stdSimplex ℝ (Fin (n + 3)))
+  let K := affineSingularSubdivisionDiscrepancyChainMap X
+  let U := universalAffinePrismComponent (n + 1) (prism (n + 1)) X
+  let V := universalAffinePrismComponent n (prism n) X
+  have hop := universalAffinePrismComponent_boundary_succ prism n h X
+  have hU : U ≫
+      ((TopCat.toSSet.obj X).chainComplex
+        (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) =
+      K.f (n + 1) -
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n ≫ V := by
+    dsimp [K, U, V] at hop ⊢
+    rw [hop]
+    abel
+  rw [Preadditive.sub_comp]
+  have hface : standardAffinePrismFaceChain prism (n + 2) ≫
+      ((TopCat.toSSet.obj X).chainComplex
+        (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) =
+      standardAffineSubdivisionDiscrepancy (n + 2) ≫
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) := by
+    rw [standardAffinePrismFaceChain_eq_identity_boundary_comp]
+    change (((TopCat.toSSet.obj X).ιChainComplex
+          (standardTopologicalSimplexIdentitySimplex (n + 2)) ≫
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1)) ≫ U) ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) = _
+    rw [Category.assoc, hU, Preadditive.comp_sub]
+    have hdd :
+        ((TopCat.toSSet.obj X).ιChainComplex
+            (standardTopologicalSimplexIdentitySimplex (n + 2)) ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1)) ≫
+            ((TopCat.toSSet.obj X).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 1) n = 0 := by
+      rw [Category.assoc,
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d_comp_d, comp_zero]
+    have hddV :
+        ((TopCat.toSSet.obj X).ιChainComplex
+            (standardTopologicalSimplexIdentitySimplex (n + 2)) ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1)) ≫
+            ((TopCat.toSSet.obj X).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 1) n ≫ V = 0 := by
+      rw [← Category.assoc, hdd, zero_comp]
+    rw [hddV, sub_zero]
+    rw [Category.assoc, ← K.comm]
+    unfold standardAffineSubdivisionDiscrepancy
+    dsimp [X, K]
+    exact (Category.assoc _ _ _).symm
+  rw [hface, sub_self]
+
+/-- The universal affine prisms, defined recursively by filling the discrepancy left after
+the already constructed face prisms. -/
+public noncomputable def canonicalAffineSubdivisionPrism
+    (n : ℕ) : AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1) :=
+  match n with
+  | 0 => 0
+  | n + 1 =>
+      standardTopologicalSimplexTotalCycleFiller (n + 1) n
+        (standardAffineSubdivisionDiscrepancy (n + 1) -
+          ∑ p : Fin (n + 2), (-1 : ℤ) ^ p.val •
+            (canonicalAffineSubdivisionPrism n ≫
+              (SSet.chainComplexMap
+                (TopCat.toSSet.map (standardSimplexFaceTopCatMap n p))
+                (AddCommGrpCat.of ℤ)).f (n + 1)))
+termination_by n
+
+@[simp]
+public theorem canonicalAffineSubdivisionPrism_zero :
+    canonicalAffineSubdivisionPrism 0 = 0 :=
+  by simp [canonicalAffineSubdivisionPrism]
+
+/-- The successor prism is the chosen filler of discrepancy minus the already constructed
+face-prism sum. -/
+public theorem canonicalAffineSubdivisionPrism_succ (n : ℕ) :
+    canonicalAffineSubdivisionPrism (n + 1) =
+      standardTopologicalSimplexTotalCycleFiller (n + 1) n
+        (standardAffineSubdivisionDiscrepancy (n + 1) -
+          standardAffinePrismFaceChain canonicalAffineSubdivisionPrism (n + 1)) := by
+  simp [canonicalAffineSubdivisionPrism, standardAffinePrismFaceChain]
+
+/-- The first recursive residual is a cycle; its degree-zero discrepancy and previous prism
+both vanish. -/
+public theorem canonicalAffineSubdivisionPrismResidual_cycle_one :
+    (standardAffineSubdivisionDiscrepancy 1 -
+        standardAffinePrismFaceChain canonicalAffineSubdivisionPrism 1) ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin 2)))).chainComplex
+          (AddCommGrpCat.of ℤ)).d 1 0 = 0 := by
+  rw [Preadditive.sub_comp,
+    standardAffineSubdivisionDiscrepancy_boundary]
+  simp [standardAffinePrismFaceChain]
+
+/-- The recursively filled universal chains satisfy the complete prism equation in every
+degree. -/
+public theorem canonicalAffineSubdivisionPrism_boundary (n : ℕ) :
+    standardAffineSubdivisionDiscrepancy n =
+      canonicalAffineSubdivisionPrism n ≫
+          ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 1) n +
+        standardAffinePrismFaceChain canonicalAffineSubdivisionPrism n := by
+  induction n with
+  | zero =>
+      simp
+  | succ n ih =>
+      have hcycle :
+          (standardAffineSubdivisionDiscrepancy (n + 1) -
+              standardAffinePrismFaceChain canonicalAffineSubdivisionPrism (n + 1)) ≫
+            ((TopCat.toSSet.obj
+              (TopCat.of (stdSimplex ℝ (Fin (n + 2))))).chainComplex
+                (AddCommGrpCat.of ℤ)).d (n + 1) n = 0 := by
+        cases n with
+        | zero =>
+            exact canonicalAffineSubdivisionPrismResidual_cycle_one
+        | succ k =>
+            exact standardAffinePrismResidual_cycle_succ
+              canonicalAffineSubdivisionPrism k ih
+      have hfill := standardTopologicalSimplexTotalCycleFiller_boundary
+        (n + 1) n
+        (standardAffineSubdivisionDiscrepancy (n + 1) -
+          standardAffinePrismFaceChain canonicalAffineSubdivisionPrism (n + 1))
+        hcycle
+      rw [canonicalAffineSubdivisionPrism_succ, hfill]
+      abel
+
+/-- The canonical universal prism transported to every singular simplex in degree `n`. -/
+public noncomputable def affineSingularSubdivisionPrismComponent
+    (X : TopCat.{0}) (n : ℕ) :
+    ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)).X n ⟶
+      ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)).X (n + 1) :=
+  universalAffinePrismComponent n (canonicalAffineSubdivisionPrism n) X
+
+@[reassoc (attr := simp)]
+public theorem iota_affineSingularSubdivisionPrismComponent
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    (TopCat.toSSet.obj X).ιChainComplex x ≫
+        affineSingularSubdivisionPrismComponent X n =
+      canonicalAffineSubdivisionPrism n ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+          (AddCommGrpCat.of ℤ)).f (n + 1) :=
+  iota_universalAffinePrismComponent n (canonicalAffineSubdivisionPrism n) X x
+
+/-- The canonical affine prism components are natural in continuous maps. -/
+public theorem affineSingularSubdivisionPrismComponent_naturality
+    {X Y : TopCat.{0}} (f : X ⟶ Y) (n : ℕ) :
+    (SSet.chainComplexMap (TopCat.toSSet.map f)
+        (AddCommGrpCat.of ℤ)).f n ≫
+      affineSingularSubdivisionPrismComponent Y n =
+    affineSingularSubdivisionPrismComponent X n ≫
+      (SSet.chainComplexMap (TopCat.toSSet.map f)
+        (AddCommGrpCat.of ℤ)).f (n + 1) := by
+  apply (TopCat.toSSet.obj X).chainComplex_hom_ext
+  intro x
+  rw [← Category.assoc, SSet.ι_chainComplexMap_f,
+    iota_affineSingularSubdivisionPrismComponent]
+  rw [← Category.assoc, iota_affineSingularSubdivisionPrismComponent]
+  let G := (SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)
+  have hsset :
+      TopCat.toSSet.map (singularSimplexTopCatMap X n x) ≫
+          TopCat.toSSet.map f =
+        TopCat.toSSet.map
+          (singularSimplexTopCatMap Y n ((TopCat.toSSet.map f).app _ x)) := by
+    rw [← Functor.map_comp, ← singularSimplexTopCatMap_map]
+  have hmap := G.congr_map hsset
+  rw [Functor.map_comp] at hmap
+  have hn := congrArg (fun K ↦ K.f (n + 1)) hmap
+  change (SSet.chainComplexMap
+      (TopCat.toSSet.map (singularSimplexTopCatMap X n x))
+      (AddCommGrpCat.of ℤ)).f (n + 1) ≫
+      (SSet.chainComplexMap (TopCat.toSSet.map f)
+        (AddCommGrpCat.of ℤ)).f (n + 1) =
+    (SSet.chainComplexMap
+      (TopCat.toSSet.map
+        (singularSimplexTopCatMap Y n ((TopCat.toSSet.map f).app _ x)))
+      (AddCommGrpCat.of ℤ)).f (n + 1) at hn
+  rw [Category.assoc, hn]
+
+/-- In positive degrees the canonical transported prism satisfies the discrepancy equation. -/
+public theorem affineSingularSubdivisionPrismComponent_discrepancy_succ
+    (X : TopCat.{0}) (n : ℕ) :
+    (affineSingularSubdivisionDiscrepancyChainMap X).f (n + 1) =
+      affineSingularSubdivisionPrismComponent X (n + 1) ≫
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) +
+      ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n ≫
+        affineSingularSubdivisionPrismComponent X n :=
+  by
+    simpa only [affineSingularSubdivisionPrismComponent] using
+      universalAffinePrismComponent_boundary_succ
+        canonicalAffineSubdivisionPrism n
+          (canonicalAffineSubdivisionPrism_boundary (n + 1)) X
+
+/-- In degree zero the canonical transported prism satisfies the discrepancy equation, with
+no lower-dimensional face term. -/
+public theorem affineSingularSubdivisionPrismComponent_discrepancy_zero
+    (X : TopCat.{0}) :
+    (affineSingularSubdivisionDiscrepancyChainMap X).f 0 =
+      affineSingularSubdivisionPrismComponent X 0 ≫
+        ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d 1 0 := by
+  apply (TopCat.toSSet.obj X).chainComplex_hom_ext
+  intro x
+  rw [iota_affineSingularSubdivisionDiscrepancyChainMap]
+  rw [← Category.assoc, iota_affineSingularSubdivisionPrismComponent]
+  simp
+
+/-- The transported prism gives the chain-homotopy identity in every positive degree. -/
+public theorem affineSingularSubdivisionPrismComponent_identity_succ
+    (X : TopCat.{0}) (n : ℕ) :
+    (affineSingularSubdivisionChainMap X).f (n + 1) =
+      ((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).d (n + 1) n ≫
+          affineSingularSubdivisionPrismComponent X n +
+        affineSingularSubdivisionPrismComponent X (n + 1) ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) +
+        𝟙 (((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).X (n + 1)) := by
+  have h := affineSingularSubdivisionPrismComponent_discrepancy_succ X n
+  change (affineSingularSubdivisionChainMap X).f (n + 1) - 𝟙 _ = _ at h
+  rw [sub_eq_iff_eq_add] at h
+  rw [h]
+  abel
+
+/-- The transported prism gives the chain-homotopy identity in degree zero. -/
+public theorem affineSingularSubdivisionPrismComponent_identity_zero
+    (X : TopCat.{0}) :
+    (affineSingularSubdivisionChainMap X).f 0 =
+      affineSingularSubdivisionPrismComponent X 0 ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d 1 0 +
+        𝟙 (((TopCat.toSSet.obj X).chainComplex
+          (AddCommGrpCat.of ℤ)).X 0) := by
+  have h := affineSingularSubdivisionPrismComponent_discrepancy_zero X
+  change (affineSingularSubdivisionChainMap X).f 0 - 𝟙 _ = _ at h
+  rw [sub_eq_iff_eq_add] at h
+  exact h
+
+/-- The homotopy family, supported from degree `i` to degree `i+1`. -/
+public noncomputable def affineSingularSubdivisionPrismHom
+    (X : TopCat.{0}) (i j : ℕ) :
+    ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)).X i ⟶
+      ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ)).X j :=
+  if h : j = i + 1 then by
+    subst j
+    exact affineSingularSubdivisionPrismComponent X i
+  else 0
+
+@[simp]
+public theorem affineSingularSubdivisionPrismHom_succ
+    (X : TopCat.{0}) (i : ℕ) :
+    affineSingularSubdivisionPrismHom X i (i + 1) =
+      affineSingularSubdivisionPrismComponent X i := by
+  simp [affineSingularSubdivisionPrismHom]
+
+/-- Affine barycentric subdivision is chain homotopic to the identity on the integral singular
+chain complex of every topological space. -/
+public noncomputable def affineSingularSubdivisionHomotopy
+    (X : TopCat.{0}) :
+    Homotopy (affineSingularSubdivisionChainMap X)
+      (𝟙 ((TopCat.toSSet.obj X).chainComplex (AddCommGrpCat.of ℤ))) where
+  hom := affineSingularSubdivisionPrismHom X
+  zero i j hij := by
+    rw [affineSingularSubdivisionPrismHom]
+    split_ifs with h
+    · exfalso
+      apply hij
+      rw [ComplexShape.down_Rel]
+      exact h.symm
+    · rfl
+  comm i := by
+    cases i with
+    | zero =>
+        rw [Homotopy.dNext_zero_chainComplex,
+          Homotopy.prevD_chainComplex]
+        simp only [affineSingularSubdivisionPrismHom_succ, zero_add,
+          HomologicalComplex.id_f]
+        exact affineSingularSubdivisionPrismComponent_identity_zero X
+    | succ n =>
+        rw [Homotopy.dNext_succ_chainComplex,
+          Homotopy.prevD_chainComplex]
+        simp only [affineSingularSubdivisionPrismHom_succ,
+          HomologicalComplex.id_f]
+        exact affineSingularSubdivisionPrismComponent_identity_succ X n
+
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularAffineSubdivisionSmallPrism.lean
+++ b/SphereSixComplex/Topology/SingularAffineSubdivisionSmallPrism.lean
@@ -1,0 +1,283 @@
+module
+
+public import SphereSixComplex.Topology.SingularAffineSubdivisionPrism
+
+/-!
+# The affine subdivision prism on cover-small singular chains
+
+The universal affine prism only precomposes a singular simplex.  It therefore preserves the
+range of any cover member, just as affine subdivision itself does.  This file restricts the
+prism to the cover-small chain complex and proves that cover-small affine subdivision is chain
+homotopic to the identity there.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set
+
+namespace SphereSixComplex
+
+variable {iota : Type} (X : TopCat) (U : iota → Set X)
+
+/-- The affine prism on a selected lift of a cover-small generator, mapped back into the small
+chain complex. -/
+public noncomputable def coverSmallAffinePrismSimplexChain
+    (n : ℕ)
+    (x : (coverSmallSingularSubcomplex X U : SSet).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    AddCommGrpCat.of ℤ ⟶
+      (CoverSmallIntegralSingularChainComplex X U).X (n + 1) :=
+  (TopCat.toSSet.obj
+      (TopCat.of (U (coverSmallSimplexPreimageIndex X U x)))).ιChainComplex
+        (coverSmallSimplexPreimage X U x) ≫
+    affineSingularSubdivisionPrismComponent
+      (TopCat.of (U (coverSmallSimplexPreimageIndex X U x))) n ≫
+    (coverMemberToSmallIntegralSingularChains X U
+      (coverSmallSimplexPreimageIndex X U x)).f (n + 1)
+
+/-- The degree-raising affine prism operator on cover-small chains. -/
+public noncomputable def coverSmallAffinePrismComponent (n : ℕ) :
+    (CoverSmallIntegralSingularChainComplex X U).X n ⟶
+      (CoverSmallIntegralSingularChainComplex X U).X (n + 1) :=
+  Sigma.desc (coverSmallAffinePrismSimplexChain X U n)
+
+@[reassoc (attr := simp)]
+public theorem iota_coverSmallAffinePrismComponent
+    (n : ℕ)
+    (x : (coverSmallSingularSubcomplex X U : SSet).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    (coverSmallSingularSubcomplex X U : SSet).ιChainComplex x ≫
+        coverSmallAffinePrismComponent X U n =
+      coverSmallAffinePrismSimplexChain X U n x := by
+  apply Sigma.ι_desc
+
+/-- The small prism on a generator agrees with the full prism after inclusion. -/
+public theorem coverSmallAffinePrismSimplexChain_comp_inclusion
+    (n : ℕ)
+    (x : (coverSmallSingularSubcomplex X U : SSet).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    coverSmallAffinePrismSimplexChain X U n x ≫
+        (coverSmallIntegralSingularChainInclusion X U).f (n + 1) =
+      (TopCat.toSSet.obj X).ιChainComplex x.1 ≫
+        affineSingularSubdivisionPrismComponent X n := by
+  let j := coverSmallSimplexPreimageIndex X U x
+  let y := coverSmallSimplexPreimage X U x
+  let I := SSet.chainComplexMap
+    (TopCat.toSSet.map (topologicalSubsetInclusion X (U j)))
+    (AddCommGrpCat.of ℤ)
+  have hcover := congrArg (fun F ↦ F.f (n + 1))
+    (coverMemberToSmallIntegralSingularChains_comp_inclusion X U j)
+  change (SSet.chainComplexMap (coverMemberToSmallSingularSet X U j)
+        (AddCommGrpCat.of ℤ)).f (n + 1) ≫
+      (SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+        (AddCommGrpCat.of ℤ)).f (n + 1) = I.f (n + 1) at hcover
+  change (((TopCat.toSSet.obj (TopCat.of (U j))).ιChainComplex y ≫
+      affineSingularSubdivisionPrismComponent (TopCat.of (U j)) n) ≫
+        (SSet.chainComplexMap (coverMemberToSmallSingularSet X U j)
+          (AddCommGrpCat.of ℤ)).f (n + 1)) ≫
+      (SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+        (AddCommGrpCat.of ℤ)).f (n + 1) = _
+  rw [Category.assoc, hcover]
+  rw [Category.assoc,
+    ← affineSingularSubdivisionPrismComponent_naturality]
+  rw [← Category.assoc, SSet.ι_chainComplexMap_f]
+  rw [show (TopCat.toSSet.map
+      (topologicalSubsetInclusion X (U j))).app _ y = x.1 from
+    coverSmallSimplexPreimage_spec X U x]
+
+/-- The small prism agrees degreewise with the full prism after inclusion. -/
+public theorem coverSmallAffinePrismComponent_comp_inclusion
+    (n : ℕ) :
+    coverSmallAffinePrismComponent X U n ≫
+        (coverSmallIntegralSingularChainInclusion X U).f (n + 1) =
+      (coverSmallIntegralSingularChainInclusion X U).f n ≫
+        affineSingularSubdivisionPrismComponent X n := by
+  change coverSmallAffinePrismComponent X U n ≫
+      (SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+        (AddCommGrpCat.of ℤ)).f (n + 1) =
+    (SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+      (AddCommGrpCat.of ℤ)).f n ≫
+      affineSingularSubdivisionPrismComponent X n
+  apply (coverSmallSingularSubcomplex X U : SSet).chainComplex_hom_ext
+  intro x
+  rw [← Category.assoc, iota_coverSmallAffinePrismComponent]
+  simp only [SSet.ι_chainComplexMap_f_assoc]
+  exact coverSmallAffinePrismSimplexChain_comp_inclusion X U n x
+
+set_option linter.style.haveILetI false in
+/-- The cover-small prism gives the chain-homotopy equation in positive degrees. -/
+public theorem coverSmallAffinePrismComponent_identity_succ
+    (n : ℕ) :
+    (coverSmallAffineSubdivisionChainMap X U).f (n + 1) =
+      (CoverSmallIntegralSingularChainComplex X U).d (n + 1) n ≫
+          coverSmallAffinePrismComponent X U n +
+        coverSmallAffinePrismComponent X U (n + 1) ≫
+          (CoverSmallIntegralSingularChainComplex X U).d (n + 2) (n + 1) +
+        𝟙 ((CoverSmallIntegralSingularChainComplex X U).X (n + 1)) := by
+  let I := SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+    (AddCommGrpCat.of ℤ)
+  haveI : Mono I := by
+    dsimp [I]
+    exact coverSmallIntegralSingularChainInclusion_mono X U
+  haveI : Mono (I.f (n + 1)) := by
+    change Mono ((HomologicalComplex.eval AddCommGrpCat
+      (ComplexShape.down ℕ) (n + 1)).map I)
+    infer_instance
+  apply (cancel_mono (I.f (n + 1))).mp
+  rw [Preadditive.add_comp, Preadditive.add_comp]
+  simp only [Category.id_comp]
+  rw [coverSmallAffineSubdivisionChainMap_f]
+  have hA := coverSmallAffineSubdivisionComponent_comp_inclusion X U (n + 1)
+  change coverSmallAffineSubdivisionComponent X U (n + 1) ≫ I.f (n + 1) =
+    I.f (n + 1) ≫ affineSingularSubdivisionComponent X (n + 1) at hA
+  have hP (k : ℕ) :
+      coverSmallAffinePrismComponent X U k ≫ I.f (k + 1) =
+        I.f k ≫ affineSingularSubdivisionPrismComponent X k := by
+    have hp := coverSmallAffinePrismComponent_comp_inclusion X U k
+    change coverSmallAffinePrismComponent X U k ≫ I.f (k + 1) =
+      I.f k ≫ affineSingularSubdivisionPrismComponent X k at hp
+    exact hp
+  rw [hA]
+  change I.f (n + 1) ≫
+      (affineSingularSubdivisionChainMap X).f (n + 1) = _
+  rw [affineSingularSubdivisionPrismComponent_identity_succ]
+  rw [Preadditive.comp_add, Preadditive.comp_add]
+  simp only [Category.comp_id]
+  apply congrArg₂ (fun a b ↦ a + b)
+  · apply congrArg₂ (fun a b ↦ a + b)
+    · rw [← Category.assoc, I.comm]
+      symm
+      calc
+        ((CoverSmallIntegralSingularChainComplex X U).d (n + 1) n ≫
+              coverSmallAffinePrismComponent X U n) ≫ I.f (n + 1) =
+            (CoverSmallIntegralSingularChainComplex X U).d (n + 1) n ≫
+              (coverSmallAffinePrismComponent X U n ≫ I.f (n + 1)) :=
+          Category.assoc _ _ _
+        _ = (CoverSmallIntegralSingularChainComplex X U).d (n + 1) n ≫
+              (I.f n ≫ affineSingularSubdivisionPrismComponent X n) := by
+          rw [hP]
+        _ = ((CoverSmallIntegralSingularChainComplex X U).d (n + 1) n ≫
+              I.f n) ≫ affineSingularSubdivisionPrismComponent X n :=
+          (Category.assoc _ _ _).symm
+    · calc
+        (I.f (n + 1) ≫
+              affineSingularSubdivisionPrismComponent X (n + 1)) ≫
+            ((TopCat.toSSet.obj X).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) =
+          (coverSmallAffinePrismComponent X U (n + 1) ≫ I.f (n + 2)) ≫
+            ((TopCat.toSSet.obj X).chainComplex
+              (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1) := by
+                rw [hP]
+        _ = coverSmallAffinePrismComponent X U (n + 1) ≫
+            (I.f (n + 2) ≫
+              ((TopCat.toSSet.obj X).chainComplex
+                (AddCommGrpCat.of ℤ)).d (n + 2) (n + 1)) :=
+          Category.assoc _ _ _
+        _ = coverSmallAffinePrismComponent X U (n + 1) ≫
+            ((CoverSmallIntegralSingularChainComplex X U).d
+              (n + 2) (n + 1) ≫ I.f (n + 1)) := by rw [I.comm]
+        _ = (coverSmallAffinePrismComponent X U (n + 1) ≫
+              (CoverSmallIntegralSingularChainComplex X U).d
+                (n + 2) (n + 1)) ≫ I.f (n + 1) :=
+          (Category.assoc _ _ _).symm
+  · rfl
+
+set_option linter.style.haveILetI false in
+/-- The cover-small prism gives the chain-homotopy equation in degree zero. -/
+public theorem coverSmallAffinePrismComponent_identity_zero :
+    (coverSmallAffineSubdivisionChainMap X U).f 0 =
+      coverSmallAffinePrismComponent X U 0 ≫
+          (CoverSmallIntegralSingularChainComplex X U).d 1 0 +
+        𝟙 ((CoverSmallIntegralSingularChainComplex X U).X 0) := by
+  let I := SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+    (AddCommGrpCat.of ℤ)
+  haveI : Mono I := by
+    dsimp [I]
+    exact coverSmallIntegralSingularChainInclusion_mono X U
+  haveI : Mono (I.f 0) := by
+    change Mono ((HomologicalComplex.eval AddCommGrpCat
+      (ComplexShape.down ℕ) 0).map I)
+    infer_instance
+  apply (cancel_mono (I.f 0)).mp
+  rw [Preadditive.add_comp]
+  simp only [Category.id_comp]
+  rw [coverSmallAffineSubdivisionChainMap_f]
+  have hA := coverSmallAffineSubdivisionComponent_comp_inclusion X U 0
+  change coverSmallAffineSubdivisionComponent X U 0 ≫ I.f 0 =
+    I.f 0 ≫ affineSingularSubdivisionComponent X 0 at hA
+  have hP : coverSmallAffinePrismComponent X U 0 ≫ I.f 1 =
+      I.f 0 ≫ affineSingularSubdivisionPrismComponent X 0 := by
+    have hp := coverSmallAffinePrismComponent_comp_inclusion X U 0
+    change coverSmallAffinePrismComponent X U 0 ≫ I.f 1 =
+      I.f 0 ≫ affineSingularSubdivisionPrismComponent X 0 at hp
+    exact hp
+  rw [hA]
+  change I.f 0 ≫ (affineSingularSubdivisionChainMap X).f 0 = _
+  rw [affineSingularSubdivisionPrismComponent_identity_zero]
+  rw [Preadditive.comp_add]
+  simp only [Category.comp_id]
+  apply congrArg₂ (fun a b ↦ a + b)
+  · calc
+      (I.f 0 ≫ affineSingularSubdivisionPrismComponent X 0) ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d 1 0 =
+        (coverSmallAffinePrismComponent X U 0 ≫ I.f 1) ≫
+          ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d 1 0 := by rw [hP]
+      _ = coverSmallAffinePrismComponent X U 0 ≫
+          (I.f 1 ≫ ((TopCat.toSSet.obj X).chainComplex
+            (AddCommGrpCat.of ℤ)).d 1 0) := Category.assoc _ _ _
+      _ = coverSmallAffinePrismComponent X U 0 ≫
+          ((CoverSmallIntegralSingularChainComplex X U).d 1 0 ≫ I.f 0) := by
+        rw [I.comm]
+      _ = (coverSmallAffinePrismComponent X U 0 ≫
+          (CoverSmallIntegralSingularChainComplex X U).d 1 0) ≫ I.f 0 :=
+        (Category.assoc _ _ _).symm
+  · rfl
+
+/-- The degree-raising small-prism family. -/
+public noncomputable def coverSmallAffinePrismHom (i j : ℕ) :
+    (CoverSmallIntegralSingularChainComplex X U).X i ⟶
+      (CoverSmallIntegralSingularChainComplex X U).X j :=
+  if h : j = i + 1 then by
+    subst j
+    exact coverSmallAffinePrismComponent X U i
+  else 0
+
+@[simp]
+public theorem coverSmallAffinePrismHom_succ (i : ℕ) :
+    coverSmallAffinePrismHom X U i (i + 1) =
+      coverSmallAffinePrismComponent X U i := by
+  simp [coverSmallAffinePrismHom]
+
+/-- Cover-small affine subdivision is chain homotopic to the identity. -/
+public noncomputable def coverSmallAffineSubdivisionHomotopy :
+    Homotopy (coverSmallAffineSubdivisionChainMap X U)
+      (𝟙 (CoverSmallIntegralSingularChainComplex X U)) where
+  hom := coverSmallAffinePrismHom X U
+  zero i j hij := by
+    rw [coverSmallAffinePrismHom]
+    split_ifs with h
+    · exfalso
+      apply hij
+      rw [ComplexShape.down_Rel]
+      exact h.symm
+    · rfl
+  comm i := by
+    cases i with
+    | zero =>
+        rw [Homotopy.dNext_zero_chainComplex,
+          Homotopy.prevD_chainComplex]
+        simp only [coverSmallAffinePrismHom_succ, zero_add,
+          HomologicalComplex.id_f]
+        exact coverSmallAffinePrismComponent_identity_zero X U
+    | succ n =>
+        rw [Homotopy.dNext_succ_chainComplex,
+          Homotopy.prevD_chainComplex]
+        simp only [coverSmallAffinePrismHom_succ,
+          HomologicalComplex.id_f]
+        exact coverSmallAffinePrismComponent_identity_succ X U n
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- promote the previously reviewed affine prism construction to `main`
- include its cover-small restriction and iterated homotopy layer
- unblock the quasi-isomorphism and open-cover excision stack

## Verification

- `lake build SphereSixComplex.Topology.SingularAffineSubdivisionIteration`
- endpoint `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`
- no `sorry`, `admit`, declarations of new axioms, `unsafe`, or `opaque`

This promotion is needed because #46–#48 were merged into already-merged parent branches, so their three-file tail did not propagate to `main`.

Tracks #43.