### PR TITLE
Promote full open-cover singular excision to main

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -238,6 +238,7 @@ public import SphereSixComplex.Topology.StandardSpherePunctures
 public import SphereSixComplex.Topology.DiskBoundaryQuotient
 public import SphereSixComplex.Topology.RelativeSingularHomology
 public import SphereSixComplex.Topology.SingularExcision
+public import SphereSixComplex.Topology.SingularExcisionOpenCover
 public import SphereSixComplex.Topology.SingularBarycentricAllDegrees
 public import SphereSixComplex.Topology.SingularBarycentricOuterFaces
 public import SphereSixComplex.Topology.SingularBarycentricHomotopy

--- a/SphereSixComplex/Topology/SingularAffineSubdivisionMesh.lean
+++ b/SphereSixComplex/Topology/SingularAffineSubdivisionMesh.lean
@@ -1,0 +1,434 @@
+module
+
+public import SphereSixComplex.Topology.SingularOpenCoverLebesgue
+public import SphereSixComplex.Topology.SingularExcisionQuasiIso
+public import Mathlib.Analysis.Normed.Module.Convex
+public import Mathlib.Analysis.SpecificLimits.Basic
+
+/-!
+# Mesh estimates for affine barycentric subdivision
+
+This file proves the quantitative geometric estimate behind the small-chain argument.  In the
+sup metric on the standard `n`-simplex, the affine simplex associated to every flag of nonempty
+faces has diameter at most `n / (n + 1)`.  The proof uses the exact face-barycenter coordinates
+from `SingularAffineSubdivision`.
+
+The final theorem packages the metric conclusion needed for iterated subdivision: any family of
+nonempty cells whose diameters are bounded by successive powers of this factor is eventually
+subordinate to an arbitrary open cover of a compact metric space.  Connecting that abstract
+family to the chain-level iterate requires keeping the ancestry of every iterated affine flag;
+that combinatorial bookkeeping is intentionally separate from the metric argument here.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits PartialOrder Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The classical mesh-contraction factor for barycentric subdivision of an `n`-simplex. -/
+public noncomputable def barycentricContractionFactor (n : ℕ) : ℝ :=
+  (n : ℝ) / (n + 1)
+
+public theorem barycentricContractionFactor_nonneg (n : ℕ) :
+    0 ≤ barycentricContractionFactor n := by
+  unfold barycentricContractionFactor
+  positivity
+
+public theorem barycentricContractionFactor_lt_one (n : ℕ) :
+    barycentricContractionFactor n < 1 := by
+  unfold barycentricContractionFactor
+  rw [div_lt_one (by positivity)]
+  norm_num
+
+/-- The intrinsic diameter of a nonempty standard simplex is one in the sup metric. -/
+public theorem diam_univ_stdSimplex (n : ℕ) (hn : 1 ≤ n) :
+    Metric.diam (Set.univ : Set (stdSimplex ℝ (Fin (n + 1)))) = 1 := by
+  let _ : Nontrivial (Fin (n + 1)) :=
+    Fin.nontrivial_iff_two_le.mpr (Nat.add_le_add_right hn 1)
+  calc
+    Metric.diam (Set.univ : Set (stdSimplex ℝ (Fin (n + 1)))) =
+        Metric.diam (Set.range
+          (Subtype.val : stdSimplex ℝ (Fin (n + 1)) → Fin (n + 1) → ℝ)) :=
+      isometry_subtype_coe.diam_range.symm
+    _ = Metric.diam (stdSimplex ℝ (Fin (n + 1))) := by
+      congr 1
+      ext w
+      simp
+    _ = 1 := diam_stdSimplex
+
+/-- Arithmetic estimate for barycenters of two nested nonempty faces. -/
+public theorem inv_natCast_sub_inv_natCast_le_barycentricContractionFactor
+    (n a b : ℕ) (ha : 1 ≤ a) (hab : a ≤ b) (hb : b ≤ n + 1) :
+    |(a : ℝ)⁻¹ - (b : ℝ)⁻¹| ≤ barycentricContractionFactor n := by
+  have haR : (1 : ℝ) ≤ a := by exact_mod_cast ha
+  have habR : (a : ℝ) ≤ b := by exact_mod_cast hab
+  have hbR : (b : ℝ) ≤ n + 1 := by exact_mod_cast hb
+  have hB : (0 : ℝ) < b := lt_of_lt_of_le zero_lt_one (haR.trans habR)
+  have h_inv_ab : (b : ℝ)⁻¹ ≤ (a : ℝ)⁻¹ :=
+    inv_anti₀ (by positivity) habR
+  rw [abs_of_nonneg (sub_nonneg.mpr h_inv_ab)]
+  have ha_one : (a : ℝ)⁻¹ ≤ 1 := by
+    simpa using (inv_anti₀ (by norm_num : (0 : ℝ) < 1) haR)
+  have hb_N : (n + 1 : ℝ)⁻¹ ≤ (b : ℝ)⁻¹ :=
+    inv_anti₀ hB hbR
+  have hfactor : barycentricContractionFactor n =
+      1 - (n + 1 : ℝ)⁻¹ := by
+    unfold barycentricContractionFactor
+    field_simp
+    ring
+  rw [hfactor]
+  linarith
+
+/-- If a face acquires a new vertex, then its barycenter coordinate at that vertex is bounded by
+the barycentric mesh factor. -/
+public theorem inv_natCast_le_barycentricContractionFactor_of_two_le
+    (n b : ℕ) (hn : 1 ≤ n) (hb₂ : 2 ≤ b) :
+    (b : ℝ)⁻¹ ≤ barycentricContractionFactor n := by
+  have hb₂R : (2 : ℝ) ≤ b := by exact_mod_cast hb₂
+  have hnR : (2 : ℝ) ≤ n + 1 := by
+    exact_mod_cast (Nat.add_le_add_right hn 1)
+  have hbhalf : (b : ℝ)⁻¹ ≤ (2 : ℝ)⁻¹ :=
+    inv_anti₀ (by norm_num) hb₂R
+  have hNhalf : (n + 1 : ℝ)⁻¹ ≤ (2 : ℝ)⁻¹ :=
+    inv_anti₀ (by norm_num) hnR
+  have hfactor : barycentricContractionFactor n =
+      1 - (n + 1 : ℝ)⁻¹ := by
+    unfold barycentricContractionFactor
+    field_simp
+    ring
+  rw [hfactor]
+  have hhalf : (2 : ℝ)⁻¹ ≤ 1 - (n + 1 : ℝ)⁻¹ := by
+    norm_num at hNhalf ⊢
+    linarith
+  exact hbhalf.trans hhalf
+
+/-- Barycenters of two nested nonempty faces of the standard `n`-simplex are at distance at
+most `n / (n + 1)` in the sup metric. -/
+public theorem dist_nonemptyFiniteChainBarycenter_le
+    (n : ℕ) (hn : 1 ≤ n)
+    (A B : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) (hAB : A ≤ B) :
+    dist (nonemptyFiniteChainBarycenter A)
+      (nonemptyFiniteChainBarycenter B) ≤ barycentricContractionFactor n := by
+  classical
+  change dist (nonemptyFiniteChainBarycenter A : Fin (n + 1) → ℝ)
+      (nonemptyFiniteChainBarycenter B : Fin (n + 1) → ℝ) ≤ _
+  rw [dist_pi_le_iff (barycentricContractionFactor_nonneg n)]
+  intro i
+  rw [Real.dist_eq, nonemptyFiniteChainBarycenter_apply,
+    nonemptyFiniteChainBarycenter_apply]
+  by_cases hiA : ULift.up i ∈ A.finset
+  · have hiB : ULift.up i ∈ B.finset := hAB hiA
+    rw [ite_eq_left hiA, ite_eq_left hiB]
+    apply inv_natCast_sub_inv_natCast_le_barycentricContractionFactor
+    · exact A.nonempty.card_pos
+    · exact Finset.card_le_card hAB
+    · simpa using B.finset.card_le_univ
+  · by_cases hiB : ULift.up i ∈ B.finset
+    · rw [ite_eq_right hiA, ite_eq_left hiB, zero_sub, abs_neg,
+        abs_of_nonneg (by positivity)]
+      apply inv_natCast_le_barycentricContractionFactor_of_two_le n
+        B.finset.card hn
+      have hss : A.finset ⊂ B.finset :=
+        Finset.ssubset_iff_subset_ne.mpr ⟨hAB, ?_⟩
+      · exact (Finset.card_lt_card hss).trans_le' A.nonempty.card_pos
+      · intro heq
+        exact hiA (heq.symm ▸ hiB)
+    · simp [hiA, hiB, barycentricContractionFactor_nonneg]
+
+/-- The finite set of barycenters occurring as the vertices of an affine flag simplex. -/
+public noncomputable def affineFlagVertexSet (n k : ℕ)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Set (Fin (n + 1) → ℝ) :=
+  Set.range fun j ↦
+    (nonemptyFiniteChainBarycenter (F.obj j) : Fin (n + 1) → ℝ)
+
+/-- The vertices of any affine flag simplex satisfy the barycentric mesh estimate. -/
+public theorem diam_affineFlagVertexSet_le
+    (n k : ℕ) (hn : 1 ≤ n)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Metric.diam (affineFlagVertexSet n k F) ≤
+      barycentricContractionFactor n := by
+  apply Metric.diam_le_of_forall_dist_le
+    (barycentricContractionFactor_nonneg n)
+  rintro _ ⟨i, rfl⟩ _ ⟨j, rfl⟩
+  change dist (nonemptyFiniteChainBarycenter (F.obj i))
+      (nonemptyFiniteChainBarycenter (F.obj j)) ≤ _
+  rcases le_total i j with hij | hji
+  · exact dist_nonemptyFiniteChainBarycenter_le n hn _ _
+      (CategoryTheory.leOfHom (F.map (CategoryTheory.homOfLE hij)))
+  · simpa [dist_comm] using
+      dist_nonemptyFiniteChainBarycenter_le n hn _ _
+        (CategoryTheory.leOfHom (F.map (CategoryTheory.homOfLE hji)))
+
+/-- Every point of an affine flag simplex lies in the convex hull of its barycenter vertices. -/
+public theorem affineFlagContinuousMap_mem_convexHull_vertices
+    (n k : ℕ)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k)))
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    (affineFlagContinuousMap n k F w : Fin (n + 1) → ℝ) ∈
+      convexHull ℝ (affineFlagVertexSet n k F) := by
+  classical
+  change (fun i ↦ ∑ j, w j * nonemptyFiniteChainBarycenter (F.obj j) i) ∈ _
+  have hmem := (convex_convexHull ℝ (affineFlagVertexSet n k F)).sum_mem
+    (t := Finset.univ) (w := fun j ↦ w j)
+    (z := fun j ↦
+      (nonemptyFiniteChainBarycenter (F.obj j) : Fin (n + 1) → ℝ))
+    (fun j _ ↦ w.2.1 j) w.2.2 (fun j _ ↦
+      subset_convexHull ℝ (affineFlagVertexSet n k F) ⟨j, rfl⟩)
+  convert hmem using 1
+  ext i
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+
+/-- The image of every affine flag map contracts the mesh by the factor `n / (n + 1)`.  The
+diameter is stated after the isometric inclusion into the ambient function space. -/
+public theorem diam_range_affineFlagContinuousMap_coe_le
+    (n k : ℕ) (hn : 1 ≤ n)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Metric.diam (Set.range fun w ↦
+      (affineFlagContinuousMap n k F w : Fin (n + 1) → ℝ)) ≤
+      barycentricContractionFactor n := by
+  calc
+    Metric.diam (Set.range fun w ↦
+        (affineFlagContinuousMap n k F w : Fin (n + 1) → ℝ)) ≤
+        Metric.diam (convexHull ℝ (affineFlagVertexSet n k F)) := by
+      apply Metric.diam_mono
+      · rintro _ ⟨w, rfl⟩
+        exact affineFlagContinuousMap_mem_convexHull_vertices n k F w
+      · rw [isBounded_convexHull]
+        apply (bounded_stdSimplex (Fin (n + 1))).subset
+        rintro _ ⟨j, rfl⟩
+        exact (nonemptyFiniteChainBarycenter (F.obj j)).2
+    _ = Metric.diam (affineFlagVertexSet n k F) := convexHull_diam _
+    _ ≤ _ := diam_affineFlagVertexSet_le n k hn F
+
+/-- Intrinsic version of the affine-flag mesh estimate. -/
+public theorem diam_range_affineFlagContinuousMap_le
+    (n k : ℕ) (hn : 1 ≤ n)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Metric.diam (Set.range (affineFlagContinuousMap n k F)) ≤
+      barycentricContractionFactor n := by
+  apply Metric.diam_le_of_forall_dist_le
+    (barycentricContractionFactor_nonneg n)
+  rintro _ ⟨w, rfl⟩ _ ⟨w', rfl⟩
+  change dist
+    (affineFlagContinuousMap n k F w : Fin (n + 1) → ℝ)
+    (affineFlagContinuousMap n k F w' : Fin (n + 1) → ℝ) ≤ _
+  exact Metric.dist_le_diam_of_mem
+    (by
+      rw [isBounded_convexHull]
+      apply (bounded_stdSimplex (Fin (n + 1))).subset
+      rintro _ ⟨j, rfl⟩
+      exact (nonemptyFiniteChainBarycenter (F.obj j)).2)
+    (affineFlagContinuousMap_mem_convexHull_vertices n k F w)
+    (affineFlagContinuousMap_mem_convexHull_vertices n k F w') |>.trans
+      (by rw [convexHull_diam]; exact diam_affineFlagVertexSet_le n k hn F)
+
+/-- Powers of the barycentric mesh factor eventually fall below every positive tolerance. -/
+public theorem exists_barycentricContractionFactor_pow_lt
+    (n : ℕ) {ε : ℝ} (hε : 0 < ε) :
+    ∃ m : ℕ, barycentricContractionFactor n ^ m < ε :=
+  exists_pow_lt_of_lt_one hε (barycentricContractionFactor_lt_one n)
+
+/-- One actual affine flag cell in the subdivision of a singular simplex maps into a cover
+member as soon as the barycentric contraction factor is below the pulled-back Lebesgue number.
+This is the direct bridge between the metric estimate in this file and cover-smallness. -/
+public theorem singularSimplex_affineFlag_image_subset_cover_of_factor_lt
+    {ι : Type} (X : TopCat.{0}) (U : ι → Set X)
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (n : ℕ) (hn : 1 ≤ n)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    ∃ δ > 0, barycentricContractionFactor n < δ →
+      ∃ i, X.toSSetObjEquiv _ x '' Set.range (affineFlagContinuousMap n n F) ⊆ U i := by
+  let s : Set (stdSimplex ℝ (Fin (n + 1))) :=
+    Set.range (affineFlagContinuousMap n n F)
+  have hsne : s.Nonempty := Set.range_nonempty _
+  have hsbounded : Bornology.IsBounded s :=
+    isCompact_univ.isBounded.subset (Set.subset_univ s)
+  obtain ⟨δ, hδ, hsmall⟩ := singularSimplex_image_subset_cover_of_diam_lt
+    X U hUopen hUcover n x hsne hsbounded
+  refine ⟨δ, hδ, fun hfactor ↦ hsmall ?_⟩
+  exact (diam_range_affineFlagContinuousMap_le n n hn F).trans_lt hfactor
+
+/-! ## Iterated affine-cell ancestry -/
+
+/-- A top-dimensional flag in the barycentric subdivision of the standard `n`-simplex. -/
+public abbrev TopAffineFlag (n : ℕ) :=
+  (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+    (Opposite.op (SimplexCategory.mk n))
+
+/-- The affine cell map described by a finite ancestry of top-dimensional flags.  The head of
+the list is the newest (innermost) subdivision cell and the tail records its parent ancestry. -/
+public noncomputable def iteratedAffineCellMap (n : ℕ)
+    (ancestry : List (TopAffineFlag n)) :
+    C(stdSimplex ℝ (Fin (n + 1)), stdSimplex ℝ (Fin (n + 1))) :=
+  match ancestry with
+  | [] => ContinuousMap.id _
+  | F :: ancestry =>
+      (iteratedAffineCellMap n ancestry).comp (affineFlagContinuousMap n n F)
+
+@[simp]
+public theorem iteratedAffineCellMap_nil (n : ℕ) :
+    iteratedAffineCellMap n [] = ContinuousMap.id _ :=
+  rfl
+
+@[simp]
+public theorem iteratedAffineCellMap_cons
+    (n : ℕ) (F : TopAffineFlag n) (ancestry : List (TopAffineFlag n)) :
+    iteratedAffineCellMap n (F :: ancestry) =
+      (iteratedAffineCellMap n ancestry).comp
+        (affineFlagContinuousMap n n F) :=
+  rfl
+
+/-- The exact relative contraction assertion needed to iterate the one-cell estimate.  It is
+restricted to the explicitly affine parent maps built from flag ancestries: subdividing inside
+such a parent cell multiplies that parent's diameter by at most the standard barycentric factor.
+No assertion is made for arbitrary continuous parent maps. -/
+public def AffineFlagRelativeMeshContraction (n : ℕ) : Prop :=
+  ∀ (ancestry : List (TopAffineFlag n)) (F : TopAffineFlag n),
+    Metric.diam (Set.range
+      ((iteratedAffineCellMap n ancestry).comp
+        (affineFlagContinuousMap n n F))) ≤
+      barycentricContractionFactor n *
+        Metric.diam (Set.range (iteratedAffineCellMap n ancestry))
+
+/-- The proven one-step estimate is the root case of relative mesh contraction. -/
+public theorem affineFlagRelativeMeshContraction_at_identity
+    (n : ℕ) (hn : 1 ≤ n) (F : TopAffineFlag n) :
+    Metric.diam (Set.range
+      ((ContinuousMap.id _).comp (affineFlagContinuousMap n n F))) ≤
+      barycentricContractionFactor n *
+        Metric.diam (Set.range (ContinuousMap.id
+          (stdSimplex ℝ (Fin (n + 1))))) := by
+  have hid : Set.range (ContinuousMap.id
+      (stdSimplex ℝ (Fin (n + 1)))) = Set.univ := by
+    ext w
+    simp
+  rw [ContinuousMap.id_comp, hid, diam_univ_stdSimplex n hn, mul_one]
+  exact diam_range_affineFlagContinuousMap_le n n hn F
+
+/-- Under relative contraction, an affine cell at ancestry depth `m` has diameter at most the
+`m`th power of the barycentric factor. -/
+public theorem diam_range_iteratedAffineCellMap_le_pow
+    (n : ℕ) (hn : 1 ≤ n) (hrelative : AffineFlagRelativeMeshContraction n)
+    (ancestry : List (TopAffineFlag n)) :
+    Metric.diam (Set.range (iteratedAffineCellMap n ancestry)) ≤
+      barycentricContractionFactor n ^ ancestry.length := by
+  induction ancestry with
+  | nil =>
+      rw [iteratedAffineCellMap_nil, List.length_nil, pow_zero]
+      have hid : Set.range (ContinuousMap.id
+          (stdSimplex ℝ (Fin (n + 1)))) = Set.univ := by
+        ext w
+        simp
+      rw [hid, diam_univ_stdSimplex n hn]
+  | cons F ancestry ih =>
+      calc
+        Metric.diam (Set.range (iteratedAffineCellMap n (F :: ancestry))) ≤
+            barycentricContractionFactor n *
+              Metric.diam (Set.range (iteratedAffineCellMap n ancestry)) := by
+          simpa only [iteratedAffineCellMap_cons] using
+            hrelative ancestry F
+        _ ≤ barycentricContractionFactor n *
+              barycentricContractionFactor n ^ ancestry.length :=
+          mul_le_mul_of_nonneg_left ih (barycentricContractionFactor_nonneg n)
+        _ = barycentricContractionFactor n ^ (F :: ancestry).length := by
+          simp only [List.length_cons, pow_succ]
+          ring
+
+/-- Relative mesh contraction gives a common ancestry depth at which every iterated affine cell
+of a fixed singular simplex is carried into one member of an arbitrary open cover. -/
+public theorem exists_iteratedAffineCell_depth_subordinate
+    {ι : Type} (X : TopCat.{0}) (U : ι → Set X)
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (n : ℕ) (hn : 1 ≤ n)
+    (hrelative : AffineFlagRelativeMeshContraction n)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    ∃ m : ℕ, ∀ ancestry : List (TopAffineFlag n), ancestry.length = m →
+      ∃ i, X.toSSetObjEquiv _ x ''
+        Set.range (iteratedAffineCellMap n ancestry) ⊆ U i := by
+  obtain ⟨δ, hδ, hLeb⟩ :=
+    singularSimplex_openCover_lebesgueNumber X U hUopen hUcover n x
+  obtain ⟨m, hm⟩ := exists_barycentricContractionFactor_pow_lt n hδ
+  refine ⟨m, fun ancestry hlength ↦ ?_⟩
+  let s : Set (stdSimplex ℝ (Fin (n + 1))) :=
+    Set.range (iteratedAffineCellMap n ancestry)
+  let w₀ : stdSimplex ℝ (Fin (n + 1)) := Classical.arbitrary _
+  obtain ⟨i, hi⟩ := hLeb (iteratedAffineCellMap n ancestry w₀)
+  refine ⟨i, ?_⟩
+  rintro _ ⟨y, ⟨w, rfl⟩, rfl⟩
+  apply hi
+  rw [Metric.mem_ball]
+  have hsbounded : Bornology.IsBounded s :=
+    isCompact_univ.isBounded.subset (Set.subset_univ s)
+  exact (Metric.dist_le_diam_of_mem hsbounded
+    (show iteratedAffineCellMap n ancestry w ∈ s from ⟨w, rfl⟩)
+    (show iteratedAffineCellMap n ancestry w₀ ∈ s from ⟨w₀, rfl⟩)).trans_lt
+      ((diam_range_iteratedAffineCellMap_le_pow n hn hrelative ancestry).trans_lt
+        (hlength.symm ▸ hm))
+
+/-- Abstract eventual-smallness theorem for iterated cells.  Once a concrete subdivision model
+supplies nonempty cells with the displayed power-law diameter bound, a single depth works for all
+cells and makes each of them lie in one member of any open cover. -/
+public theorem exists_depth_for_diameter_controlled_cells_subordinate
+    {X α ι : Type*} [PseudoMetricSpace X] [CompactSpace X]
+    (n : ℕ) (U : ι → Set X) (hUopen : ∀ i, IsOpen (U i))
+    (hUcover : (Set.univ : Set X) ⊆ ⋃ i, U i)
+    (cell : ℕ → α → Set X)
+    (hcell : ∀ m a, (cell m a).Nonempty)
+    (hdiam : ∀ m a, Metric.diam (cell m a) ≤
+      barycentricContractionFactor n ^ m) :
+    ∃ m : ℕ, ∀ a : α, ∃ i : ι, cell m a ⊆ U i := by
+  obtain ⟨δ, hδ, hball⟩ :=
+    lebesgue_number_lemma_of_metric isCompact_univ hUopen hUcover
+  obtain ⟨m, hm⟩ := exists_barycentricContractionFactor_pow_lt n hδ
+  refine ⟨m, fun a ↦ ?_⟩
+  obtain ⟨x, hx⟩ := hcell m a
+  obtain ⟨i, hi⟩ := hball x (Set.mem_univ x)
+  refine ⟨i, fun y hy ↦ hi ?_⟩
+  rw [Metric.mem_ball]
+  exact (Metric.dist_le_diam_of_mem
+    (isCompact_univ.isBounded.subset (Set.subset_univ _)) hy hx).trans_lt
+      ((hdiam m a).trans_lt hm)
+
+/-! ## Chain-level endpoint -/
+
+/-- Iterating affine subdivision is additive in the exponent.  This synchronization identity is
+the algebraic tool for putting finitely many generatorwise subdivision depths over one common
+depth. -/
+public theorem affineSingularSubdivisionIterate_add
+    (X : TopCat) (m r : ℕ) :
+    affineSingularSubdivisionIterate X (m + r) =
+      affineSingularSubdivisionIterate X m ≫
+        affineSingularSubdivisionIterate X r := by
+  induction r with
+  | zero => simp
+  | succ r ih =>
+      rw [Nat.add_succ, affineSingularSubdivisionIterate_succ, ih,
+        affineSingularSubdivisionIterate_succ, Category.assoc]
+
+/-- A sharply stated range bridge from geometry to the algebraic small-chain endpoint: it is
+enough to prove that some affine-subdivision iterate of every chain lies in the degreewise range
+of the cover-small inclusion. -/
+public theorem coverSmallAffineSubdivisionEventuallySmall_of_iterate_mem_range
+    {iota : Type} (X : TopCat) (U : iota → Set X)
+    (h : ∀ (n : ℕ) (x : (IntegralSingularChainComplexObj X).X n),
+      ∃ m : ℕ, (affineSingularSubdivisionIterate X m).f n x ∈
+        Set.range ((coverSmallIntegralSingularChainInclusion X U).f n)) :
+    CoverSmallAffineSubdivisionEventuallySmall X U := by
+  intro n x
+  obtain ⟨m, y, hy⟩ := h n x
+  exact ⟨m, y, hy⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularAffineSubdivisionRelativeMesh.lean
+++ b/SphereSixComplex/Topology/SingularAffineSubdivisionRelativeMesh.lean
@@ -1,0 +1,488 @@
+module
+
+public import SphereSixComplex.Topology.SingularAffineSubdivisionMesh
+
+/-!
+# Relative mesh estimates for affine barycentric subdivision
+
+This file proves the relative (rather than merely intrinsic) mesh estimate.  If the vertices of
+an affine parent simplex are `p i`, then the images of the barycenters in any flag of nested
+nonempty faces have diameter at most `n / (n + 1)` times the diameter of the parent vertices.
+The result is stated first in an arbitrary real normed vector space and then specialized to the
+affine self-maps used by iterated singular subdivision.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits PartialOrder Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The centroid of the vertices indexed by a nonempty face. -/
+public noncomputable def affineParentFaceCentroid
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {n : ℕ} (p : Fin (n + 1) → E)
+    (A : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) : E :=
+  A.finset.centroid ℝ (fun i ↦ p i.down)
+
+public theorem affineParentFaceCentroid_eq_smul_sum
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {n : ℕ} (p : Fin (n + 1) → E)
+    (A : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) :
+    affineParentFaceCentroid p A =
+      (A.finset.card : ℝ)⁻¹ • ∑ i ∈ A.finset, p i.down := by
+  unfold affineParentFaceCentroid
+  rw [Finset.centroid_def, Finset.affineCombination_eq_linear_combination]
+  · simp only [Finset.centroidWeights_apply, Finset.smul_sum]
+  · exact A.finset.sum_centroidWeights_eq_one_of_nonempty ℝ A.nonempty
+
+/-- A face centroid belongs to the convex hull of the parent vertices. -/
+public theorem affineParentFaceCentroid_mem_convexHull
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {n : ℕ} (p : Fin (n + 1) → E)
+    (A : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) :
+    affineParentFaceCentroid p A ∈ convexHull ℝ (Set.range p) := by
+  unfold affineParentFaceCentroid
+  rw [Finset.centroid_def]
+  have h := affineCombination_mem_convexHull
+    (s := A.finset) (v := fun i ↦ p i.down)
+    (w := A.finset.centroidWeights ℝ)
+    (fun i hi ↦ by simp only [Finset.centroidWeights_apply]; positivity)
+    (A.finset.sum_centroidWeights_eq_one_of_nonempty ℝ A.nonempty)
+  have hrange : Set.range (fun i : ULift.{0} (Fin (n + 1)) ↦ p i.down) =
+      Set.range p := by
+    ext x
+    constructor
+    · rintro ⟨i, rfl⟩
+      exact ⟨i.down, rfl⟩
+    · rintro ⟨i, rfl⟩
+      exact ⟨ULift.up i, rfl⟩
+  rwa [hrange] at h
+
+/-- Translation formula for a parent-face centroid, in vector-space notation. -/
+public theorem affineParentFaceCentroid_sub
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {n : ℕ} (p : Fin (n + 1) → E)
+    (A : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) (c : E) :
+    affineParentFaceCentroid p A - c =
+      (A.finset.card : ℝ)⁻¹ • ∑ i ∈ A.finset, (p i.down - c) := by
+  calc
+    affineParentFaceCentroid p A - c =
+        affineParentFaceCentroid (fun i ↦ p i - c) A := by
+      unfold affineParentFaceCentroid
+      simpa only [vsub_eq_sub] using
+        (A.finset.centroid_vsub_const ℝ
+          (p := fun i ↦ p i.down) (p₀ := c) A.nonempty)
+    _ = _ := affineParentFaceCentroid_eq_smul_sum _ _
+
+/-- The unnormalized displacement vectors from a face centroid sum to zero. -/
+public theorem sum_sub_affineParentFaceCentroid_eq_zero
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {n : ℕ} (p : Fin (n + 1) → E)
+    (A : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) :
+    ∑ i ∈ A.finset, (p i.down - affineParentFaceCentroid p A) = 0 := by
+  have h : (A.finset.card : ℝ)⁻¹ •
+      (∑ i ∈ A.finset, (p i.down - affineParentFaceCentroid p A)) = 0 := by
+    rw [← affineParentFaceCentroid_sub]
+    exact sub_self _
+  have hcard : (A.finset.card : ℝ) ≠ 0 := by
+    exact_mod_cast (Nat.ne_of_gt A.nonempty.card_pos)
+  simpa [hcard] using h
+
+/-- The proportion of vertices introduced between nested nonempty faces is bounded by the
+barycentric contraction factor. -/
+public theorem card_sub_div_card_le_barycentricContractionFactor
+    (n a b : ℕ) (ha : 1 ≤ a) (hab : a ≤ b) (hb : b ≤ n + 1) :
+    ((b - a : ℕ) : ℝ) / (b : ℝ) ≤ barycentricContractionFactor n := by
+  have haR : (1 : ℝ) ≤ a := by exact_mod_cast ha
+  have habR : (a : ℝ) ≤ b := by exact_mod_cast hab
+  have hbR : (b : ℝ) ≤ n + 1 := by exact_mod_cast hb
+  have hbpos : (0 : ℝ) < b := lt_of_lt_of_le zero_lt_one (haR.trans habR)
+  have hnpos : (0 : ℝ) < n + 1 := by positivity
+  have hone_div_b_le : (1 : ℝ) / b ≤ a / b :=
+    div_le_div_of_nonneg_right haR hbpos.le
+  have hone_div_N_le : (1 : ℝ) / (n + 1) ≤ 1 / b := by
+    exact one_div_le_one_div_of_le hbpos hbR
+  have hratio : (1 : ℝ) / (n + 1) ≤ a / b :=
+    hone_div_N_le.trans hone_div_b_le
+  have hcast : ((b - a : ℕ) : ℝ) = (b : ℝ) - a := by
+    exact_mod_cast (Nat.cast_sub hab : ((b - a : ℕ) : ℝ) = b - a)
+  have hlhs : ((b : ℝ) - a) / b = 1 - a / b := by
+    field_simp
+  have hrhs : barycentricContractionFactor n = 1 - 1 / (n + 1 : ℝ) := by
+    unfold barycentricContractionFactor
+    field_simp
+    ring
+  rw [hcast, hlhs, hrhs]
+  linarith
+
+/-- Centroids of two nested nonempty faces contract by the standard barycentric factor, measured
+relative to the diameter of the arbitrary affine parent vertex family. -/
+public theorem dist_affineParentFaceCentroid_le
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (n : ℕ) (p : Fin (n + 1) → E)
+    (A B : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) (hAB : A ≤ B) :
+    dist (affineParentFaceCentroid p A) (affineParentFaceCentroid p B) ≤
+      barycentricContractionFactor n * Metric.diam (Set.range p) := by
+  classical
+  let cA := affineParentFaceCentroid p A
+  let D := Metric.diam (Set.range p)
+  have hbpos : (0 : ℝ) < B.finset.card := by
+    exact_mod_cast B.nonempty.card_pos
+  have hbinv : 0 ≤ (B.finset.card : ℝ)⁻¹ := by positivity
+  have hAsum : ∑ i ∈ A.finset, (p i.down - cA) = 0 := by
+    exact sum_sub_affineParentFaceCentroid_eq_zero p A
+  have hBsum : ∑ i ∈ B.finset, (p i.down - cA) =
+      ∑ i ∈ B.finset \ A.finset, (p i.down - cA) := by
+    rw [← Finset.sum_sdiff hAB, hAsum, add_zero]
+  have hconvexBounded : Bornology.IsBounded (convexHull ℝ (Set.range p)) := by
+    rw [isBounded_convexHull]
+    exact (Set.finite_range p).isBounded
+  have hterm (i : ULift.{0} (Fin (n + 1))) :
+      ‖p i.down - cA‖ ≤ D := by
+    have hp : p i.down ∈ convexHull ℝ (Set.range p) :=
+      (subset_convexHull ℝ (Set.range p)) (Set.mem_range_self i.down)
+    have hc : cA ∈ convexHull ℝ (Set.range p) :=
+      affineParentFaceCentroid_mem_convexHull p A
+    have hdist := Metric.dist_le_diam_of_mem hconvexBounded hp hc
+    rw [convexHull_diam] at hdist
+    simpa only [dist_eq_norm] using hdist
+  rw [dist_comm, dist_eq_norm, affineParentFaceCentroid_sub, hBsum, norm_smul,
+    Real.norm_eq_abs, abs_of_pos (inv_pos.mpr hbpos)]
+  calc
+    (B.finset.card : ℝ)⁻¹ *
+          ‖∑ i ∈ B.finset \ A.finset, (p i.down - cA)‖ ≤
+        (B.finset.card : ℝ)⁻¹ *
+          ∑ i ∈ B.finset \ A.finset, ‖p i.down - cA‖ :=
+      mul_le_mul_of_nonneg_left (norm_sum_le _ _) hbinv
+    _ ≤ (B.finset.card : ℝ)⁻¹ *
+          ∑ _i ∈ B.finset \ A.finset, D := by
+      apply mul_le_mul_of_nonneg_left _ hbinv
+      exact Finset.sum_le_sum fun i _ ↦ hterm i
+    _ = (((B.finset \ A.finset).card : ℝ) / B.finset.card) * D := by
+      rw [Finset.sum_const, nsmul_eq_mul]
+      ring
+    _ = (((B.finset.card - A.finset.card : ℕ) : ℝ) /
+          B.finset.card) * D := by
+      rw [Finset.card_sdiff_of_subset hAB]
+    _ ≤ barycentricContractionFactor n * D := by
+      apply mul_le_mul_of_nonneg_right _ (Metric.diam_nonneg)
+      exact card_sub_div_card_le_barycentricContractionFactor n
+        A.finset.card B.finset.card A.nonempty.card_pos
+        (Finset.card_le_card hAB) (by simpa using B.finset.card_le_univ)
+
+/-- The affine combination of a family in a real normed vector space. -/
+public noncomputable def normedAffineCombination
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {I : Type*} [Fintype I] (p : I → E) (w : stdSimplex ℝ I) : E :=
+  ∑ i, w i • p i
+
+/-- Evaluating an affine parent on a face barycenter gives the centroid of the corresponding
+parent vertices. -/
+public theorem normedAffineCombination_nonemptyFiniteChainBarycenter
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {n : ℕ} (p : Fin (n + 1) → E)
+    (A : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) :
+    normedAffineCombination p (nonemptyFiniteChainBarycenter A) =
+      affineParentFaceCentroid p A := by
+  classical
+  rw [affineParentFaceCentroid_eq_smul_sum]
+  unfold normedAffineCombination
+  simp only [nonemptyFiniteChainBarycenter_apply, ite_smul, zero_smul]
+  rw [Finset.sum_ite]
+  simp only [Finset.sum_const_zero, add_zero]
+  rw [Finset.smul_sum]
+  rw [← A.finset.sum_attach]
+  symm
+  apply Finset.sum_bij (fun i _ ↦ i.1.down)
+  · intro i hi
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact i.2
+  · intro i₁ hi₁ i₂ hi₂ h
+    apply Subtype.ext
+    exact ULift.down_injective h
+  · intro i hi
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi
+    exact ⟨⟨ULift.up i, hi⟩, Finset.mem_attach _ _, rfl⟩
+  · intro i hi
+    rfl
+
+/-- Applying an affine parent after a flag simplex is the affine combination of the images of
+the flag's barycenter vertices. -/
+public theorem normedAffineCombination_affineFlagContinuousMap
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (n k : ℕ) (p : Fin (n + 1) → E)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k)))
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    normedAffineCombination p (affineFlagContinuousMap n k F w) =
+      normedAffineCombination
+        (fun j ↦ affineParentFaceCentroid p (F.obj j)) w := by
+  classical
+  unfold normedAffineCombination affineFlagContinuousMap
+  change (∑ i, (∑ j, w j * nonemptyFiniteChainBarycenter (F.obj j) i) • p i) =
+    ∑ j, w j • affineParentFaceCentroid p (F.obj j)
+  simp_rw [← normedAffineCombination_nonemptyFiniteChainBarycenter p (F.obj _)]
+  unfold normedAffineCombination
+  simp only [Finset.sum_smul, Finset.smul_sum, mul_smul]
+  rw [Finset.sum_comm]
+
+/-- The parent images of the barycenter vertices in an affine flag. -/
+public noncomputable def affineParentFlagVertexSet
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (n k : ℕ) (p : Fin (n + 1) → E)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) : Set E :=
+  Set.range fun j ↦ affineParentFaceCentroid p (F.obj j)
+
+/-- The vertices of a subdivided affine parent satisfy the relative mesh estimate. -/
+public theorem diam_affineParentFlagVertexSet_le
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (n k : ℕ) (p : Fin (n + 1) → E)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Metric.diam (affineParentFlagVertexSet n k p F) ≤
+      barycentricContractionFactor n * Metric.diam (Set.range p) := by
+  apply Metric.diam_le_of_forall_dist_le
+    (mul_nonneg (barycentricContractionFactor_nonneg n) Metric.diam_nonneg)
+  rintro _ ⟨i, rfl⟩ _ ⟨j, rfl⟩
+  rcases le_total i j with hij | hji
+  · exact dist_affineParentFaceCentroid_le n p _ _
+      (CategoryTheory.leOfHom (F.map (CategoryTheory.homOfLE hij)))
+  · simpa [dist_comm] using
+      dist_affineParentFaceCentroid_le n p _ _
+        (CategoryTheory.leOfHom (F.map (CategoryTheory.homOfLE hji)))
+
+/-- Every point in the subdivided affine parent lies in the convex hull of its new vertices. -/
+public theorem normedAffineCombination_affineFlag_mem_convexHull_vertices
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (n k : ℕ) (p : Fin (n + 1) → E)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k)))
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    normedAffineCombination p (affineFlagContinuousMap n k F w) ∈
+      convexHull ℝ (affineParentFlagVertexSet n k p F) := by
+  rw [normedAffineCombination_affineFlagContinuousMap]
+  unfold normedAffineCombination
+  have hmem := (convex_convexHull ℝ (affineParentFlagVertexSet n k p F)).sum_mem
+    (t := Finset.univ) (w := fun j ↦ w j)
+    (z := fun j ↦ affineParentFaceCentroid p (F.obj j))
+    (fun j _ ↦ w.2.1 j) w.2.2
+    (fun j _ ↦ subset_convexHull ℝ
+      (affineParentFlagVertexSet n k p F) ⟨j, rfl⟩)
+  simpa only [smul_eq_mul] using hmem
+
+/-- Diameter form of the relative mesh estimate for an arbitrary affine parent in a normed
+vector space. -/
+public theorem diam_range_normedAffineCombination_affineFlag_le
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (n k : ℕ) (p : Fin (n + 1) → E)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Metric.diam (Set.range fun w ↦
+      normedAffineCombination p (affineFlagContinuousMap n k F w)) ≤
+      barycentricContractionFactor n * Metric.diam (Set.range p) := by
+  calc
+    Metric.diam (Set.range fun w ↦
+        normedAffineCombination p (affineFlagContinuousMap n k F w)) ≤
+        Metric.diam (convexHull ℝ (affineParentFlagVertexSet n k p F)) := by
+      apply Metric.diam_mono
+      · rintro _ ⟨w, rfl⟩
+        exact normedAffineCombination_affineFlag_mem_convexHull_vertices n k p F w
+      · rw [isBounded_convexHull]
+        exact (Set.finite_range fun j ↦ affineParentFaceCentroid p (F.obj j)).isBounded
+    _ = Metric.diam (affineParentFlagVertexSet n k p F) :=
+      convexHull_diam _
+    _ ≤ _ := diam_affineParentFlagVertexSet_le n k p F
+
+/-- An affine combination evaluated at a standard-simplex vertex returns that vertex's image. -/
+@[simp]
+public theorem stdSimplexAffineCombination_vertex
+    {X Y : Type*} [Fintype X] [Fintype Y] [DecidableEq X]
+    (p : X → stdSimplex ℝ Y) (i : X) :
+    stdSimplexAffineCombination p (stdSimplex.vertex i) = p i := by
+  classical
+  ext y
+  simp [stdSimplexAffineCombination_apply, Pi.single_apply]
+
+/-- Coercing a standard-simplex affine combination to its ambient vector space gives the
+corresponding normed-space affine combination. -/
+public theorem coe_stdSimplexAffineCombination_eq_normedAffineCombination
+    {X Y : Type*} [Fintype X] [Fintype Y]
+    (p : X → stdSimplex ℝ Y) (w : stdSimplex ℝ X) :
+    (stdSimplexAffineCombination p w : Y → ℝ) =
+      normedAffineCombination (fun i ↦ (p i : Y → ℝ)) w := by
+  ext y
+  simp only [stdSimplexAffineCombination_apply, normedAffineCombination,
+    Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+
+/-- The affine map determined by vertices in a standard simplex. -/
+public noncomputable def affineParentContinuousMap
+    {X Y : Type*} [Fintype X] [Fintype Y]
+    (p : X → stdSimplex ℝ Y) :
+    C(stdSimplex ℝ X, stdSimplex ℝ Y) :=
+  ⟨stdSimplexAffineCombination p, continuous_stdSimplexAffineCombination p⟩
+
+/-- Subdividing an arbitrary affine parent simplex contracts its image diameter by at most the
+standard barycentric factor. -/
+public theorem diam_range_affineParentContinuousMap_comp_affineFlag_le
+    (n k : ℕ) (p : Fin (n + 1) → stdSimplex ℝ (Fin (n + 1)))
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    Metric.diam (Set.range
+      ((affineParentContinuousMap p).comp (affineFlagContinuousMap n k F))) ≤
+      barycentricContractionFactor n *
+        Metric.diam (Set.range (affineParentContinuousMap p)) := by
+  classical
+  let p' : Fin (n + 1) → (Fin (n + 1) → ℝ) :=
+    fun i ↦ (p i : Fin (n + 1) → ℝ)
+  let s : Set (Fin (n + 1) → ℝ) := Set.range fun w ↦
+    normedAffineCombination p' (affineFlagContinuousMap n k F w)
+  have hsbounded : Bornology.IsBounded s := by
+    apply (show Bornology.IsBounded
+      (convexHull ℝ (affineParentFlagVertexSet n k p' F)) by
+        rw [isBounded_convexHull]
+        exact (Set.finite_range fun j ↦
+          affineParentFaceCentroid p' (F.obj j)).isBounded).subset
+    rintro _ ⟨w, rfl⟩
+    exact normedAffineCombination_affineFlag_mem_convexHull_vertices n k p' F w
+  have hpoint (w w' : stdSimplex ℝ (Fin (k + 1))) :
+      dist (normedAffineCombination p' (affineFlagContinuousMap n k F w))
+          (normedAffineCombination p' (affineFlagContinuousMap n k F w')) ≤
+        barycentricContractionFactor n * Metric.diam (Set.range p') := by
+    exact (Metric.dist_le_diam_of_mem hsbounded ⟨w, rfl⟩ ⟨w', rfl⟩).trans
+      (diam_range_normedAffineCombination_affineFlag_le n k p' F)
+  have hpdiam : Metric.diam (Set.range p') = Metric.diam (Set.range p) := by
+    have himage :
+        (Subtype.val : stdSimplex ℝ (Fin (n + 1)) → Fin (n + 1) → ℝ) ''
+            Set.range p = Set.range p' := by
+      ext x
+      constructor
+      · rintro ⟨_, ⟨i, rfl⟩, rfl⟩
+        exact ⟨i, rfl⟩
+      · rintro ⟨i, rfl⟩
+        exact ⟨p i, ⟨i, rfl⟩, rfl⟩
+    rw [← himage, isometry_subtype_coe.diam_image]
+  have hvertices : Set.range p ⊆ Set.range (affineParentContinuousMap p) := by
+    rintro _ ⟨i, rfl⟩
+    exact ⟨stdSimplex.vertex i, stdSimplexAffineCombination_vertex p i⟩
+  have hparentdiam : Metric.diam (Set.range p) ≤
+      Metric.diam (Set.range (affineParentContinuousMap p)) := by
+    apply Metric.diam_mono hvertices
+    exact isCompact_univ.isBounded.subset (Set.subset_univ _)
+  apply Metric.diam_le_of_forall_dist_le
+    (mul_nonneg (barycentricContractionFactor_nonneg n) Metric.diam_nonneg)
+  rintro _ ⟨w, rfl⟩ _ ⟨w', rfl⟩
+  change dist
+      (stdSimplexAffineCombination p (affineFlagContinuousMap n k F w) :
+        Fin (n + 1) → ℝ)
+      (stdSimplexAffineCombination p (affineFlagContinuousMap n k F w') :
+        Fin (n + 1) → ℝ) ≤ _
+  rw [coe_stdSimplexAffineCombination_eq_normedAffineCombination,
+    coe_stdSimplexAffineCombination_eq_normedAffineCombination]
+  change dist
+      (normedAffineCombination p' (affineFlagContinuousMap n k F w))
+      (normedAffineCombination p' (affineFlagContinuousMap n k F w')) ≤ _
+  exact (hpoint w w').trans <| by
+    rw [hpdiam]
+    exact mul_le_mul_of_nonneg_left hparentdiam
+      (barycentricContractionFactor_nonneg n)
+
+/-- Associativity of standard-simplex affine combinations. -/
+public theorem stdSimplexAffineCombination_assoc
+    {I J K : Type*} [Fintype I] [Fintype J] [Fintype K]
+    (p : I → stdSimplex ℝ K) (q : J → stdSimplex ℝ I)
+    (w : stdSimplex ℝ J) :
+    stdSimplexAffineCombination p (stdSimplexAffineCombination q w) =
+      stdSimplexAffineCombination
+        (fun j ↦ stdSimplexAffineCombination p (q j)) w := by
+  classical
+  ext z
+  simp only [stdSimplexAffineCombination_apply]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  apply Finset.sum_congr rfl
+  intro i _
+  ring
+
+/-- Composition of two explicitly affine standard-simplex maps is explicitly affine. -/
+public theorem affineParentContinuousMap_comp
+    {I J K : Type*} [Fintype I] [Fintype J] [Fintype K]
+    (p : I → stdSimplex ℝ K) (q : J → stdSimplex ℝ I) :
+    (affineParentContinuousMap p).comp (affineParentContinuousMap q) =
+      affineParentContinuousMap
+        (fun j ↦ affineParentContinuousMap p (q j)) := by
+  apply ContinuousMap.ext
+  intro w
+  exact stdSimplexAffineCombination_assoc p q w
+
+/-- The flag map itself is the affine map determined by its face-barycenter vertices. -/
+public theorem affineFlagContinuousMap_eq_affineParentContinuousMap
+    (n k : ℕ)
+    (F : (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).obj
+      (Opposite.op (SimplexCategory.mk k))) :
+    affineFlagContinuousMap n k F =
+      affineParentContinuousMap
+        (fun j ↦ nonemptyFiniteChainBarycenter (F.obj j)) :=
+  rfl
+
+/-- An iterated affine cell is still the affine map determined by the images of the original
+vertices. -/
+public theorem iteratedAffineCellMap_eq_affineParentContinuousMap_vertices
+    (n : ℕ) (ancestry : List (TopAffineFlag n)) :
+    iteratedAffineCellMap n ancestry =
+      affineParentContinuousMap
+        (fun i ↦ iteratedAffineCellMap n ancestry (stdSimplex.vertex i)) := by
+  classical
+  induction ancestry with
+  | nil =>
+      apply ContinuousMap.ext
+      intro w
+      ext y
+      simp [affineParentContinuousMap, stdSimplexAffineCombination_apply,
+        Pi.single_apply]
+  | cons F ancestry ih =>
+      rw [iteratedAffineCellMap_cons, ih,
+        affineFlagContinuousMap_eq_affineParentContinuousMap,
+        affineParentContinuousMap_comp]
+      congr 1
+      funext i
+      simp [affineParentContinuousMap]
+
+/-- The relative mesh contraction property required by the iterated-cell argument holds
+unconditionally for every positive-dimensional standard simplex. -/
+public theorem affineFlagRelativeMeshContraction
+    (n : ℕ) : AffineFlagRelativeMeshContraction n := by
+  intro ancestry F
+  rw [iteratedAffineCellMap_eq_affineParentContinuousMap_vertices n ancestry]
+  exact diam_range_affineParentContinuousMap_comp_affineFlag_le n n
+    (fun i ↦ iteratedAffineCellMap n ancestry (stdSimplex.vertex i)) F
+
+/-- Every iterated affine cell satisfies the power-law diameter bound, with no relative-mesh
+hypothesis left to discharge. -/
+public theorem diam_range_iteratedAffineCellMap_le_pow_unconditional
+    (n : ℕ) (hn : 1 ≤ n) (ancestry : List (TopAffineFlag n)) :
+    Metric.diam (Set.range (iteratedAffineCellMap n ancestry)) ≤
+      barycentricContractionFactor n ^ ancestry.length :=
+  diam_range_iteratedAffineCellMap_le_pow n hn
+    (affineFlagRelativeMeshContraction n) ancestry
+
+/-- At a common sufficiently large ancestry depth, every iterated affine cell of a singular
+simplex is subordinate to a prescribed open cover. -/
+public theorem exists_iteratedAffineCell_depth_subordinate_unconditional
+    {ι : Type} (X : TopCat.{0}) (U : ι → Set X)
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (n : ℕ) (hn : 1 ≤ n)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    ∃ m : ℕ, ∀ ancestry : List (TopAffineFlag n), ancestry.length = m →
+      ∃ i, X.toSSetObjEquiv _ x ''
+        Set.range (iteratedAffineCellMap n ancestry) ⊆ U i :=
+  exists_iteratedAffineCell_depth_subordinate X U hUopen hUcover n hn
+    (affineFlagRelativeMeshContraction n) x
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularAffineSubdivisionSupport.lean
+++ b/SphereSixComplex/Topology/SingularAffineSubdivisionSupport.lean
@@ -1,0 +1,523 @@
+module
+
+public import SphereSixComplex.Topology.SingularAffineSubdivisionMesh
+public import Mathlib.Algebra.FreeAbelianGroup.Finsupp
+
+/-!
+# Support of iterated affine subdivision
+
+This file connects the permutation expansion of affine barycentric subdivision with the
+geometric ancestry cells used in the mesh estimate.  It then lifts an iterate whose ancestry
+cells are subordinate to a cover into the cover-small singular chain complex.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The singular simplex obtained by restricting `x` to one iterated affine ancestry cell. -/
+public noncomputable def iteratedAffineCellSingularSimplex
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (ancestry : List (TopAffineFlag n)) :
+    (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)) :=
+  (X.toSSetObjEquiv _).symm
+    ((X.toSSetObjEquiv _ x).comp (iteratedAffineCellMap n ancestry))
+
+@[simp]
+public theorem toSSetObjEquiv_iteratedAffineCellSingularSimplex_apply
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (ancestry : List (TopAffineFlag n))
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    X.toSSetObjEquiv _
+        (iteratedAffineCellSingularSimplex X n x ancestry) w =
+      X.toSSetObjEquiv _ x (iteratedAffineCellMap n ancestry w) := by
+  rfl
+
+@[simp]
+public theorem iteratedAffineCellSingularSimplex_nil
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    iteratedAffineCellSingularSimplex X n x [] = x := by
+  apply (X.toSSetObjEquiv _).injective
+  rfl
+
+/-- Adding the newest flag to an ancestry is the same as restricting the parent cell by that
+affine flag. -/
+public theorem iteratedAffineCellSingularSimplex_cons
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (F : TopAffineFlag n) (ancestry : List (TopAffineFlag n)) :
+    iteratedAffineCellSingularSimplex X n x (F :: ancestry) =
+      (TopCat.toSSet.map
+        (singularSimplexTopCatMap X n
+          (iteratedAffineCellSingularSimplex X n x ancestry))).app _
+        (affineFlagSingularSimplex n n F) := by
+  apply (X.toSSetObjEquiv _).injective
+  apply ContinuousMap.ext
+  intro w
+  rfl
+
+/-- Restricting a parent ancestry cell by one more flag adds that flag at the head of the
+ancestry. -/
+public theorem iteratedAffineCellSingularSimplex_singleton_parent
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (F : TopAffineFlag n) (ancestry : List (TopAffineFlag n)) :
+    iteratedAffineCellSingularSimplex X n
+        (iteratedAffineCellSingularSimplex X n x ancestry) [F] =
+      iteratedAffineCellSingularSimplex X n x (F :: ancestry) := by
+  calc
+    iteratedAffineCellSingularSimplex X n
+        (iteratedAffineCellSingularSimplex X n x ancestry) [F] =
+        (TopCat.toSSet.map
+          (singularSimplexTopCatMap X n
+            (iteratedAffineCellSingularSimplex X n x ancestry))).app _
+          (affineFlagSingularSimplex n n F) := by
+            rw [iteratedAffineCellSingularSimplex_cons,
+              iteratedAffineCellSingularSimplex_nil]
+    _ = iteratedAffineCellSingularSimplex X n x (F :: ancestry) :=
+      (iteratedAffineCellSingularSimplex_cons X n x F ancestry).symm
+
+/-- One affine subdivision of a generator is exactly the signed sum over permutation maximal
+flags. -/
+public theorem affineSubdivisionSingularSimplexChain_eq_permutation_sum
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    affineSubdivisionSingularSimplexChain X n x =
+      ∑ σ : Equiv.Perm (Fin (n + 1)),
+        permutationSignInteger σ •
+          (TopCat.toSSet.obj X).ιChainComplex
+            (iteratedAffineCellSingularSimplex X n x
+              [permutationMaximalFlagSimplex σ]) := by
+  rw [affineSubdivisionSingularSimplexChain,
+    affineSubdividedSimplexFundamentalChain,
+    subdividedSimplexFundamentalChain, Preadditive.sum_comp,
+    Preadditive.sum_comp]
+  apply Finset.sum_congr rfl
+  intro σ _
+  simp only [Preadditive.zsmul_comp,
+    affineFlagChainMap_f, iota_affineFlagChainComponent,
+    SSet.ι_chainComplexMap_f]
+  apply congrArg (fun f ↦ permutationSignInteger σ • f)
+  rw [iteratedAffineCellSingularSimplex_cons,
+    iteratedAffineCellSingularSimplex_nil]
+
+/-- A depth-`m` choice of one permutation maximal flag at every subdivision stage. -/
+public abbrev AffinePermutationAncestry (n m : ℕ) :=
+  Fin m → Equiv.Perm (Fin (n + 1))
+
+/-- The list of affine flags encoded by a permutation ancestry, newest first. -/
+public noncomputable def affinePermutationAncestryFlags
+    (n m : ℕ) (a : AffinePermutationAncestry n m) :
+    List (TopAffineFlag n) :=
+  List.ofFn fun i ↦ permutationMaximalFlagSimplex (a i)
+
+/-- The product of the orientation signs along a permutation ancestry. -/
+public noncomputable def affinePermutationAncestrySign
+    (n m : ℕ) (a : AffinePermutationAncestry n m) : ℤ :=
+  ∏ i, permutationSignInteger (a i)
+
+@[simp]
+public theorem affinePermutationAncestryFlags_zero
+    (n : ℕ) (a : AffinePermutationAncestry n 0) :
+    affinePermutationAncestryFlags n 0 a = [] := by
+  simp [affinePermutationAncestryFlags]
+
+@[simp]
+public theorem affinePermutationAncestrySign_zero
+    (n : ℕ) (a : AffinePermutationAncestry n 0) :
+    affinePermutationAncestrySign n 0 a = 1 := by
+  simp [affinePermutationAncestrySign]
+
+@[simp]
+public theorem affinePermutationAncestryFlags_cons
+    (n m : ℕ) (σ : Equiv.Perm (Fin (n + 1)))
+    (a : AffinePermutationAncestry n m) :
+    affinePermutationAncestryFlags n (m + 1) (Fin.cons σ a) =
+      permutationMaximalFlagSimplex σ ::
+        affinePermutationAncestryFlags n m a := by
+  simp [affinePermutationAncestryFlags]
+
+@[simp]
+public theorem affinePermutationAncestrySign_cons
+    (n m : ℕ) (σ : Equiv.Perm (Fin (n + 1)))
+    (a : AffinePermutationAncestry n m) :
+    affinePermutationAncestrySign n (m + 1) (Fin.cons σ a) =
+      permutationSignInteger σ * affinePermutationAncestrySign n m a := by
+  simp [affinePermutationAncestrySign, Fin.prod_univ_succ]
+
+/-- The exact generator expansion after `m` affine subdivisions.  Its summands are precisely the
+singular simplices obtained from depth-`m` affine ancestries. -/
+public theorem iota_affineSingularSubdivisionIterate_eq_ancestry_sum
+    (X : TopCat.{0}) (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n))) :
+    ∀ m : ℕ,
+      (TopCat.toSSet.obj X).ιChainComplex x ≫
+          (affineSingularSubdivisionIterate X m).f n =
+        ∑ a : AffinePermutationAncestry n m,
+          affinePermutationAncestrySign n m a •
+            (TopCat.toSSet.obj X).ιChainComplex
+              (iteratedAffineCellSingularSimplex X n x
+                (affinePermutationAncestryFlags n m a)) := by
+  intro m
+  induction m with
+  | zero =>
+      classical
+      simp only [affineSingularSubdivisionIterate_zero]
+      rw [Fintype.sum_unique]
+      simp
+  | succ m ih =>
+      classical
+      rw [affineSingularSubdivisionIterate_succ]
+      change ((TopCat.toSSet.obj X).ιChainComplex x ≫
+          (affineSingularSubdivisionIterate X m).f n) ≫
+            (affineSingularSubdivisionChainMap X).f n = _
+      rw [ih, Preadditive.sum_comp]
+      simp only [Preadditive.zsmul_comp,
+        affineSingularSubdivisionChainMap_f,
+        iota_affineSingularSubdivisionComponent,
+        affineSubdivisionSingularSimplexChain_eq_permutation_sum,
+        Finset.smul_sum, smul_smul]
+      rw [Finset.sum_comm]
+      rw [← Fintype.sum_prod_type']
+      apply Fintype.sum_equiv
+        (Fin.consEquiv (fun _ : Fin (m + 1) ↦
+          Equiv.Perm (Fin (n + 1)))) _ _
+      rintro ⟨σ, a⟩
+      change (affinePermutationAncestrySign n m a *
+          permutationSignInteger σ) • _ =
+        affinePermutationAncestrySign n (m + 1) (Fin.cons σ a) •
+          (TopCat.toSSet.obj X).ιChainComplex
+            (iteratedAffineCellSingularSimplex X n x
+              (affinePermutationAncestryFlags n (m + 1) (Fin.cons σ a)))
+      rw [affinePermutationAncestrySign_cons,
+        affinePermutationAncestryFlags_cons]
+      rw [mul_comm]
+      rw [iteratedAffineCellSingularSimplex_singleton_parent]
+
+section CoverSmall
+
+variable {ι : Type} (X : TopCat.{0}) (U : ι → Set X)
+
+/-- A geometric ancestry cell subordinate to one cover member defines a cover-small singular
+simplex. -/
+public theorem iteratedAffineCellSingularSimplex_mem_coverSmall
+    (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (ancestry : List (TopAffineFlag n))
+    (hsmall : ∃ i, X.toSSetObjEquiv _ x ''
+      Set.range (iteratedAffineCellMap n ancestry) ⊆ U i) :
+    iteratedAffineCellSingularSimplex X n x ancestry ∈
+      (coverSmallSingularSubcomplex X U).obj
+        (Opposite.op (SimplexCategory.mk n)) := by
+  rw [mem_coverSmallSingularSubcomplex_iff_exists_preimage]
+  obtain ⟨i, hi⟩ := hsmall
+  let f : C(stdSimplex ℝ (Fin (n + 1)), U i) :=
+    ⟨fun w ↦
+      ⟨X.toSSetObjEquiv _ x (iteratedAffineCellMap n ancestry w),
+        hi ⟨iteratedAffineCellMap n ancestry w, ⟨w, rfl⟩, rfl⟩⟩,
+      Continuous.subtype_mk
+        ((X.toSSetObjEquiv _ x).continuous.comp
+          (iteratedAffineCellMap n ancestry).continuous) _⟩
+  refine ⟨i, (TopCat.toSSetObjEquiv _ _).symm f, ?_⟩
+  apply (X.toSSetObjEquiv _).injective
+  apply ContinuousMap.ext
+  intro w
+  rfl
+
+/-- The cover-small simplex corresponding to a subordinate ancestry cell. -/
+public noncomputable def coverSmallIteratedAffineCellSimplex
+    (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (ancestry : List (TopAffineFlag n))
+    (hsmall : ∃ i, X.toSSetObjEquiv _ x ''
+      Set.range (iteratedAffineCellMap n ancestry) ⊆ U i) :
+    (coverSmallSingularSubcomplex X U : SSet).obj
+      (Opposite.op (SimplexCategory.mk n)) :=
+  ⟨iteratedAffineCellSingularSimplex X n x ancestry,
+    iteratedAffineCellSingularSimplex_mem_coverSmall X U n x ancestry hsmall⟩
+
+@[simp]
+public theorem coverSmallIteratedAffineCellSimplex_val
+    (n : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (ancestry : List (TopAffineFlag n))
+    (hsmall : ∃ i, X.toSSetObjEquiv _ x ''
+      Set.range (iteratedAffineCellMap n ancestry) ⊆ U i) :
+    (coverSmallIteratedAffineCellSimplex X U n x ancestry hsmall).1 =
+      iteratedAffineCellSingularSimplex X n x ancestry :=
+  rfl
+
+/-- The signed ancestry expansion, lifted generator by generator to cover-small chains. -/
+public noncomputable def coverSmallAffineAncestryLiftChain
+    (n m : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (hsmall : ∀ a : AffinePermutationAncestry n m,
+      ∃ i, X.toSSetObjEquiv _ x ''
+        Set.range (iteratedAffineCellMap n
+          (affinePermutationAncestryFlags n m a)) ⊆ U i) :
+    AddCommGrpCat.of ℤ ⟶
+      (CoverSmallIntegralSingularChainComplex X U).X n :=
+  ∑ a : AffinePermutationAncestry n m,
+    affinePermutationAncestrySign n m a •
+      (coverSmallSingularSubcomplex X U : SSet).ιChainComplex
+        (coverSmallIteratedAffineCellSimplex X U n x
+          (affinePermutationAncestryFlags n m a) (hsmall a))
+
+/-- The lifted ancestry chain maps to the actual affine-subdivision iterate of its original
+generator. -/
+public theorem coverSmallAffineAncestryLiftChain_comp_inclusion
+    (n m : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (hsmall : ∀ a : AffinePermutationAncestry n m,
+      ∃ i, X.toSSetObjEquiv _ x ''
+        Set.range (iteratedAffineCellMap n
+          (affinePermutationAncestryFlags n m a)) ⊆ U i) :
+    coverSmallAffineAncestryLiftChain X U n m x hsmall ≫
+        (coverSmallIntegralSingularChainInclusion X U).f n =
+      (TopCat.toSSet.obj X).ιChainComplex x ≫
+        (affineSingularSubdivisionIterate X m).f n := by
+  change coverSmallAffineAncestryLiftChain X U n m x hsmall ≫
+      (SSet.chainComplexMap (coverSmallSingularSubcomplex X U).ι
+        (AddCommGrpCat.of ℤ)).f n = _
+  rw [coverSmallAffineAncestryLiftChain, Preadditive.sum_comp]
+  simp_rw [Preadditive.zsmul_comp, SSet.ι_chainComplexMap_f]
+  exact (iota_affineSingularSubdivisionIterate_eq_ancestry_sum X n x m).symm
+
+/-- If every depth-`m` ancestry cell of a generator is subordinate to the cover, its subdivided
+chain lies in the degreewise range of the cover-small inclusion. -/
+public theorem affineSingularSubdivisionIterate_generator_mem_range_of_ancestries
+    (n m : ℕ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk n)))
+    (hsmall : ∀ a : AffinePermutationAncestry n m,
+      ∃ i, X.toSSetObjEquiv _ x ''
+        Set.range (iteratedAffineCellMap n
+          (affinePermutationAncestryFlags n m a)) ⊆ U i) :
+    (affineSingularSubdivisionIterate X m).f n
+        ((TopCat.toSSet.obj X).ιChainComplex
+          (R := AddCommGrpCat.of ℤ) x 1) ∈
+      Set.range ((coverSmallIntegralSingularChainInclusion X U).f n) := by
+  refine ⟨coverSmallAffineAncestryLiftChain X U n m x hsmall 1, ?_⟩
+  exact ConcreteCategory.congr_hom
+    (coverSmallAffineAncestryLiftChain_comp_inclusion X U n m x hsmall) 1
+
+@[simp]
+public theorem length_affinePermutationAncestryFlags
+    (n m : ℕ) (a : AffinePermutationAncestry n m) :
+    (affinePermutationAncestryFlags n m a).length = m := by
+  simp [affinePermutationAncestryFlags]
+
+/-- Once an iterate lies in the range of the cover-small inclusion, every later iterate does as
+well. -/
+public theorem affineSingularSubdivisionIterate_mem_range_add
+    (n m r : ℕ)
+    (c : (IntegralSingularChainComplexObj X).X n)
+    (h : (affineSingularSubdivisionIterate X m).f n c ∈
+      Set.range ((coverSmallIntegralSingularChainInclusion X U).f n)) :
+    (affineSingularSubdivisionIterate X (m + r)).f n c ∈
+      Set.range ((coverSmallIntegralSingularChainInclusion X U).f n) := by
+  obtain ⟨y, hy⟩ := h
+  refine ⟨(coverSmallAffineSubdivisionIterate X U r).f n y, ?_⟩
+  have hcomm := ConcreteCategory.congr_hom
+    (congrArg (fun f ↦ f.f n)
+      (coverSmallAffineSubdivisionIterate_comp_inclusion X U r)) y
+  have hmiddle :
+      (affineSingularSubdivisionIterate X r).f n
+          ((coverSmallIntegralSingularChainInclusion X U).f n y) =
+        (affineSingularSubdivisionIterate X r).f n
+          ((affineSingularSubdivisionIterate X m).f n c) :=
+    congrArg ((affineSingularSubdivisionIterate X r).f n) hy
+  have htotal :
+      (affineSingularSubdivisionIterate X r).f n
+          ((affineSingularSubdivisionIterate X m).f n c) =
+        (affineSingularSubdivisionIterate X (m + r)).f n c := by
+    rw [affineSingularSubdivisionIterate_add]
+    rfl
+  exact hcomm.trans (hmiddle.trans htotal)
+
+/-- Chains which become cover-small after some (chain-dependent) number of affine subdivisions
+form an additive subgroup. -/
+public noncomputable def affineSubdivisionEventuallySmallAddSubgroup
+    (n : ℕ) : AddSubgroup ((IntegralSingularChainComplexObj X).X n) where
+  carrier := {c | ∃ m : ℕ,
+    (affineSingularSubdivisionIterate X m).f n c ∈
+      Set.range ((coverSmallIntegralSingularChainInclusion X U).f n)}
+  zero_mem' := by
+    refine ⟨0, 0, ?_⟩
+    exact ((coverSmallIntegralSingularChainInclusion X U).f n).hom.map_zero.trans
+      ((affineSingularSubdivisionIterate X 0).f n).hom.map_zero.symm
+  add_mem' := by
+    rintro c d ⟨m, hm⟩ ⟨r, hr⟩
+    have hm' := affineSingularSubdivisionIterate_mem_range_add
+      X U n m r c hm
+    have hr' := affineSingularSubdivisionIterate_mem_range_add
+      X U n r m d hr
+    rw [Nat.add_comm r m] at hr'
+    obtain ⟨yc, hyc⟩ := hm'
+    obtain ⟨yd, hyd⟩ := hr'
+    refine ⟨m + r, yc + yd, ?_⟩
+    simp only [map_add]
+    rw [hyc, hyd]
+    exact ((affineSingularSubdivisionIterate X (m + r)).f n).hom.map_add c d |>.symm
+  neg_mem' := by
+    rintro c ⟨m, hm⟩
+    obtain ⟨y, hy⟩ := hm
+    refine ⟨m, -y, ?_⟩
+    simp only [map_neg]
+    rw [hy]
+    exact ((affineSingularSubdivisionIterate X m).f n).hom.map_neg c |>.symm
+
+/-- Generatorwise subordinate permutation ancestries suffice for every chain: the required
+subdivision depth may depend on the chain. -/
+public theorem exists_affineSubdivisionIterate_mem_range_of_generator_ancestries
+    (n : ℕ)
+    (hsmall : ∀ x : (TopCat.toSSet.obj X).obj
+        (Opposite.op (SimplexCategory.mk n)),
+      ∃ m : ℕ, ∀ a : AffinePermutationAncestry n m,
+        ∃ i, X.toSSetObjEquiv _ x ''
+          Set.range (iteratedAffineCellMap n
+            (affinePermutationAncestryFlags n m a)) ⊆ U i) :
+    ∀ c : (IntegralSingularChainComplexObj X).X n,
+      ∃ m : ℕ, (affineSingularSubdivisionIterate X m).f n c ∈
+        Set.range ((coverSmallIntegralSingularChainInclusion X U).f n) := by
+  let P := affineSubdivisionEventuallySmallAddSubgroup X U n
+  let Q := AddCommGrpCat.of ((IntegralSingularChainComplexObj X).X n ⧸ P)
+  let q : (IntegralSingularChainComplexObj X).X n ⟶ Q :=
+    AddCommGrpCat.ofHom (QuotientAddGroup.mk' P)
+  have hq : q = 0 := by
+    apply (TopCat.toSSet.obj X).chainComplex_hom_ext
+    intro x
+    let j : AddCommGrpCat.of ℤ ⟶ (IntegralSingularChainComplexObj X).X n :=
+      (TopCat.toSSet.obj X).ιChainComplex x
+    apply AddCommGrpCat.hom_ext
+    apply AddMonoidHom.ext
+    intro z
+    change QuotientAddGroup.mk' P (j z) = 0
+    obtain ⟨m, hm⟩ := hsmall x
+    have hgen : j 1 ∈ P := by
+      exact ⟨m,
+        affineSingularSubdivisionIterate_generator_mem_range_of_ancestries
+          X U n m x hm⟩
+    have hzsmul := P.zsmul_mem hgen z
+    have heq : j z = z • j 1 := by
+      calc
+        j z = j (z • (1 : ℤ)) := by simp
+        _ = z • j 1 := j.hom.map_zsmul z 1
+    rw [← heq] at hzsmul
+    have hker : j z ∈ (QuotientAddGroup.mk' P).ker := by
+      rwa [QuotientAddGroup.ker_mk']
+    exact hker
+  intro c
+  have hc : QuotientAddGroup.mk' P c = 0 := by
+    have hcq := ConcreteCategory.congr_hom hq c
+    exact hcq
+  change c ∈ P
+  have hcker : c ∈ (QuotientAddGroup.mk' P).ker := hc
+  rwa [QuotientAddGroup.ker_mk'] at hcker
+
+/-- If all ancestry cells of one common depth are subordinate for each singular simplex, then
+every chain in that degree has a cover-small subdivision iterate. -/
+public theorem exists_affineSubdivisionIterate_mem_range_of_ancestries
+    (n : ℕ)
+    (hsmall : ∀ x : (TopCat.toSSet.obj X).obj
+        (Opposite.op (SimplexCategory.mk n)),
+      ∃ m : ℕ, ∀ ancestry : List (TopAffineFlag n),
+        ancestry.length = m →
+          ∃ i, X.toSSetObjEquiv _ x ''
+            Set.range (iteratedAffineCellMap n ancestry) ⊆ U i) :
+    ∀ c : (IntegralSingularChainComplexObj X).X n,
+      ∃ m : ℕ, (affineSingularSubdivisionIterate X m).f n c ∈
+        Set.range ((coverSmallIntegralSingularChainInclusion X U).f n) := by
+  apply exists_affineSubdivisionIterate_mem_range_of_generator_ancestries X U n
+  intro x
+  obtain ⟨m, hm⟩ := hsmall x
+  refine ⟨m, fun a ↦ ?_⟩
+  exact hm (affinePermutationAncestryFlags n m a)
+    (length_affinePermutationAncestryFlags n m a)
+
+/-- Cover-subordination of every depth-`m` ancestry cell (with a depth depending on the original
+simplex and degree) implies affine eventual smallness for all singular chains. -/
+public theorem coverSmallAffineSubdivisionEventuallySmall_of_ancestries
+    (hsmall : ∀ (n : ℕ) (x : (TopCat.toSSet.obj X).obj
+        (Opposite.op (SimplexCategory.mk n))),
+      ∃ m : ℕ, ∀ ancestry : List (TopAffineFlag n),
+        ancestry.length = m →
+          ∃ i, X.toSSetObjEquiv _ x ''
+            Set.range (iteratedAffineCellMap n ancestry) ⊆ U i) :
+    CoverSmallAffineSubdivisionEventuallySmall X U := by
+  apply coverSmallAffineSubdivisionEventuallySmall_of_iterate_mem_range X U
+  intro n c
+  exact exists_affineSubdivisionIterate_mem_range_of_ancestries
+    X U n (hsmall n) c
+
+set_option linter.unnecessarySimpa false in
+/-- Zero-dimensional singular simplices are already subordinate to any covering family. -/
+public theorem exists_zero_dimensional_ancestry_depth_subordinate
+    (hUcover : ⋃ i, U i = Set.univ)
+    (x : (TopCat.toSSet.obj X).obj
+      (Opposite.op (SimplexCategory.mk 0))) :
+    ∃ m : ℕ, ∀ ancestry : List (TopAffineFlag 0),
+      ancestry.length = m →
+        ∃ i, X.toSSetObjEquiv _ x ''
+          Set.range (iteratedAffineCellMap 0 ancestry) ⊆ U i := by
+  refine ⟨0, fun ancestry hlength ↦ ?_⟩
+  cases ancestry with
+  | cons F ancestry => simp at hlength
+  | nil =>
+  let w₀ : stdSimplex ℝ (Fin (0 + 1)) := Classical.arbitrary _
+  have hwcover : X.toSSetObjEquiv _ x w₀ ∈ ⋃ i, U i := by
+    rw [hUcover]
+    trivial
+  simp only [Set.mem_iUnion] at hwcover
+  obtain ⟨i, hi⟩ := hwcover
+  refine ⟨i, ?_⟩
+  rintro y ⟨z, ⟨w, rfl⟩, rfl⟩
+  have hw : w = w₀ := by
+    apply Subtype.ext
+    funext j
+    have hj : j = 0 := Fin.eq_zero j
+    subst j
+    have hwone : w 0 = 1 := by simpa using w.property.2
+    have hw₀one : w₀ 0 = 1 := by simpa using w₀.property.2
+    exact hwone.trans hw₀one.symm
+  simpa [hw] using hi
+
+/-- Relative mesh contraction in every positive degree supplies the ancestry-subordination
+hypothesis, while degree zero is already small. -/
+public theorem coverSmallAffineSubdivisionEventuallySmall_of_relativeMesh
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hrelative : ∀ n : ℕ, 1 ≤ n → AffineFlagRelativeMeshContraction n) :
+    CoverSmallAffineSubdivisionEventuallySmall X U := by
+  apply coverSmallAffineSubdivisionEventuallySmall_of_ancestries X U
+  intro n x
+  cases n with
+  | zero =>
+      exact exists_zero_dimensional_ancestry_depth_subordinate X U hUcover x
+  | succ n =>
+      exact exists_iteratedAffineCell_depth_subordinate X U hUopen hUcover
+        (n + 1) (Nat.succ_le_succ (Nat.zero_le n))
+        (hrelative (n + 1) (Nat.succ_le_succ (Nat.zero_le n))) x
+
+end CoverSmall
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularExcisionOpenCover.lean
+++ b/SphereSixComplex/Topology/SingularExcisionOpenCover.lean
@@ -1,0 +1,63 @@
+module
+
+public import SphereSixComplex.Topology.SingularAffineSubdivisionRelativeMesh
+public import SphereSixComplex.Topology.SingularAffineSubdivisionSupport
+public import SphereSixComplex.Topology.SingularExcisionQuasiIso
+
+/-!
+# Small-chain approximation for open covers
+
+This file assembles the geometric affine-mesh theorem, the exact permutation-ancestry expansion,
+the adaptive quasi-isomorphism argument, and projectivity.  The result is the classical
+small-singular-chain theorem for every open cover, with no additional hypothesis.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Set
+
+namespace SphereSixComplex
+
+variable {ι : Type} (X : TopCat) (U : ι → Set X)
+
+/-- Every finite singular chain becomes subordinate to an open cover after sufficiently many
+genuine affine barycentric subdivisions. -/
+public theorem coverSmallAffineSubdivisionEventuallySmall_of_openCover
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ) :
+    CoverSmallAffineSubdivisionEventuallySmall X U :=
+  coverSmallAffineSubdivisionEventuallySmall_of_relativeMesh X U hUopen hUcover
+    (fun n _ ↦ affineFlagRelativeMeshContraction n)
+
+/-- The cover-small inclusion is a quasi-isomorphism for every open cover. -/
+public theorem coverSmallChainQuasiIsomorphism_of_openCover
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ) :
+    CoverSmallChainQuasiIsomorphism X U :=
+  coverSmallChainQuasiIsomorphism_of_eventuallySmall X U
+    (coverSmallAffineSubdivisionEventuallySmall_of_openCover X U hUopen hUcover)
+
+/-- Classical small-chain approximation: the inclusion of chains subordinate to an open cover is
+a chain-homotopy equivalence for integral singular chains. -/
+public theorem coverSmallChainApproximation_of_openCover
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ) :
+    CoverSmallChainApproximation X U :=
+  coverSmallChainApproximation_of_eventuallySmall X U
+    (coverSmallAffineSubdivisionEventuallySmall_of_openCover X U hUopen hUcover)
+
+/-- The concrete two-set cover of the seven-disk now satisfies the formerly missing small-chain
+approximation theorem unconditionally. -/
+public theorem diskSevenSmallChainApproximation :
+    DiskSevenSmallChainApproximation :=
+  coverSmallChainApproximation_of_openCover
+    (TopCat.disk.{0} 7) diskSevenExcisionCover diskSevenExcisionCover_isOpen
+      diskSevenExcisionCover_iUnion
+
+/-- Equivalently, the cover-small inclusion for the concrete disk cover is a quasi-isomorphism. -/
+public theorem diskSevenSmallChainQuasiIsomorphism :
+    DiskSevenSmallChainQuasiIsomorphism :=
+  coverSmallChainQuasiIsomorphism_of_openCover
+    (TopCat.disk.{0} 7) diskSevenExcisionCover diskSevenExcisionCover_isOpen
+      diskSevenExcisionCover_iUnion
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularExcisionQuasiIso.lean
+++ b/SphereSixComplex/Topology/SingularExcisionQuasiIso.lean
@@ -1,0 +1,220 @@
+module
+
+public import SphereSixComplex.Topology.SingularExcisionProjective
+public import SphereSixComplex.Topology.SingularAffineSubdivisionIteration
+public import Mathlib.Algebra.Homology.ConcreteCategory
+
+/-!
+# The algebraic endgame of the small-chain argument
+
+This file separates the finite-chain algebra in the classical subdivision proof from the
+geometric assertion that iterated affine subdivision eventually makes a chain subordinate to a
+cover.  The abstract theorem says that a monomorphic inclusion of chain complexes is a
+quasi-isomorphism when compatible endomorphisms on the source and target are homotopic to the
+identity and every target chain is eventually carried into the image of the inclusion.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+section Abstract
+
+variable {K L : ChainComplex AddCommGrpCat ℕ}
+
+/-- Elementwise eventual factorization, together with compatible endomorphisms homotopic to the
+identity, makes a monomorphic inclusion of nonnegative chain complexes a quasi-isomorphism.
+
+The exponent is allowed to depend on the individual chain.  This is the form needed for singular
+chains, whose elements have finite support but do not admit a uniform subdivision exponent. -/
+public theorem chainComplex_quasiIso_of_eventually_factors
+    (I : K ⟶ L) [Mono I]
+    (smallIterate : ℕ → (K ⟶ K))
+    (largeIterate : ℕ → (L ⟶ L))
+    (hcompat : ∀ m, smallIterate m ≫ I = I ≫ largeIterate m)
+    (hsmall : ∀ m, Homotopy (smallIterate m) (𝟙 K))
+    (hlarge : ∀ m, Homotopy (largeIterate m) (𝟙 L))
+    (heventually : ∀ (n : ℕ) (x : L.X n),
+      ∃ (m : ℕ) (y : K.X n), I.f n y = (largeIterate m).f n x) :
+    QuasiIso I := by
+  rw [quasiIso_iff]
+  intro n
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  apply (ConcreteCategory.isIso_iff_bijective _).2
+  constructor
+  · intro a b hab
+    suffices a - b = 0 by exact sub_eq_zero.mp this
+    let q : K.homology n := a - b
+    have hqmap : HomologicalComplex.homologyMap I n q = 0 := by
+      dsimp [q]
+      rw [map_sub, hab, sub_self]
+    obtain ⟨z, hz⟩ :=
+      (AddCommGrpCat.epi_iff_surjective (K.homologyπ n)).1 inferInstance q
+    have hzmap :
+        L.homologyπ n (HomologicalComplex.cyclesMap I n z) = 0 := by
+      rw [← ConcreteCategory.comp_apply,
+        ← HomologicalComplex.homologyπ_naturality,
+        ConcreteCategory.comp_apply, hz]
+      exact hqmap
+    let T : ShortComplex AddCommGrpCat :=
+      ShortComplex.mk (L.toCycles (n + 1) n) (L.homologyπ n) (by simp)
+    have hT : T.Exact := by
+      exact T.exact_of_g_is_cokernel (L.homologyIsCokernel (n + 1) n (by simp))
+    obtain ⟨w, hw⟩ := (T.ab_exact_iff.mp hT)
+      (HomologicalComplex.cyclesMap I n z) hzmap
+    obtain ⟨m, w', hw'⟩ := heventually (n + 1) w
+    have hzchain :
+        I.f n (K.iCycles n z) = L.d (n + 1) n w := by
+      rw [← ConcreteCategory.comp_apply, ← HomologicalComplex.cyclesMap_i,
+        ConcreteCategory.comp_apply, ← hw]
+      dsimp [T]
+      rw [← ConcreteCategory.comp_apply, HomologicalComplex.toCycles_i]
+    have hboundary :
+        (smallIterate m).f n (K.iCycles n z) = K.d (n + 1) n w' := by
+      apply (AddCommGrpCat.mono_iff_injective (I.f n)).1
+      · change Mono ((HomologicalComplex.eval AddCommGrpCat
+            (ComplexShape.down ℕ) n).map I)
+        infer_instance
+      have hc := congrArg (fun F ↦ F.f n) (hcompat m)
+      have hc' := ConcreteCategory.congr_hom hc (K.iCycles n z)
+      simp only [HomologicalComplex.comp_f,
+        ConcreteCategory.comp_apply] at hc'
+      calc
+        I.f n ((smallIterate m).f n (K.iCycles n z)) =
+            (largeIterate m).f n (I.f n (K.iCycles n z)) := hc'
+        _ = (largeIterate m).f n (L.d (n + 1) n w) := by rw [hzchain]
+        _ = L.d (n + 1) n ((largeIterate m).f (n + 1) w) := by
+          rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply,
+            (largeIterate m).comm]
+        _ = L.d (n + 1) n (I.f (n + 1) w') := by rw [← hw']
+        _ = I.f n (K.d (n + 1) n w') := by
+          rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, I.comm]
+    have hiterzero :
+        HomologicalComplex.homologyMap (smallIterate m) n
+            (K.homologyπ n z) = 0 := by
+      rw [← ConcreteCategory.comp_apply,
+        HomologicalComplex.homologyπ_naturality,
+        ConcreteCategory.comp_apply]
+      let B : K.X (n + 1) ⟶ K.cycles n := K.toCycles (n + 1) n
+      have hB : B w' =
+          HomologicalComplex.cyclesMap (smallIterate m) n z := by
+        apply (AddCommGrpCat.mono_iff_injective (K.iCycles n)).1 inferInstance
+        calc
+          K.iCycles n (B w') = K.d (n + 1) n w' := by
+            rw [← ConcreteCategory.comp_apply]
+            exact ConcreteCategory.congr_hom
+              (HomologicalComplex.toCycles_i K (n + 1) n) w'
+          _ = (smallIterate m).f n (K.iCycles n z) := hboundary.symm
+          _ = K.iCycles n
+              (HomologicalComplex.cyclesMap (smallIterate m) n z) := by
+            exact ConcreteCategory.congr_hom
+              (HomologicalComplex.cyclesMap_i (smallIterate m) n).symm z
+      rw [← hB, ← ConcreteCategory.comp_apply,
+        HomologicalComplex.toCycles_comp_homologyπ]
+      rfl
+    have hiter := congrArg (fun f ↦ f (K.homologyπ n z))
+      ((hsmall m).homologyMap_eq n)
+    rw [HomologicalComplex.homologyMap_id] at hiter
+    change q = 0
+    calc
+      q = K.homologyπ n z := hz.symm
+      _ = HomologicalComplex.homologyMap (smallIterate m) n
+          (K.homologyπ n z) := by simpa using hiter.symm
+      _ = 0 := hiterzero
+  · intro y
+    obtain ⟨z, rfl⟩ :=
+      (AddCommGrpCat.epi_iff_surjective (L.homologyπ n)).1 inferInstance y
+    let x : L.X n := L.iCycles n z
+    obtain ⟨m, x', hx'⟩ := heventually n x
+    let j : ℕ := (ComplexShape.down ℕ).next n
+    have hxcycle : L.d n j x = 0 := by
+      dsimp [x]
+      rw [← ConcreteCategory.comp_apply, HomologicalComplex.iCycles_d]
+      rfl
+    have hx'cycle : K.d n j x' = 0 := by
+      apply (AddCommGrpCat.mono_iff_injective (I.f j)).1
+      · change Mono ((HomologicalComplex.eval AddCommGrpCat
+            (ComplexShape.down ℕ) j).map I)
+        infer_instance
+      rw [map_zero, ← ConcreteCategory.comp_apply, ← I.comm,
+        ConcreteCategory.comp_apply, hx', ← ConcreteCategory.comp_apply,
+        (largeIterate m).comm, ConcreteCategory.comp_apply, hxcycle, map_zero]
+    have hx'mem : x' ∈ (K.sc n).g.hom.ker := by
+      change (K.sc n).g x' = 0
+      change K.d n ((ComplexShape.down ℕ).next n) x' = 0
+      simpa [j] using hx'cycle
+    let z' : K.cycles n :=
+      (K.sc n).abCyclesIso.inv ⟨x', hx'mem⟩
+    refine ⟨K.homologyπ n z', ?_⟩
+    rw [← ConcreteCategory.comp_apply,
+      HomologicalComplex.homologyπ_naturality,
+      ConcreteCategory.comp_apply]
+    have hcycles : HomologicalComplex.cyclesMap I n z' =
+        HomologicalComplex.cyclesMap (largeIterate m) n z := by
+      apply (AddCommGrpCat.mono_iff_injective (L.iCycles n)).1 inferInstance
+      calc
+        L.iCycles n (HomologicalComplex.cyclesMap I n z') =
+            I.f n (K.iCycles n z') := by
+          rw [← ConcreteCategory.comp_apply,
+            HomologicalComplex.cyclesMap_i,
+            ConcreteCategory.comp_apply]
+        _ = I.f n x' := by
+          congr 1
+          dsimp [z']
+          exact (K.sc n).abCyclesIso_inv_apply_iCycles _
+        _ = (largeIterate m).f n x := hx'
+        _ = (largeIterate m).f n (L.iCycles n z) := rfl
+        _ = L.iCycles n
+            (HomologicalComplex.cyclesMap (largeIterate m) n z) := by
+          exact ConcreteCategory.congr_hom
+            (HomologicalComplex.cyclesMap_i (largeIterate m) n).symm z
+    rw [hcycles, ← ConcreteCategory.comp_apply,
+      ← HomologicalComplex.homologyπ_naturality,
+      ConcreteCategory.comp_apply]
+    have hiter := congrArg (fun f ↦ f (L.homologyπ n z))
+      ((hlarge m).homologyMap_eq n)
+    simpa using hiter
+
+end Abstract
+
+section Singular
+
+variable {iota : Type} (X : TopCat) (U : iota → Set X)
+
+/-- The geometric input still needed by the small-chain proof: every finite singular chain is
+carried into the cover-small subcomplex by some finite affine-subdivision iterate. -/
+public def CoverSmallAffineSubdivisionEventuallySmall : Prop :=
+  ∀ (n : ℕ) (x : (IntegralSingularChainComplexObj X).X n),
+    ∃ (m : ℕ) (y : (CoverSmallIntegralSingularChainComplex X U).X n),
+      (coverSmallIntegralSingularChainInclusion X U).f n y =
+        (affineSingularSubdivisionIterate X m).f n x
+
+/-- Eventual smallness of every finite singular chain implies the cover-small inclusion is a
+quasi-isomorphism. -/
+public theorem coverSmallChainQuasiIsomorphism_of_eventuallySmall
+    (h : CoverSmallAffineSubdivisionEventuallySmall X U) :
+    CoverSmallChainQuasiIsomorphism X U := by
+  apply chainComplex_quasiIso_of_eventually_factors
+    (coverSmallIntegralSingularChainInclusion X U)
+    (coverSmallAffineSubdivisionIterate X U)
+    (affineSingularSubdivisionIterate X)
+  · exact coverSmallAffineSubdivisionIterate_comp_inclusion X U
+  · exact coverSmallAffineSubdivisionIterateHomotopy X U
+  · exact affineSingularSubdivisionIterateHomotopy X
+  · exact h
+
+/-- The same geometric input supplies the stronger chain-homotopy approximation interface via
+projectivity of integral singular chain groups. -/
+public theorem coverSmallChainApproximation_of_eventuallySmall
+    (h : CoverSmallAffineSubdivisionEventuallySmall X U) :
+    CoverSmallChainApproximation X U :=
+  coverSmallChainApproximation_of_quasiIso X U
+    (coverSmallChainQuasiIsomorphism_of_eventuallySmall X U h)
+
+end Singular
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- promote the completed #54–#56 tail from the stacked excision branches onto `main`
- add the adaptive quasi-isomorphism, affine mesh/relative-mesh/support control, and unconditional open-cover endpoint
- expose the final theorem through `SphereSixComplex.Main`

This promotion is required because #54–#56 were merged through branches whose parent PR had already landed, so those commits did not propagate to the default branch.

## Verification

- `lake build SphereSixComplex.Topology.SingularExcisionOpenCover SphereSixComplex.Main`
- full `SphereSixComplex.Main` build completed successfully: 9,360 jobs
- all five public endpoint axiom audits report only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check`
- no `sorry`, `admit`, declarations of new axioms, `unsafe`, `opaque`, or `implemented_by` in this six-file promotion diff

Closes #43.