### PR TITLE
Add canonical simplicial-singular comparison foundations

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenRealization.lean
+++ b/SphereSixComplex/Topology/BoundarySevenRealization.lean
@@ -1,0 +1,498 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits
+public import Mathlib.Analysis.Convex.GaugeRescale
+public import Mathlib.Analysis.Normed.Affine.AddTorsorBases
+
+/-!
+# The geometric realization of the boundary of the seven-simplex
+
+This file isolates the canonical map from `|∂Δ[7]|` to the ordinary topological seven-simplex
+and its compatibility with all eight codimension-one faces.  It also uses gauge rescaling to
+identify the ordinary affine boundary with the project's unit six-sphere.  Thus the only missing
+geometric-realization input is that realization of the simplicial subcomplex carries the expected
+subspace topology and underlying boundary points.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The ordinary boundary of a standard simplex: at least one barycentric coordinate vanishes. -/
+public abbrev StandardSimplexBoundary (n : ℕ) :=
+  {w : stdSimplex ℝ (Fin (n + 1)) // ∃ i, w i = 0}
+
+/-- The canonical map from realization of the simplicial boundary into the ordinary standard
+seven-simplex. -/
+public noncomputable def boundarySevenRealizationToStdSimplex :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
+  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι x),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
+      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
+
+/-- On each simplicial face, the canonical realization map is the usual affine face inclusion. -/
+public theorem boundarySevenRealizationToStdSimplex_face
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenRealizationToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
+  unfold boundarySevenRealizationToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
+  rw [← ConcreteCategory.comp_apply]
+  rw [← SSet.toTop.map_comp]
+  rw [SSet.boundary.ι_ι]
+  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
+
+/-- The ordinary affine inclusion of a codimension-one face lands in the topological boundary. -/
+public noncomputable def standardSimplexFaceToBoundary
+    (n : ℕ) (i : Fin (n + 2)) :
+    C(stdSimplex ℝ (Fin (n + 1)), StandardSimplexBoundary (n + 1)) := by
+  let f : C(stdSimplex ℝ (Fin (n + 1)), stdSimplex ℝ (Fin (n + 2))) :=
+    ⟨stdSimplex.map i.succAbove, stdSimplex.continuous_map i.succAbove⟩
+  refine ⟨fun w ↦ ⟨f w, ⟨i, ?_⟩⟩, f.continuous.subtype_mk _⟩
+  classical
+  change stdSimplex.map i.succAbove w i = 0
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  apply Finset.sum_eq_zero
+  intro j hj
+  exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+
+/-- The realization map restricted to every face agrees with the corresponding map to the
+ordinary topological boundary, after forgetting the boundary witness. -/
+public theorem boundarySevenRealizationToStdSimplex_face_eq_val
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenRealizationToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      (standardSimplexFaceToBoundary 6 i
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) :
+          stdSimplex ℝ (Fin 8)) := by
+  change boundarySevenRealizationToStdSimplex
+      (SSet.toTop.map (SSet.boundary.ι i) x) =
+    stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x)
+  exact boundarySevenRealizationToStdSimplex_face i x
+
+/-- A chosen affine basis with eight vertices in seven-dimensional Euclidean space. -/
+public noncomputable def boundarySevenAffineBasis :
+    AffineBasis (Fin 8) ℝ (EuclideanSpace ℝ (Fin 7)) :=
+  Classical.choice (AffineBasis.exists_affineBasis_of_finiteDimensional
+    (k := ℝ) (V := EuclideanSpace ℝ (Fin 7))
+    (P := EuclideanSpace ℝ (Fin 7)) (ι := Fin 8) (by simp))
+
+/-- The compact convex body spanned by the chosen affine basis. -/
+public def boundarySevenAffineBody : Set (EuclideanSpace ℝ (Fin 7)) :=
+  convexHull ℝ (Set.range boundarySevenAffineBasis)
+
+public theorem boundarySevenAffineBody_convex : Convex ℝ boundarySevenAffineBody :=
+  convex_convexHull ℝ _
+
+public theorem boundarySevenAffineBody_bounded : Bornology.IsBounded boundarySevenAffineBody := by
+  unfold boundarySevenAffineBody
+  rw [isBounded_convexHull]
+  exact (Set.finite_range boundarySevenAffineBasis).isBounded
+
+public theorem boundarySevenAffineBody_interior_nonempty :
+    (interior boundarySevenAffineBody).Nonempty := by
+  exact ⟨_, boundarySevenAffineBasis.centroid_mem_interior_convexHull⟩
+
+/-- Barycentric coordinates identify the standard seven-simplex with the convex hull of the
+chosen affine basis. -/
+public noncomputable def stdSimplexHomeomorphBoundarySevenAffineBody :
+    stdSimplex ℝ (Fin 8) ≃ₜ boundarySevenAffineBody where
+  toFun w := ⟨Finset.univ.affineCombination ℝ boundarySevenAffineBasis w,
+    affineCombination_mem_convexHull (fun i _ ↦ w.2.1 i) w.2.2⟩
+  invFun x := ⟨fun i ↦ boundarySevenAffineBasis.coord i x,
+    ⟨fun i ↦ by
+        have hx : x.1 ∈ convexHull ℝ (Set.range boundarySevenAffineBasis) := by
+          simpa only [boundarySevenAffineBody] using x.2
+        rw [boundarySevenAffineBasis.convexHull_eq_nonneg_coord] at hx
+        exact hx i,
+      boundarySevenAffineBasis.sum_coord_apply_eq_one x⟩⟩
+  left_inv w := by
+    apply Subtype.ext
+    ext i
+    exact boundarySevenAffineBasis.coord_apply_combination_of_mem
+      (Finset.mem_univ i) w.2.2
+  right_inv x := by
+    apply Subtype.ext
+    exact boundarySevenAffineBasis.affineCombination_coord_eq_self x
+  continuous_toFun := by
+    apply Continuous.subtype_mk
+    have h : Continuous (fun w : stdSimplex ℝ (Fin 8) ↦
+        ∑ i, w i • boundarySevenAffineBasis i) := by
+      apply continuous_finsetSum
+      intro i hi
+      exact ((continuous_apply i).comp continuous_subtype_val).smul continuous_const
+    exact h.congr fun w ↦
+      (Finset.univ.affineCombination_eq_linear_combination
+        boundarySevenAffineBasis w w.2.2).symm
+  continuous_invFun := by
+    have h : Continuous (fun x : boundarySevenAffineBody ↦
+        fun i ↦ boundarySevenAffineBasis.coord i x) := by
+      apply continuous_pi
+      intro i
+      exact (continuous_barycentric_coord boundarySevenAffineBasis i).comp
+        continuous_subtype_val
+    exact h.subtype_mk _
+
+/-- Gauge rescaling supplies an ambient homeomorphism carrying the affine-simplex frontier to the
+unit sphere in seven-dimensional Euclidean space. -/
+public noncomputable def boundarySevenAffineBodyGaugeHomeomorph :
+    EuclideanSpace ℝ (Fin 7) ≃ₜ EuclideanSpace ℝ (Fin 7) :=
+  Classical.choose (exists_homeomorph_image_interior_closure_frontier_eq_unitBall
+    boundarySevenAffineBody_convex boundarySevenAffineBody_interior_nonempty
+      boundarySevenAffineBody_bounded)
+
+public theorem boundarySevenAffineBodyGaugeHomeomorph_frontier :
+    boundarySevenAffineBodyGaugeHomeomorph '' frontier boundarySevenAffineBody =
+      Metric.sphere (0 : EuclideanSpace ℝ (Fin 7)) 1 :=
+  (Classical.choose_spec (exists_homeomorph_image_interior_closure_frontier_eq_unitBall
+    boundarySevenAffineBody_convex boundarySevenAffineBody_interior_nonempty
+      boundarySevenAffineBody_bounded)).2.2
+
+public theorem boundarySevenAffineBody_closed : IsClosed boundarySevenAffineBody := by
+  unfold boundarySevenAffineBody
+  exact ((Set.finite_range boundarySevenAffineBasis).isCompact_convexHull ℝ).isClosed
+
+/-- Under barycentric coordinates, belonging to the frontier is exactly the vanishing of at least
+one standard-simplex coordinate. -/
+public theorem stdSimplexHomeomorphBoundarySevenAffineBody_mem_frontier_iff
+    (w : stdSimplex ℝ (Fin 8)) :
+    (stdSimplexHomeomorphBoundarySevenAffineBody w :
+        EuclideanSpace ℝ (Fin 7)) ∈
+        frontier boundarySevenAffineBody ↔
+      ∃ i, w i = 0 := by
+  classical
+  have hcoord (i : Fin 8) :
+      boundarySevenAffineBasis.coord i
+          (stdSimplexHomeomorphBoundarySevenAffineBody w) = w i :=
+    boundarySevenAffineBasis.coord_apply_combination_of_mem
+      (Finset.mem_univ i) w.2.2
+  have hinter :
+      (stdSimplexHomeomorphBoundarySevenAffineBody w :
+          EuclideanSpace ℝ (Fin 7)) ∈
+          interior boundarySevenAffineBody ↔
+        ∀ i, 0 < w i := by
+    have hset : interior boundarySevenAffineBody =
+        {x | ∀ i, 0 < boundarySevenAffineBasis.coord i x} := by
+      simpa only [boundarySevenAffineBody] using
+        boundarySevenAffineBasis.interior_convexHull
+    rw [hset]
+    constructor
+    · intro h i
+      exact (hcoord i) ▸ h i
+    · intro h i
+      exact (hcoord i).symm ▸ h i
+  rw [boundarySevenAffineBody_closed.frontier_eq]
+  simp only [Set.mem_sdiff, (stdSimplexHomeomorphBoundarySevenAffineBody w).2,
+    true_and, hinter]
+  constructor
+  · rw [not_forall]
+    rintro ⟨i, hi⟩
+    exact ⟨i, le_antisymm (le_of_not_gt hi) (w.2.1 i)⟩
+  · rintro ⟨i, hi⟩ hall
+    exact (ne_of_gt (hall i)) hi
+
+/-- Flatten the frontier regarded as a subspace of the affine body to the same frontier regarded
+as a subspace of the ambient Euclidean space. -/
+public noncomputable def boundarySevenFrontierInBodyHomeomorphFrontier :
+    {y : boundarySevenAffineBody //
+      (y : EuclideanSpace ℝ (Fin 7)) ∈ frontier boundarySevenAffineBody} ≃ₜ
+      frontier boundarySevenAffineBody where
+  toFun y := ⟨y.1.1, y.2⟩
+  invFun x := ⟨⟨x.1, by
+      simpa only [boundarySevenAffineBody_closed.closure_eq] using
+        (frontier_subset_closure x.2)⟩, x.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  continuous_toFun :=
+    (continuous_subtype_val.comp continuous_subtype_val).subtype_mk _
+  continuous_invFun := by
+    apply Continuous.subtype_mk
+    exact continuous_subtype_val.subtype_mk fun x ↦ by
+      simpa only [boundarySevenAffineBody_closed.closure_eq] using
+        (frontier_subset_closure x.2)
+
+/-- The ordinary barycentric boundary of the standard seven-simplex is homeomorphic to the
+frontier of a full-dimensional affine simplex in seven-dimensional Euclidean space. -/
+public noncomputable def standardSimplexBoundarySevenHomeomorphAffineFrontier :
+    StandardSimplexBoundary 7 ≃ₜ frontier boundarySevenAffineBody := by
+  let e : StandardSimplexBoundary 7 ≃ₜ
+      {y : boundarySevenAffineBody //
+        (y : EuclideanSpace ℝ (Fin 7)) ∈ frontier boundarySevenAffineBody} :=
+    stdSimplexHomeomorphBoundarySevenAffineBody.subtype
+      (p := fun w : stdSimplex ℝ (Fin 8) ↦ ∃ i, w i = 0)
+      (q := fun y : boundarySevenAffineBody ↦
+        (y : EuclideanSpace ℝ (Fin 7)) ∈
+        frontier boundarySevenAffineBody)
+      (fun w ↦ (stdSimplexHomeomorphBoundarySevenAffineBody_mem_frontier_iff w).symm)
+  exact e.trans boundarySevenFrontierInBodyHomeomorphFrontier
+
+/-- Gauge rescaling restricts to a homeomorphism from the affine-simplex frontier to the unit
+six-sphere. -/
+public noncomputable def boundarySevenAffineFrontierHomeomorphSixSphere :
+    frontier boundarySevenAffineBody ≃ₜ SixSphere :=
+  boundarySevenAffineBodyGaugeHomeomorph.subtype fun x ↦ by
+    constructor
+    · intro hx
+      rw [← boundarySevenAffineBodyGaugeHomeomorph_frontier]
+      exact ⟨x, hx, rfl⟩
+    · intro hx
+      rw [← boundarySevenAffineBodyGaugeHomeomorph_frontier] at hx
+      obtain ⟨y, hy, heq⟩ := hx
+      have hxy : y = x := boundarySevenAffineBodyGaugeHomeomorph.injective heq
+      simpa [hxy] using hy
+
+/-- The ordinary topological boundary of the seven-simplex is the project's standard unit
+six-sphere. -/
+public noncomputable def standardSimplexBoundarySevenHomeomorphSixSphere :
+    StandardSimplexBoundary 7 ≃ₜ SixSphere :=
+  standardSimplexBoundarySevenHomeomorphAffineFrontier.trans
+    boundarySevenAffineFrontierHomeomorphSixSphere
+
+/-! ## The exact realization/subspace gap -/
+
+/-- The boundary is categorically the multicoequalizer of its eight faces and their pairwise
+intersections. -/
+public theorem boundarySevenFaceMulticoequalizerDiagram :
+    SSet.Subcomplex.MulticoequalizerDiagram (SSet.boundary 7)
+      (fun i : Fin 8 ↦ SSet.stdSimplex.face {i}ᶜ)
+      (fun i j : Fin 8 ↦ SSet.stdSimplex.face {i}ᶜ ⊓
+        SSet.stdSimplex.face {j}ᶜ) where
+  iSup_eq := (SSet.boundary_eq_iSup 7).symm
+  eq_inf _ _ := rfl
+
+/-- Since geometric realization is a left adjoint, realization of the boundary is the same
+multicoequalizer of realized faces. -/
+public noncomputable def boundarySevenRealizationIsColimitOfFaces :
+    IsColimit
+      (SSet.toTop.mapCocone
+        (boundarySevenFaceMulticoequalizerDiagram.multicofork.map
+          SSet.Subcomplex.toSSetFunctor)) :=
+  isColimitOfPreserves SSet.toTop
+    boundarySevenFaceMulticoequalizerDiagram.isColimit
+
+/-- Every point of the realized boundary is represented by a point of one of its eight
+codimension-one simplicial faces.  This is the point-set surjectivity part of the realized
+multicoequalizer, extracted after forgetting the topology. -/
+public theorem boundarySevenRealization_faceCovered
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    ∃ (i : Fin 8)
+      (y : (SSet.toTop.obj
+        (SSet.stdSimplex.face {i}ᶜ : SSet.Subcomplex (Δ[7] : SSet.{0})) : Type)),
+      SSet.toTop.map (SSet.boundary.faceι i) y = x := by
+  have h := isColimitOfPreserves (forget TopCat)
+    boundarySevenRealizationIsColimitOfFaces
+  obtain ⟨j, y, hy⟩ := Types.jointly_surjective_of_isColimit h x
+  rcases j with l | i
+  · let f := WalkingMultispan.Hom.fst
+      (J := MultispanShape.prod (Fin 8)) l
+    let y' := (((boundarySevenFaceMulticoequalizerDiagram.multispanIndex.map
+      SSet.Subcomplex.toSSetFunctor).multispan ⋙ SSet.toTop) ⋙
+        forget TopCat).map f y
+    refine ⟨l.1, y', ?_⟩
+    have hw := ((forget TopCat).mapCocone
+      (SSet.toTop.mapCocone
+        (boundarySevenFaceMulticoequalizerDiagram.multicofork.map
+          SSet.Subcomplex.toSSetFunctor))).w f
+    exact (ConcreteCategory.congr_hom hw y).trans hy
+  · exact ⟨i, y, hy⟩
+
+/-- Equivalently, every realized boundary point comes from an ordinary standard six-simplex via
+one of the eight standard boundary maps. -/
+public theorem boundarySevenRealization_standardFaceCovered
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    ∃ (i : Fin 8) (y : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)),
+      SSet.toTop.map (SSet.boundary.ι i) y = x := by
+  obtain ⟨i, y, hy⟩ := boundarySevenRealization_faceCovered x
+  refine ⟨i, SSet.toTop.map (SSet.stdSimplex.faceSingletonComplIso i).inv y, ?_⟩
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    SSet.boundary.faceSingletonComplIso_inv_ι]
+  exact hy
+
+public theorem boundarySevenRealizationToStdSimplex_mem_boundary
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    ∃ i, boundarySevenRealizationToStdSimplex x i = 0 := by
+  obtain ⟨i, y, rfl⟩ := boundarySevenRealization_standardFaceCovered x
+  rw [boundarySevenRealizationToStdSimplex_face_eq_val]
+  exact (standardSimplexFaceToBoundary 6 i
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)).2
+
+/-- The canonical realization map, now lifted to the ordinary zero-coordinate boundary.  The
+landing condition follows from the face cover, so it requires no choice of a preferred face. -/
+public noncomputable def boundarySevenRealizationToBoundary :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), StandardSimplexBoundary 7) :=
+  ⟨fun x ↦ ⟨boundarySevenRealizationToStdSimplex x,
+      boundarySevenRealizationToStdSimplex_mem_boundary x⟩,
+    boundarySevenRealizationToStdSimplex.continuous.subtype_mk _⟩
+
+@[simp]
+public theorem boundarySevenRealizationToBoundary_val
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    (boundarySevenRealizationToBoundary x : stdSimplex ℝ (Fin 8)) =
+      boundarySevenRealizationToStdSimplex x := rfl
+
+/-- Every point of the ordinary barycentric boundary belongs to one of the standard affine
+faces. -/
+public theorem standardSimplexBoundarySeven_standardFaceCovered
+    (w : StandardSimplexBoundary 7) :
+    ∃ (i : Fin 8) (z : stdSimplex ℝ (Fin 7)),
+      stdSimplex.map i.succAbove z = w.1 := by
+  classical
+  obtain ⟨i, hi⟩ := w.2
+  let z : stdSimplex ℝ (Fin 7) := ⟨fun j ↦ w.1 (i.succAbove j),
+    ⟨fun j ↦ w.1.2.1 (i.succAbove j), by
+      have hsum := w.1.2.2
+      change ∑ k, w.1 k = 1 at hsum
+      rw [Fin.sum_univ_succAbove (fun k ↦ w.1 k) i, hi, zero_add] at hsum
+      exact hsum⟩⟩
+  refine ⟨i, z, ?_⟩
+  apply stdSimplex.ext
+  funext k
+  obtain rfl | ⟨j, rfl⟩ := Fin.eq_self_or_eq_succAbove i k
+  · simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_zero]
+    · exact hi.symm
+    · intro j hj
+      exact (Fin.succAbove_ne k j (Finset.mem_filter.mp hj).2).elim
+  · simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_single j]
+    · rfl
+    · intro b hb hbj
+      exact (hbj (Fin.succAbove_right_inj.mp (Finset.mem_filter.mp hb).2)).elim
+    · simp
+
+/-- The canonical map from the realized simplicial boundary onto the ordinary barycentric
+boundary is surjective. -/
+public theorem boundarySevenRealizationToBoundary_surjective :
+    Function.Surjective boundarySevenRealizationToBoundary := by
+  intro w
+  obtain ⟨i, z, hz⟩ := standardSimplexBoundarySeven_standardFaceCovered w
+  let y := (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm z
+  refine ⟨SSet.toTop.map (SSet.boundary.ι i) y, ?_⟩
+  apply Subtype.ext
+  rw [boundarySevenRealizationToBoundary_val,
+    boundarySevenRealizationToStdSimplex_face]
+  change stdSimplex.map i.succAbove
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) = w.1
+  rw [Homeomorph.apply_symm_apply]
+  exact hz
+
+/-- The realized simplicial boundary is compact: it is a finite union of the continuous images of
+the eight compact realized standard six-simplices. -/
+public theorem boundarySevenRealization_isCompact_univ :
+    IsCompact (Set.univ : Set (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) := by
+  have hsource : IsCompact
+      (Set.univ : Set (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) := by
+    simpa only [Set.image_univ,
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm.surjective.range_eq]
+      using (isCompact_univ.image
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm.continuous)
+  have hface (i : Fin 8) : IsCompact
+      (Set.range fun y : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ↦
+        SSet.toTop.map (SSet.boundary.ι i) y) :=
+    by simpa only [Set.image_univ] using
+      hsource.image (SSet.toTop.map (SSet.boundary.ι i)).hom.continuous
+  have hcover : (⋃ i : Fin 8, Set.range fun y :
+      (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ↦
+        SSet.toTop.map (SSet.boundary.ι i) y) = Set.univ := by
+    apply Set.eq_univ_of_forall
+    intro x
+    obtain ⟨i, y, hy⟩ := boundarySevenRealization_standardFaceCovered x
+    exact Set.mem_iUnion.2 ⟨i, ⟨y, hy⟩⟩
+  rw [← hcover]
+  exact isCompact_iUnion hface
+
+/-- Injectivity is the only remaining point-set condition needed to turn the canonical continuous
+surjection into a homeomorphism. -/
+public noncomputable def boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+    (hinj : Function.Injective boundarySevenRealizationToBoundary) :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ StandardSimplexBoundary 7 := by
+  letI : CompactSpace (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) :=
+    isCompact_univ_iff.mp boundarySevenRealization_isCompact_univ
+  exact (Equiv.ofBijective boundarySevenRealizationToBoundary
+    ⟨hinj, boundarySevenRealizationToBoundary_surjective⟩).toHomeomorphOfContinuousClosed
+      boundarySevenRealizationToBoundary.continuous
+      boundarySevenRealizationToBoundary.continuous.isClosedMap
+
+/-- The one missing topological realization theorem: the canonical map identifies realization of
+the simplicial boundary with the ordinary zero-coordinate boundary, not merely face by face. -/
+public def BoundarySevenRealizationIdentifiesStandardSimplexBoundary : Prop :=
+  ∃ e : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ StandardSimplexBoundary 7,
+    ∀ x, (e x : stdSimplex ℝ (Fin 8)) = boundarySevenRealizationToStdSimplex x
+
+/-- The exact remaining content of the realization/subspace comparison is injectivity of the
+canonical map.  Surjectivity, continuity, compactness of the source, and Hausdorffness of the
+target have all been proved above. -/
+public theorem boundarySevenRealizationIdentifiesStandardSimplexBoundary_iff_injective :
+    BoundarySevenRealizationIdentifiesStandardSimplexBoundary ↔
+      Function.Injective boundarySevenRealizationToBoundary := by
+  constructor
+  · rintro ⟨e, he⟩ x y hxy
+    apply e.injective
+    apply Subtype.ext
+    rw [he x, he y]
+    exact congr_arg Subtype.val hxy
+  · intro hinj
+    refine ⟨boundarySevenRealizationHomeomorphStandardBoundary_of_injective hinj, ?_⟩
+    intro x
+    rfl
+
+/-- Equivalently, the remaining injectivity assertion says that geometric realization sends the
+monomorphism from the simplicial boundary into the representable seven-simplex to an injective
+continuous map. -/
+public theorem boundarySevenRealizationToBoundary_injective_iff_realizedInclusion :
+    Function.Injective boundarySevenRealizationToBoundary ↔
+      Function.Injective (SSet.toTop.map
+        (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι) := by
+  constructor
+  · intro h x y hxy
+    apply h
+    apply Subtype.ext
+    rw [boundarySevenRealizationToBoundary_val,
+      boundarySevenRealizationToBoundary_val]
+    exact congr_arg (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)) hxy
+  · intro h x y hxy
+    apply h
+    apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).injective
+    change boundarySevenRealizationToStdSimplex x =
+      boundarySevenRealizationToStdSimplex y
+    exact congr_arg Subtype.val hxy
+
+/-- Once the realization functor's face-colimit is identified with the ordinary closed face
+cover, the desired realization/sphere homeomorphism follows from the concrete affine geometry
+proved above. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere_of_identifiesBoundary
+    (h : BoundarySevenRealizationIdentifiesStandardSimplexBoundary) :
+    BoundarySevenRealizationHomeomorphSixSphere := by
+  obtain ⟨e, he⟩ := h
+  exact ⟨e.trans standardSimplexBoundarySevenHomeomorphSixSphere⟩
+
+/-- A final reduction of the desired homeomorphism to the sole missing face-gluing statement:
+different face representatives with the same ordinary barycentric point represent the same point
+of geometric realization. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere_of_injective
+    (hinj : Function.Injective boundarySevenRealizationToBoundary) :
+    BoundarySevenRealizationHomeomorphSixSphere :=
+  boundarySevenRealizationHomeomorphSixSphere_of_identifiesBoundary
+    (boundarySevenRealizationIdentifiesStandardSimplexBoundary_iff_injective.mpr hinj)
+
+/-- Therefore it is enough to supply the currently absent theorem that realization preserves
+injectivity for this simplicial subcomplex inclusion. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere_of_realizedInclusion_injective
+    (hinj : Function.Injective (SSet.toTop.map
+      (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι)) :
+    BoundarySevenRealizationHomeomorphSixSphere :=
+  boundarySevenRealizationHomeomorphSixSphere_of_injective
+    (boundarySevenRealizationToBoundary_injective_iff_realizedInclusion.mpr hinj)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenRealizationInjective.lean
+++ b/SphereSixComplex/Topology/BoundarySevenRealizationInjective.lean
@@ -1,0 +1,253 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenRealization
+
+/-!
+# Injectivity of the realized boundary inclusion
+
+This file proves the remaining point-set assertion face by face.  Two points of the realized
+boundary are represented by codimension-one faces.  If their ordinary barycentric coordinates
+agree, either the faces coincide or both representatives factor through their common
+codimension-two face.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Set Simplicial
+
+namespace SphereSixComplex
+
+public theorem stdSimplex_map_apply_of_injective
+    {m n : ℕ} (f : Fin m → Fin n) (hf : Function.Injective f)
+    (w : stdSimplex ℝ (Fin m)) (i : Fin m) :
+    stdSimplex.map f w (f i) = w i := by
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply, hf.eq_iff]
+  rw [Finset.sum_eq_single i]
+  · simp
+  · simp
+
+public theorem stdSimplex_map_injective
+    {m n : ℕ} (f : Fin m → Fin n) (hf : Function.Injective f) :
+    Function.Injective (stdSimplex.map (S := ℝ) f) := by
+  intro x y h
+  apply stdSimplex.ext
+  funext i
+  have hi := congrArg (fun w : stdSimplex ℝ (Fin n) ↦ w (f i)) h
+  simpa only [stdSimplex_map_apply_of_injective f hf] using hi
+
+public theorem stdSimplex_map_succAbove_apply_self
+    {n : ℕ} (i : Fin (n + 2)) (w : stdSimplex ℝ (Fin (n + 1))) :
+    stdSimplex.map i.succAbove w i = 0 := by
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  apply Finset.sum_eq_zero
+  intro j hj
+  exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+
+/-- Removing a zero coordinate gives the unique point of the corresponding affine face. -/
+public noncomputable def stdSimplexDeleteZeroCoordinate
+    {n : ℕ} (i : Fin (n + 2)) (w : stdSimplex ℝ (Fin (n + 2)))
+    (hi : w i = 0) : stdSimplex ℝ (Fin (n + 1)) :=
+  ⟨fun j ↦ w (i.succAbove j),
+    ⟨fun j ↦ w.2.1 _, by
+      have hsum := w.2.2
+      change (∑ k : Fin (n + 2), w k) = 1 at hsum
+      change (∑ j : Fin (n + 1), w (i.succAbove j)) = 1
+      rw [Fin.sum_univ_succAbove (fun k ↦ w k) i, hi, zero_add] at hsum
+      exact hsum⟩⟩
+
+public theorem stdSimplex_map_deleteZeroCoordinate
+    {n : ℕ} (i : Fin (n + 2)) (w : stdSimplex ℝ (Fin (n + 2)))
+    (hi : w i = 0) :
+    stdSimplex.map i.succAbove (stdSimplexDeleteZeroCoordinate i w hi) = w := by
+  apply stdSimplex.ext
+  funext k
+  obtain rfl | ⟨j, rfl⟩ := Fin.eq_self_or_eq_succAbove i k
+  · simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_zero]
+    · exact hi.symm
+    · intro j hj
+      exact (Fin.succAbove_ne k j (Finset.mem_filter.mp hj).2).elim
+  · exact stdSimplex_map_apply_of_injective i.succAbove
+      Fin.succAbove_right_injective _ j
+
+/-- Each individual realized face embeds in the realized boundary. -/
+public theorem boundarySevenRealizedFace_injective (i : Fin 8) :
+    Function.Injective (SSet.toTop.map (SSet.boundary.ι.{0} i)) := by
+  intro x y h
+  apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+  apply stdSimplex_map_injective i.succAbove Fin.succAbove_right_injective
+  simpa only [boundarySevenRealizationToStdSimplex_face] using
+    congrArg (fun z : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ↦
+      boundarySevenRealizationToStdSimplex z) h
+
+/-- The two standard parametrizations of a codimension-two face use the same ordered embedding
+of its six vertices. -/
+public theorem finPairFaceEmbedding_eq
+    (i j : Fin 8) (hij : i < j) :
+    (fun k : Fin 6 ↦
+        i.succAbove ((j.pred (Fin.ne_zero_of_lt hij)).succAbove k)) =
+      (fun k : Fin 6 ↦
+        j.succAbove ((i.castPred (Fin.ne_last_of_lt hij)).succAbove k)) := by
+  funext k
+  let ki := j.pred (Fin.ne_zero_of_lt hij)
+  let kj := i.castPred (Fin.ne_last_of_lt hij)
+  have hkj : Fin.castSucc kj < j := by
+    simpa [kj] using hij
+  have hcat : SimplexCategory.δ kj ≫ SimplexCategory.δ j =
+      SimplexCategory.δ ki ≫ SimplexCategory.δ i := by
+    simpa [ki, kj] using SimplexCategory.δ_comp_δ' hkj
+  exact congrArg (fun f : SimplexCategory.mk 5 ⟶ SimplexCategory.mk 7 ↦
+    f.toOrderHom k) hcat.symm
+
+/-- Representatives lying in two different facets with the same barycentric point are identified
+through their common codimension-two simplicial face. -/
+public theorem boundarySevenRealizedFaces_eq_of_lt
+    (i j : Fin 8) (hij : i < j)
+    (x y : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type))
+    (hxy : stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) =
+      stdSimplex.map j.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)) :
+    SSet.toTop.map (SSet.boundary.ι.{0} i) x =
+      SSet.toTop.map (SSet.boundary.ι.{0} j) y := by
+  let xi := SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x
+  let yj := SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y
+  let ki : Fin 7 := j.pred (Fin.ne_zero_of_lt hij)
+  let kj : Fin 7 := i.castPred (Fin.ne_last_of_lt hij)
+  have hiki : i.succAbove ki = j := by
+    exact Fin.succAbove_pred_of_lt i j hij
+  have hjkj : j.succAbove kj = i := by
+    exact Fin.succAbove_castPred_of_lt j i hij
+  have hxi : xi ki = 0 := by
+    calc
+      xi ki = stdSimplex.map i.succAbove xi (i.succAbove ki) :=
+        (stdSimplex_map_apply_of_injective i.succAbove
+          Fin.succAbove_right_injective xi ki).symm
+      _ = stdSimplex.map j.succAbove yj (i.succAbove ki) :=
+        congrArg (fun w : stdSimplex ℝ (Fin 8) ↦ w (i.succAbove ki)) hxy
+      _ = stdSimplex.map j.succAbove yj j := by rw [hiki]
+      _ = 0 := stdSimplex_map_succAbove_apply_self j yj
+  have hyj : yj kj = 0 := by
+    calc
+      yj kj = stdSimplex.map j.succAbove yj (j.succAbove kj) :=
+        (stdSimplex_map_apply_of_injective j.succAbove
+          Fin.succAbove_right_injective yj kj).symm
+      _ = stdSimplex.map i.succAbove xi (j.succAbove kj) :=
+        congrArg (fun w : stdSimplex ℝ (Fin 8) ↦ w (j.succAbove kj)) hxy.symm
+      _ = stdSimplex.map i.succAbove xi i := by rw [hjkj]
+      _ = 0 := stdSimplex_map_succAbove_apply_self i xi
+  let zx := stdSimplexDeleteZeroCoordinate ki xi hxi
+  let zy := stdSimplexDeleteZeroCoordinate kj yj hyj
+  have hz : zx = zy := by
+    apply stdSimplex_map_injective
+      (fun k : Fin 6 ↦ i.succAbove (ki.succAbove k))
+      (Fin.succAbove_right_injective.comp Fin.succAbove_right_injective)
+    calc
+      stdSimplex.map (fun k : Fin 6 ↦ i.succAbove (ki.succAbove k)) zx =
+          stdSimplex.map i.succAbove (stdSimplex.map ki.succAbove zx) := by
+            exact (stdSimplex.map_comp_apply ki.succAbove i.succAbove zx).symm
+      _ = stdSimplex.map i.succAbove xi := by
+        rw [stdSimplex_map_deleteZeroCoordinate]
+      _ = stdSimplex.map j.succAbove yj := hxy
+      _ = stdSimplex.map j.succAbove (stdSimplex.map kj.succAbove zy) := by
+        rw [stdSimplex_map_deleteZeroCoordinate]
+      _ = stdSimplex.map (fun k : Fin 6 ↦ j.succAbove (kj.succAbove k)) zy := by
+        exact stdSimplex.map_comp_apply kj.succAbove j.succAbove zy
+      _ = stdSimplex.map (fun k : Fin 6 ↦ i.succAbove (ki.succAbove k)) zy := by
+        rw [finPairFaceEmbedding_eq i j hij]
+  let z : (SSet.toTop.obj (Δ[5] : SSet.{0}) : Type) :=
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 5)).symm zx
+  have hx : SSet.toTop.map (SSet.stdSimplex.δ ki) z = x := by
+    apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+    calc
+      SimplexCategory.toTopHomeo (SimplexCategory.mk 6)
+          (SSet.toTop.map (SSet.stdSimplex.δ ki) z) =
+          stdSimplex.map ki.succAbove
+            (SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z) :=
+        SimplexCategory.toTopHomeo_naturality_apply
+          (SimplexCategory.δ ki) z
+      _ = stdSimplex.map ki.succAbove zx := by
+        rw [show SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z = zx by
+          simp [z]]
+      _ = xi := stdSimplex_map_deleteZeroCoordinate ki xi hxi
+      _ = SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x := rfl
+  have hy : SSet.toTop.map (SSet.stdSimplex.δ kj) z = y := by
+    apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+    calc
+      SimplexCategory.toTopHomeo (SimplexCategory.mk 6)
+          (SSet.toTop.map (SSet.stdSimplex.δ kj) z) =
+          stdSimplex.map kj.succAbove
+            (SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z) :=
+        SimplexCategory.toTopHomeo_naturality_apply
+          (SimplexCategory.δ kj) z
+      _ = stdSimplex.map kj.succAbove zx := by
+        rw [show SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z = zx by
+          simp [z]]
+      _ = stdSimplex.map kj.succAbove zy := by rw [hz]
+      _ = yj := stdSimplex_map_deleteZeroCoordinate kj yj hyj
+      _ = SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y := rfl
+  have hfaces : SSet.stdSimplex.δ ki ≫ SSet.boundary.ι.{0} i =
+      SSet.stdSimplex.δ kj ≫ SSet.boundary.ι.{0} j := by
+    rw [← cancel_mono (SSet.boundary 7).ι]
+    simp only [Category.assoc, SSet.boundary.ι_ι]
+    let hpair := SSet.stdSimplex.facePairComplIso_hom_ι
+      (n := 5) i j hij
+    let hpair' := SSet.stdSimplex.facePairComplIso_hom_ι'
+      (n := 5) i j hij
+    simpa [ki, kj] using hpair'.symm.trans hpair
+  rw [← hx, ← hy]
+  change (SSet.toTop.map (SSet.stdSimplex.δ ki) ≫
+      SSet.toTop.map (SSet.boundary.ι.{0} i)) z =
+    (SSet.toTop.map (SSet.stdSimplex.δ kj) ≫
+      SSet.toTop.map (SSet.boundary.ι.{0} j)) z
+  rw [← Functor.map_comp, ← Functor.map_comp, hfaces]
+
+/-- The canonical map from realization of the simplicial boundary to the ordinary barycentric
+boundary is injective.  Equal barycentric points either lie in the same standard facet or factor
+through the common codimension-two face of two distinct facets. -/
+public theorem boundarySevenRealizationToBoundary_injective :
+    Function.Injective boundarySevenRealizationToBoundary := by
+  intro x y hxy
+  obtain ⟨i, xi, hxi⟩ := boundarySevenRealization_standardFaceCovered x
+  obtain ⟨j, yj, hyj⟩ := boundarySevenRealization_standardFaceCovered y
+  rw [← hxi, ← hyj]
+  have hcoord : stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) xi) =
+      stdSimplex.map j.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) yj) := by
+    have hv := congrArg Subtype.val hxy
+    rw [← hxi, ← hyj] at hv
+    simpa only [boundarySevenRealizationToBoundary_val,
+      boundarySevenRealizationToStdSimplex_face] using hv
+  rcases lt_trichotomy i j with hij | hij | hij
+  · exact boundarySevenRealizedFaces_eq_of_lt i j hij xi yj hcoord
+  · subst j
+    have hface : xi = yj := by
+      apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+      apply stdSimplex_map_injective i.succAbove Fin.succAbove_right_injective
+      exact hcoord
+    subst yj
+    rfl
+  · exact (boundarySevenRealizedFaces_eq_of_lt j i hij yj xi hcoord.symm).symm
+
+/-- The geometric realization of the boundary of the seven-simplex is homeomorphic to the
+project's standard six-sphere. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere :
+    BoundarySevenRealizationHomeomorphSixSphere :=
+  boundarySevenRealizationHomeomorphSixSphere_of_injective
+    boundarySevenRealizationToBoundary_injective
+
+/-- Consequently the boundary comparison package now requires only the chain-level
+simplicial-to-singular quasi-isomorphism. -/
+public theorem boundarySevenComparisonInputs_of_quasiIsomorphism
+    (R : AddCommGrpCat)
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) R) :
+    BoundarySevenComparisonInputs R :=
+  ⟨hcomparison, boundarySevenRealizationHomeomorphSixSphere⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/ContractibleSingularMapQuasiIso.lean
+++ b/SphereSixComplex/Topology/ContractibleSingularMapQuasiIso.lean
@@ -1,0 +1,98 @@
+module
+
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparisonGeneral
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Singular chains of maps between contractible spaces
+
+Every specified continuous map between two contractible spaces is itself a homotopy equivalence.
+Consequently its singular-chain map is a quasi-isomorphism, with arbitrary coefficients.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+variable {X Y : Type}
+variable [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- Replacing the forward map of a homotopy equivalence by a homotopic map preserves the bundled
+homotopy equivalence. -/
+public noncomputable def homotopyEquivOfHomotopicTo
+    (f : C(X, Y)) (e : X ≃ₕ Y) (h : f.Homotopic e.toFun) : X ≃ₕ Y where
+  toFun := f
+  invFun := e.invFun
+  left_inv := (ContinuousMap.Homotopic.comp (.refl e.invFun) h).trans e.left_inv
+  right_inv := (ContinuousMap.Homotopic.comp h (.refl e.invFun)).trans e.right_inv
+
+/-- Any specified continuous map between contractible spaces carries a homotopy equivalence. -/
+public noncomputable def homotopyEquivOfMapBetweenContractibleSpaces
+    [ContractibleSpace X] [ContractibleSpace Y] (f : C(X, Y)) : X ≃ₕ Y := by
+  let e := Classical.choice (ContractibleSpace.hequiv X Y)
+  let hnull := id_nullhomotopic Y
+  let y := Classical.choose hnull
+  let hy := Classical.choose_spec hnull
+  have hf : f.Homotopic (ContinuousMap.const X y) := by
+    simpa only [ContinuousMap.id_comp, ContinuousMap.const_comp] using
+      ContinuousMap.Homotopic.comp hy (.refl f)
+  have he : e.toFun.Homotopic (ContinuousMap.const X y) := by
+    simpa only [ContinuousMap.id_comp, ContinuousMap.const_comp] using
+      ContinuousMap.Homotopic.comp hy (.refl e.toFun)
+  exact homotopyEquivOfHomotopicTo f e (hf.trans he.symm)
+
+/-- Applying singular chains with arbitrary coefficients to the forward map of a homotopy
+equivalence gives a quasi-isomorphism. -/
+public theorem singularChainMap_quasiIso_of_homotopyEquiv
+    (R : AddCommGrpCat) (e : X ≃ₕ Y) :
+    QuasiIso (SSet.chainComplexMap
+      (TopCat.toSSet.map (TopCat.ofHom e.toFun)) R) := by
+  rw [quasiIso_iff]
+  intro k
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  change IsIso (singularHomologyIsoOfHomotopyEquiv R k e).hom
+  infer_instance
+
+/-- The singular-chain map of any continuous map between contractible spaces is a
+quasi-isomorphism. -/
+public theorem singularChainMap_quasiIso_of_contractibleSpaces
+    [ContractibleSpace X] [ContractibleSpace Y]
+    (R : AddCommGrpCat) (f : C(X, Y)) :
+    QuasiIso (SSet.chainComplexMap
+      (TopCat.toSSet.map (TopCat.ofHom f)) R) := by
+  exact singularChainMap_quasiIso_of_homotopyEquiv R
+    (homotopyEquivOfMapBetweenContractibleSpaces f)
+
+/-- The canonical standard-simplex comparison followed by any continuous map to a contractible
+space. -/
+public noncomputable def standardSimplexToContractibleSingularChainMap
+    {Z : Type} [TopologicalSpace Z] (R : AddCommGrpCat) (n : ℕ)
+    (f : C((SSet.toTop.obj (Δ[n] : SSet.{0}) : Type), Z)) :
+    (Δ[n] : SSet.{0}).chainComplex R ⟶
+      (TopCat.toSSet.obj (TopCat.of Z)).chainComplex R :=
+  simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R ≫
+    SSet.chainComplexMap (TopCat.toSSet.map (TopCat.ofHom f)) R
+
+/-- Every such standard-simplex-to-contractible-space comparison is a quasi-isomorphism, with
+arbitrary coefficients. -/
+public theorem standardSimplexToContractibleSingularChainMap_quasiIso
+    {Z : Type} [TopologicalSpace Z] [ContractibleSpace Z]
+    (R : AddCommGrpCat) (n : ℕ)
+    (f : C((SSet.toTop.obj (Δ[n] : SSet.{0}) : Type), Z)) :
+    QuasiIso (standardSimplexToContractibleSingularChainMap R n f) := by
+  let _ : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    standardSimplexRealization_contractibleSpace n
+  let hstandard : QuasiIso
+      (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) :=
+    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso_general R n
+  let htarget : QuasiIso
+      (SSet.chainComplexMap (TopCat.toSSet.map (TopCat.ofHom f)) R) :=
+    singularChainMap_quasiIso_of_contractibleSpaces R f
+  unfold standardSimplexToContractibleSingularChainMap
+  infer_instance
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/HomotopySphereHomology.lean
+++ b/SphereSixComplex/Topology/HomotopySphereHomology.lean
@@ -1,0 +1,71 @@
+module
+
+public import SphereSixComplex.Topology.OrientedSmoothHomotopySphere
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Homology transport for marked homotopy six-spheres
+
+A marking is an actual homotopy equivalence with the standard six-sphere.  This file packages the
+resulting singular-homology isomorphism for arbitrary coefficients in `AddCommGrpCat`, so the
+mod-two middle-homology input in the Kervaire argument reduces exactly to the corresponding
+calculation for the standard sphere.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap
+
+namespace SphereSixComplex
+
+/-- Singular homology with arbitrary abelian-group coefficients is invariant under a specified
+homotopy equivalence. -/
+public noncomputable def singularHomologyIsoOfHomotopyEquiv
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (R : AddCommGrpCat) (k : ℕ) (e : X ≃ₕ Y) :
+    ((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of X) ≅
+      ((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of Y) := by
+  let F := (singularHomologyFunctor AddCommGrpCat k).obj R
+  let f : TopCat.of X ⟶ TopCat.of Y := TopCat.ofHom e.toFun
+  let g : TopCat.of Y ⟶ TopCat.of X := TopCat.ofHom e.invFun
+  exact CategoryTheory.Iso.mk (F.map f) (F.map g) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.left_inv.some R k) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.right_inv.some R k)
+
+/-- Vanishing of a singular-homology group transports backward across a homotopy equivalence. -/
+public theorem singularHomology_isZero_of_homotopyEquiv
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (R : AddCommGrpCat) (k : ℕ) (e : X ≃ₕ Y)
+    (hY : IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of Y))) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of X)) :=
+  hY.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
+
+/-- For a marked smooth homotopy six-sphere, every coefficientwise homology-vanishing theorem for
+the standard sphere immediately transports to its carrier. -/
+public theorem OrientedMarkedSmoothHomotopySixSphere.singularHomology_isZero_of_standard
+    (S : OrientedMarkedSmoothHomotopySixSphere) (R : AddCommGrpCat) (k : ℕ)
+    (hstandard :
+      IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj
+        (TopCat.of SixSphere))) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj
+      (TopCat.of S.carrier)) :=
+  singularHomology_isZero_of_homotopyEquiv R k S.marking hstandard
+
+/-- The exact middle-dimensional mod-two input for the Kervaire argument on all marked homotopy
+six-spheres follows from the single standard-sphere calculation. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (hstandard :
+      IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+        (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)))
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  S.singularHomology_isZero_of_standard (AddCommGrpCat.of (ZMod 2)) 3 hstandard
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/OrientedSmoothHomotopySphere.lean
+++ b/SphereSixComplex/Topology/OrientedSmoothHomotopySphere.lean
@@ -1,0 +1,220 @@
+module
+
+public import SphereSixComplex.Topology.SmoothRecognition
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+
+/-!
+# Oriented marked smooth homotopy six-spheres
+
+This file packages the geometric objects underlying the classical group `Θ₆`.  A *marking* is an
+actual homotopy equivalence with the standard sphere.  Classically its degree is `+1` or `-1` and
+therefore determines an orientation.  Mathlib does not yet define orientations of manifolds or the
+degree of a map between manifolds, so retaining the marking is the strongest concrete replacement
+currently available for an oriented homotopy sphere.
+
+This is deliberately different from an unoriented diffeomorphism class of smooth structures on a
+topological sphere.  No quotient and no h-cobordism theorem is introduced here.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open ContinuousMap
+open scoped ContDiff Manifold
+
+namespace SphereSixComplex
+
+/-- A closed smooth homotopy six-sphere with a chosen homotopy marking to the standard sphere.
+
+The explicit marking is the formal orientation datum: replacing it by its composite with the
+antipodal map reverses the induced classical orientation.  The Hausdorff and countability fields
+record the hypotheses used by the classical differential-topology theorems. -/
+public structure OrientedMarkedSmoothHomotopySixSphere.{u} where
+  /-- The underlying carrier. -/
+  carrier : Type u
+  /-- Topology of the carrier. -/
+  [topologicalSpace : TopologicalSpace carrier]
+  /-- Smooth atlas modelled on real six-space. -/
+  [chartedSpace : ChartedSpace RealModel carrier]
+  /-- Classical manifolds are Hausdorff. -/
+  [t2Space : T2Space carrier]
+  /-- Classical manifolds are second countable. -/
+  [secondCountableTopology : SecondCountableTopology carrier]
+  /-- The given atlas is smooth. -/
+  [isManifold : IsManifold 𝓘(ℝ, RealModel) ∞ carrier]
+  /-- The homotopy sphere is compact. -/
+  [compactSpace : CompactSpace carrier]
+  /-- The homotopy sphere is connected. -/
+  [connectedSpace : ConnectedSpace carrier]
+  /-- The ends used in h-cobordisms are closed manifolds. -/
+  [boundaryless : BoundarylessManifold 𝓘(ℝ, RealModel) carrier]
+  /-- The marking whose degree determines the orientation. -/
+  marking : carrier ≃ₕ SixSphere
+
+namespace OrientedMarkedSmoothHomotopySixSphere
+
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : TopologicalSpace S.carrier :=
+  S.topologicalSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : ChartedSpace RealModel S.carrier :=
+  S.chartedSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : T2Space S.carrier := S.t2Space
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : SecondCountableTopology S.carrier :=
+  S.secondCountableTopology
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : IsManifold 𝓘(ℝ, RealModel) ∞ S.carrier :=
+  S.isManifold
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : CompactSpace S.carrier := S.compactSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : ConnectedSpace S.carrier := S.connectedSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) :
+    BoundarylessManifold 𝓘(ℝ, RealModel) S.carrier :=
+  S.boundaryless
+
+/-- Forgetting the explicit marking gives the recognition layer's smooth homotopy-sphere
+contract. -/
+public theorem smoothHomotopySixSphere (S : OrientedMarkedSmoothHomotopySixSphere) :
+    SmoothHomotopySixSphere S.carrier where
+  isManifold := inferInstance
+  compact := inferInstance
+  connected := inferInstance
+  homotopyEquiv := ⟨S.marking⟩
+
+/-- The standard marked sphere. -/
+public def standard : OrientedMarkedSmoothHomotopySixSphere where
+  carrier := SixSphere
+  connectedSpace := sixSphere_connectedSpace
+  marking := ContinuousMap.HomotopyEquiv.refl SixSphere
+
+/-- The antipodal self-homeomorphism of the standard sphere, regarded as a homotopy
+equivalence.  Classically this map has degree `-1` in dimension six. -/
+public def antipodalMarking : SixSphere ≃ₕ SixSphere :=
+  (Homeomorph.neg SixSphere).toHomotopyEquiv
+
+@[simp]
+public theorem antipodalMarking_apply (x : SixSphere) : antipodalMarking x = -x :=
+  rfl
+
+/-- Reverse the orientation represented by a marking by postcomposing it with the antipodal map
+of `S⁶`.  This changes no underlying smooth-manifold data. -/
+public def reverseOrientation (S : OrientedMarkedSmoothHomotopySixSphere) :
+    OrientedMarkedSmoothHomotopySixSphere where
+  carrier := S.carrier
+  marking := S.marking.trans antipodalMarking
+
+@[simp]
+public theorem reverseOrientation_carrier (S : OrientedMarkedSmoothHomotopySixSphere) :
+    S.reverseOrientation.carrier = S.carrier :=
+  rfl
+
+/-- The presently missing degree theory for self-homotopy equivalences of `S⁶`.
+
+The composition law and the assertion that every self-equivalence has degree `±1` prevent this
+from being a bare label for the desired antipodal conclusion.  A future implementation should
+construct `degree` from the induced map on top integral homology. -/
+public structure SixSphereDegreeTheory where
+  /-- Degree of a self-homotopy equivalence. -/
+  degree : (SixSphere ≃ₕ SixSphere) → ℤ
+  /-- The identity has degree one. -/
+  degree_refl : degree (ContinuousMap.HomotopyEquiv.refl SixSphere) = 1
+  /-- Degree is multiplicative under composition. -/
+  degree_trans : ∀ f g, degree (f.trans g) = degree f * degree g
+  /-- Every homotopy equivalence has degree `±1`. -/
+  degree_eq_one_or_neg_one : ∀ f, degree f = 1 ∨ degree f = -1
+  /-- The antipodal equivalence has degree `-1` in even sphere dimension. -/
+  degree_antipodal : degree antipodalMarking = -1
+  /-- Homotopic self-maps have the same degree. -/
+  degree_homotopic : ∀ f g : SixSphere ≃ₕ SixSphere,
+    f.toFun.Homotopic g.toFun → degree f = degree g
+
+/-- Availability of degree theory, isolated as a named proposition rather than an axiom. -/
+public def SixSphereDegreeTheoryObligation : Prop := Nonempty SixSphereDegreeTheory
+
+/-- Two markings of the same homotopy sphere induce the same orientation when their transition
+self-equivalence of `S⁶` has degree one. -/
+public def SameOrientation (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    (e₁ e₂ : X ≃ₕ SixSphere) : Prop :=
+  D.degree (e₁.symm.trans e₂) = 1
+
+namespace SameOrientation
+
+/-- Homotopic markings induce the same orientation. -/
+public theorem of_homotopic (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    {e₁ e₂ : X ≃ₕ SixSphere} (h : e₁.toFun.Homotopic e₂.toFun) :
+    SameOrientation D e₁ e₂ := by
+  unfold SameOrientation
+  have htransition : (e₁.symm.trans e₂).toFun.Homotopic
+      (ContinuousMap.HomotopyEquiv.refl SixSphere).toFun :=
+    (ContinuousMap.Homotopic.comp h.symm (.refl e₁.invFun)).trans e₁.right_inv
+  rw [D.degree_homotopic _ _ htransition]
+  exact D.degree_refl
+
+/-- A marking induces the same orientation as itself. -/
+public theorem refl (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    (e : X ≃ₕ SixSphere) : SameOrientation D e e := by
+  unfold SameOrientation
+  rw [D.degree_homotopic (e.symm.trans e)
+    (ContinuousMap.HomotopyEquiv.refl SixSphere) e.right_inv]
+  exact D.degree_refl
+
+/-- Reversing the comparison of two markings preserves the same-orientation condition. -/
+public theorem symm (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    {e₁ e₂ : X ≃ₕ SixSphere} (h : SameOrientation D e₁ e₂) :
+    SameOrientation D e₂ e₁ := by
+  let f := e₁.symm.trans e₂
+  have hf : D.degree f = 1 := h
+  have hfinv : D.degree f.symm = 1 := by
+    calc
+      D.degree f.symm = D.degree f * D.degree f.symm := by rw [hf, one_mul]
+      _ = D.degree (f.trans f.symm) := (D.degree_trans f f.symm).symm
+      _ = D.degree (ContinuousMap.HomotopyEquiv.refl SixSphere) :=
+        D.degree_homotopic _ _ f.left_inv
+      _ = 1 := D.degree_refl
+  exact hfinv
+
+/-- Same orientation is transitive on markings of a fixed homotopy sphere. -/
+public theorem trans (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    {e₁ e₂ e₃ : X ≃ₕ SixSphere}
+    (h₁₂ : SameOrientation D e₁ e₂) (h₂₃ : SameOrientation D e₂ e₃) :
+    SameOrientation D e₁ e₃ := by
+  let f₁₂ := e₁.symm.trans e₂
+  let f₂₃ := e₂.symm.trans e₃
+  have hcomp : D.degree (f₁₂.trans f₂₃) = 1 := by
+    rw [D.degree_trans, show D.degree f₁₂ = 1 from h₁₂,
+      show D.degree f₂₃ = 1 from h₂₃, one_mul]
+  have hcancel : (f₁₂.trans f₂₃).toFun.Homotopic
+      (e₁.symm.trans e₃).toFun := by
+    exact ContinuousMap.Homotopic.comp (.refl e₃.toFun)
+      (ContinuousMap.Homotopic.comp e₂.left_inv (.refl e₁.invFun))
+  exact (D.degree_homotopic _ _ hcancel).symm.trans hcomp
+
+/-- Precomposing both markings by a homotopy equivalence does not change their relative
+orientation. -/
+public theorem precomp (D : SixSphereDegreeTheory)
+    {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    {e₁ e₂ : X ≃ₕ SixSphere} (a : Y ≃ₕ X) (h : SameOrientation D e₁ e₂) :
+    SameOrientation D (a.trans e₁) (a.trans e₂) := by
+  unfold SameOrientation at h ⊢
+  have hcancel : ((a.trans e₁).symm.trans (a.trans e₂)).toFun.Homotopic
+      (e₁.symm.trans e₂).toFun := by
+    exact ContinuousMap.Homotopic.comp (.refl e₂.toFun)
+      (ContinuousMap.Homotopic.comp a.right_inv (.refl e₁.invFun))
+  rw [D.degree_homotopic _ _ hcancel]
+  exact h
+
+/-- Postcomposition with the antipodal map genuinely reverses the orientation represented by a
+marking. -/
+public theorem not_reverseOrientation (D : SixSphereDegreeTheory)
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    ¬ SameOrientation D S.marking S.reverseOrientation.marking := by
+  unfold SameOrientation
+  have hcancel :
+      (S.marking.symm.trans S.reverseOrientation.marking).toFun.Homotopic
+        antipodalMarking.toFun := by
+    exact ContinuousMap.Homotopic.comp (.refl antipodalMarking.toFun) S.marking.right_inv
+  rw [D.degree_homotopic _ _ hcancel, D.degree_antipodal]
+  norm_num
+
+end SameOrientation
+
+end OrientedMarkedSmoothHomotopySixSphere
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSingularComparison.lean
+++ b/SphereSixComplex/Topology/SimplicialSingularComparison.lean
@@ -1,0 +1,133 @@
+module
+
+public import SphereSixComplex.Topology.HomotopySphereHomology
+public import SphereSixComplex.Topology.SimplicialSixSphereHomology
+public import SphereSixComplex.Topology.SingularHomologyModTwo
+public import Mathlib.Algebra.Homology.QuasiIso
+public import Mathlib.AlgebraicTopology.SimplicialSet.TopAdj
+
+/-!
+# The canonical simplicial-to-singular comparison
+
+The unit of the geometric-realization/singular-set adjunction sends every simplex of a simplicial
+set to the corresponding singular simplex of its realization.  Applying simplicial chains gives
+the canonical comparison map.  This file packages that concrete map and proves that its
+quasi-isomorphism, together with a homeomorphism `|∂Δ[7]| ≃ S⁶`, transports the already-computed
+degree-two and degree-three homology vanishing to the standard topological sphere.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical chain map from simplicial chains to singular chains on geometric realization. -/
+public noncomputable def simplicialToRealizationSingularChainMap
+    (K : SSet.{0}) (R : AddCommGrpCat) :
+    K.chainComplex R ⟶
+      (TopCat.toSSet.obj (SSet.toTop.obj K)).chainComplex R :=
+  SSet.chainComplexMap (sSetTopAdj.unit.app K) R
+
+/-- The precise general comparison theorem needed here. -/
+public def SimplicialToSingularComparisonQuasiIsomorphism
+    (K : SSet.{0}) (R : AddCommGrpCat) : Prop :=
+  QuasiIso (simplicialToRealizationSingularChainMap K R)
+
+/-- A quasi-isomorphic comparison transports vanishing from simplicial homology to singular
+homology of the realization. -/
+public theorem realizationSingularHomology_isZero_of_simplicial
+    (K : SSet.{0}) (R : AddCommGrpCat) (k : ℕ)
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism K R)
+    (hsimplicial : IsZero ((K.chainComplex R).homology k)) :
+    IsZero (((TopCat.toSSet.obj (SSet.toTop.obj K)).chainComplex R).homology k) := by
+  let _ : QuasiIso (simplicialToRealizationSingularChainMap K R) := hcomparison
+  exact hsimplicial.of_iso
+    (isoOfQuasiIsoAt (simplicialToRealizationSingularChainMap K R) k).symm
+
+/-- The geometric identification of the realization of the boundary of the seven-simplex with
+the project's standard six-sphere. -/
+public def BoundarySevenRealizationHomeomorphSixSphere : Prop :=
+  Nonempty ((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ SixSphere)
+
+/-- The two exact comparison inputs, isolated from the finite cone calculation. -/
+public def BoundarySevenComparisonInputs (R : AddCommGrpCat) : Prop :=
+  SimplicialToSingularComparisonQuasiIsomorphism (∂Δ[7] : SSet.{0}) R ∧
+    BoundarySevenRealizationHomeomorphSixSphere
+
+/-- The boundary comparison inputs imply degree-three singular homology vanishing for `S⁶`. -/
+public theorem sixSphere_singularHomology_three_isZero_of_boundaryComparison
+    (R : AddCommGrpCat) (h : BoundarySevenComparisonInputs R) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj R).obj
+      (TopCat.of SixSphere)) := by
+  obtain ⟨hcomparison, ⟨e⟩⟩ := h
+  have hrealization :
+      IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj R).obj
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))) :=
+    realizationSingularHomology_isZero_of_simplicial
+      (∂Δ[7] : SSet.{0}) R 3 hcomparison
+        (boundarySeven_simplicialHomology_three_isZero R)
+  exact hrealization.of_iso
+    (((singularHomologyFunctor AddCommGrpCat 3).obj R).mapIso
+      (TopCat.isoOfHomeo e.symm))
+
+/-- Likewise, the comparison inputs imply degree-two singular homology vanishing for `S⁶`. -/
+public theorem sixSphere_singularHomology_two_isZero_of_boundaryComparison
+    (R : AddCommGrpCat) (h : BoundarySevenComparisonInputs R) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 2).obj R).obj
+      (TopCat.of SixSphere)) := by
+  obtain ⟨hcomparison, ⟨e⟩⟩ := h
+  have hrealization :
+      IsZero (((singularHomologyFunctor AddCommGrpCat 2).obj R).obj
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))) :=
+    realizationSingularHomology_isZero_of_simplicial
+      (∂Δ[7] : SSet.{0}) R 2 hcomparison
+        (boundarySeven_simplicialHomology_two_isZero R)
+  exact hrealization.of_iso
+    (((singularHomologyFunctor AddCommGrpCat 2).obj R).mapIso
+      (TopCat.isoOfHomeo e.symm))
+
+/-- The comparison theorem over `𝔽₂` supplies exactly the standard-sphere Kervaire input. -/
+public theorem sixSphere_modTwoHomology_three_isZero_of_boundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of (ZMod 2))) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) :=
+  sixSphere_singularHomology_three_isZero_of_boundaryComparison
+    (AddCommGrpCat.of (ZMod 2)) h
+
+/-- It is enough to prove the simplicial-to-singular comparison with integral coefficients:
+degree-two and degree-three integral vanishing pass to mod-two degree-three homology through the
+proved coefficient Bockstein sequence. -/
+public theorem sixSphere_modTwoHomology_three_isZero_of_integralBoundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of ℤ)) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) := by
+  apply modTwoSingularHomologyThree_isZero (TopCat.of SixSphere)
+  · exact sixSphere_singularHomology_three_isZero_of_boundaryComparison
+      (AddCommGrpCat.of ℤ) h
+  · exact sixSphere_singularHomology_two_isZero_of_boundaryComparison
+      (AddCommGrpCat.of ℤ) h
+
+/-- Consequently, the same two comparison inputs give the middle-dimensional mod-two vanishing
+for every marked smooth homotopy six-sphere. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_of_boundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of (ZMod 2)))
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (sixSphere_modTwoHomology_three_isZero_of_boundaryComparison h) S
+
+/-- The integral comparison inputs therefore also suffice for every marked homotopy sphere. -/
+public theorem
+    markedHomotopySixSphere_modTwoHomology_three_isZero_of_integralBoundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of ℤ))
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (sixSphere_modTwoHomology_three_isZero_of_integralBoundaryComparison h) S
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSingularComparisonProof.lean
+++ b/SphereSixComplex/Topology/SimplicialSingularComparisonProof.lean
@@ -1,0 +1,339 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import SphereSixComplex.Topology.SingularExcisionOpenCover
+
+/-!
+# Reduction of simplicial--singular comparison to cover-small chains
+
+For an open cover of the realization, the affine subdivision theorem proves that cover-small
+singular chains include quasi-isomorphically into all singular chains.  Consequently, whenever
+the adjunction unit lands in the cover-small singular subcomplex, the canonical comparison is a
+quasi-isomorphism exactly when its lift to cover-small chains is one.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+variable {iota : Type} (K : SSet.{0})
+  (U : iota → Set (SSet.toTop.obj K))
+
+/-- The adjunction unit defining the simplicial--singular comparison has image in the simplices
+small for `U`. -/
+public def SimplicialRealizationUnitLandsInCoverSmall : Prop :=
+  SSet.Subcomplex.range (sSetTopAdj.unit.app K) ≤
+    coverSmallSingularSubcomplex (SSet.toTop.obj K) U
+
+/-- Elementwise form of cover-smallness: every canonical realized simplex factors through one
+member of the cover. -/
+public theorem simplicialRealizationUnitLandsInCoverSmall_iff :
+    SimplicialRealizationUnitLandsInCoverSmall K U ↔
+      ∀ (n : SimplexCategoryᵒᵖ) (x : K.obj n),
+        ∃ (j : iota)
+          (y : (TopCat.toSSet.obj (TopCat.of (U j))).obj n),
+          (TopCat.toSSet.map
+            (topologicalSubsetInclusion (SSet.toTop.obj K) (U j))).app n y =
+            (sSetTopAdj.unit.app K).app n x := by
+  constructor
+  · intro h n x
+    apply (mem_coverSmallSingularSubcomplex_iff_exists_preimage
+      (SSet.toTop.obj K) U _).mp
+    exact h n ⟨x, rfl⟩
+  · intro h n z hz
+    obtain ⟨x, rfl⟩ := hz
+    exact (mem_coverSmallSingularSubcomplex_iff_exists_preimage
+      (SSet.toTop.obj K) U _).mpr (h n x)
+
+/-- The adjunction unit lifted to the cover-small singular simplicial set. -/
+public noncomputable def simplicialToCoverSmallSingularSet
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    K ⟶ coverSmallSingularSubcomplex (SSet.toTop.obj K) U :=
+  SSet.Subcomplex.lift (sSetTopAdj.unit.app K) hsmall
+
+@[reassoc (attr := simp)]
+public theorem simplicialToCoverSmallSingularSet_comp_inclusion
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    simplicialToCoverSmallSingularSet K U hsmall ≫
+        (coverSmallSingularSubcomplex (SSet.toTop.obj K) U).ι =
+      sSetTopAdj.unit.app K :=
+  SSet.Subcomplex.lift_ι _ _
+
+/-- The integral simplicial comparison, with codomain restricted to cover-small singular
+chains. -/
+public noncomputable def simplicialToCoverSmallSingularChainMap
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    K.chainComplex (AddCommGrpCat.of ℤ) ⟶
+      CoverSmallIntegralSingularChainComplex (SSet.toTop.obj K) U :=
+  SSet.chainComplexMap (simplicialToCoverSmallSingularSet K U hsmall)
+    (AddCommGrpCat.of ℤ)
+
+/-- The cover-small lift followed by inclusion is the canonical comparison map. -/
+@[reassoc]
+public theorem simplicialToCoverSmallSingularChainMap_comp_inclusion
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    simplicialToCoverSmallSingularChainMap K U hsmall ≫
+        coverSmallIntegralSingularChainInclusion (SSet.toTop.obj K) U =
+      simplicialToRealizationSingularChainMap K (AddCommGrpCat.of ℤ) := by
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (simplicialToCoverSmallSingularSet K U hsmall) ≫
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (coverSmallSingularSubcomplex (SSet.toTop.obj K) U).ι =
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+      (sSetTopAdj.unit.app K)
+  rw [← Functor.map_comp,
+    simplicialToCoverSmallSingularSet_comp_inclusion]
+
+/-- For an open cover, affine subdivision removes the full-singular-chain part of the comparison
+problem: the canonical comparison is a quasi-isomorphism if and only if its cover-small lift is.
+-/
+public theorem simplicialToSingularComparisonQuasiIsomorphism_iff_coverSmallLift
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    SimplicialToSingularComparisonQuasiIsomorphism K (AddCommGrpCat.of ℤ) ↔
+      QuasiIso (simplicialToCoverSmallSingularChainMap K U hsmall) := by
+  have hcover : QuasiIso
+      (coverSmallIntegralSingularChainInclusion (SSet.toTop.obj K) U) :=
+    coverSmallChainQuasiIsomorphism_of_openCover
+      (SSet.toTop.obj K) U hUopen hUcover
+  change QuasiIso
+      (simplicialToRealizationSingularChainMap K (AddCommGrpCat.of ℤ)) ↔
+    QuasiIso (simplicialToCoverSmallSingularChainMap K U hsmall)
+  rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion K U hsmall]
+  exact quasiIso_iff_comp_right _ _ (hφ' := hcover)
+
+/-- The canonical map from the boundary realization to the ordinary affine standard
+seven-simplex, duplicated here so that the comparison proof is independent of any later geometric
+identification of the boundary realization. -/
+public noncomputable def boundarySevenComparisonToStdSimplex :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
+  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι x),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
+      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
+
+/-- On a codimension-one face, the comparison map is the usual affine face inclusion. -/
+public theorem boundarySevenComparisonToStdSimplex_face
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenComparisonToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
+  unfold boundarySevenComparisonToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
+  rw [← ConcreteCategory.comp_apply]
+  rw [← SSet.toTop.map_comp]
+  rw [SSet.boundary.ι_ι]
+  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
+
+/-- An open neighborhood of the `i`-th affine face, pulled back to the realization of
+`∂Δ[7]`. -/
+public def boundarySevenComparisonFaceNeighborhood (i : Fin 8) :
+    Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
+  {x | boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8}
+
+/-- The affine face neighborhoods are open. -/
+public theorem boundarySevenComparisonFaceNeighborhood_isOpen (i : Fin 8) :
+    IsOpen (boundarySevenComparisonFaceNeighborhood i) := by
+  apply isOpen_lt
+  · exact ((continuous_apply i).comp continuous_subtype_val).comp
+      boundarySevenComparisonToStdSimplex.continuous
+  · exact continuous_const
+
+/-- The realization of the `i`-th simplicial face lands in its corresponding open affine
+neighborhood. -/
+public noncomputable def boundarySevenFaceToComparisonFaceNeighborhood (i : Fin 8) :
+    SSet.toTop.obj (Δ[6] : SSet.{0}) ⟶
+      TopCat.of (boundarySevenComparisonFaceNeighborhood i) := by
+  refine TopCat.ofHom
+    { toFun := fun x ↦ ⟨SSet.toTop.map (SSet.boundary.ι i) x, ?_⟩
+      continuous_toFun := ?_ }
+  · change boundarySevenComparisonToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) i < (1 : ℝ) / 8
+    rw [boundarySevenComparisonToStdSimplex_face]
+    change stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) i < (1 : ℝ) / 8
+    have hz : stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) i = 0 := by
+      classical
+      simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+      apply Finset.sum_eq_zero
+      intro j hj
+      exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+    rw [hz]
+    norm_num
+  · exact (SSet.toTop.map (SSet.boundary.ι i)).hom.continuous.subtype_mk _
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenFaceToComparisonFaceNeighborhood_comp_inclusion
+    (i : Fin 8) :
+    boundarySevenFaceToComparisonFaceNeighborhood i ≫
+        topologicalSubsetInclusion (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          (boundarySevenComparisonFaceNeighborhood i) =
+      SSet.toTop.map (SSet.boundary.ι i) := by
+  rfl
+
+/-- The unit on one standard face, mapped into the cover-small singular simplicial set of the
+boundary realization. -/
+public noncomputable def boundarySevenFaceUnitToSmallSingularSet (i : Fin 8) :
+    (Δ[6] : SSet.{0}) ⟶
+      coverSmallSingularSubcomplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood :=
+  sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+    TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i) ≫
+      coverMemberToSmallSingularSet
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood i
+
+/-- The facewise small unit is the restriction of the boundary comparison unit. -/
+@[reassoc (attr := simp)]
+public theorem boundarySevenFaceUnitToSmallSingularSet_comp_inclusion (i : Fin 8) :
+    boundarySevenFaceUnitToSmallSingularSet i ≫
+        (coverSmallSingularSubcomplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood).ι =
+      SSet.boundary.ι i ≫ sSetTopAdj.unit.app (∂Δ[7] : SSet.{0}) := by
+  unfold boundarySevenFaceUnitToSmallSingularSet
+  rw [Category.assoc, Category.assoc,
+    coverMemberToSmallSingularSet_comp_inclusion]
+  rw [← Functor.map_comp,
+    boundarySevenFaceToComparisonFaceNeighborhood_comp_inclusion]
+  exact (sSetTopAdj.unit.naturality (SSet.boundary.ι i)).symm
+
+/-- Every canonical simplicial simplex of `∂Δ[7]` lands in one of the eight affine face
+neighborhoods. -/
+public theorem boundarySevenComparisonUnitLandsInFaceNeighborhoods :
+    SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood := by
+  intro n z hz
+  obtain ⟨x, rfl⟩ := hz
+  have hx := x.2
+  simp only [SSet.boundary_eq_iSup, SSet.stdSimplex.face_singleton_compl,
+    Subfunctor.iSup_obj, Set.mem_iUnion,
+    SSet.Subcomplex.mem_ofSimplex_obj_iff, Opposite.op_unop] at hx
+  obtain ⟨i, ⟨y, hy⟩⟩ := hx
+  let y' : (Δ[6] : SSet.{0}).obj n := SSet.stdSimplex.objEquiv.symm y
+  have hxy : (SSet.boundary.ι i).app n y' = x := by
+    apply Subtype.ext
+    change (SSet.stdSimplex.map (SimplexCategory.δ i)).app n y' = x.1
+    exact hy
+  let w := (boundarySevenFaceUnitToSmallSingularSet i).app n y'
+  have hw : w.1 = (sSetTopAdj.unit.app (∂Δ[7] : SSet.{0})).app n x := by
+    have h := ConcreteCategory.congr_hom
+      (congr_app (boundarySevenFaceUnitToSmallSingularSet_comp_inclusion i) n) y'
+    change ((boundarySevenFaceUnitToSmallSingularSet i).app n y').1 =
+      (sSetTopAdj.unit.app (∂Δ[7] : SSet.{0})).app n
+        ((SSet.boundary.ι i).app n y') at h
+    simpa only [hxy] using h
+  rw [← hw]
+  exact w.2
+
+/-- The remaining global geometric assertion needed to know that the eight explicit affine face
+neighborhoods cover the whole realization.  It states precisely that the comparison map from the
+realized simplicial boundary lands in the affine boundary. -/
+public def BoundarySevenComparisonMapLandsInAffineBoundary : Prop :=
+  ∀ x : SSet.toTop.obj (∂Δ[7] : SSet.{0}),
+    ∃ i : Fin 8, boundarySevenComparisonToStdSimplex x i = 0
+
+/-- If the comparison map lands in the affine boundary, the eight explicit face neighborhoods
+cover the realization. -/
+public theorem boundarySevenComparisonFaceNeighborhood_iUnion
+    (hboundary : BoundarySevenComparisonMapLandsInAffineBoundary) :
+    ⋃ i, boundarySevenComparisonFaceNeighborhood i = Set.univ := by
+  apply Set.eq_univ_of_forall
+  intro x
+  obtain ⟨i, hi⟩ := hboundary x
+  apply Set.mem_iUnion.2
+  refine ⟨i, ?_⟩
+  change boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8
+  rw [hi]
+  norm_num
+
+/-- Specialized sharp reduction for the boundary of the seven-simplex.  It remains only to prove
+that the explicitly lifted map into cover-small chains is a quasi-isomorphism. -/
+public theorem boundarySeven_integralComparison_iff_coverSmallLift
+    (U : iota → Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})))
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) U) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ↔
+      QuasiIso (simplicialToCoverSmallSingularChainMap
+        (∂Δ[7] : SSet.{0}) U hsmall) :=
+  simplicialToSingularComparisonQuasiIsomorphism_iff_coverSmallLift
+    (∂Δ[7] : SSet.{0}) U hUopen hUcover hsmall
+
+/-- The second, purely chain-level input for the concrete eight-member face-neighborhood cover:
+the explicitly lifted simplicial comparison must be a quasi-isomorphism. -/
+public def BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism : Prop :=
+  QuasiIso (simplicialToCoverSmallSingularChainMap
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods)
+
+/-- Once the realized boundary is known to map to the affine boundary, the original comparison
+problem is exactly the quasi-isomorphism problem for the explicit face-neighborhood-small lift. -/
+public theorem boundarySeven_integralComparison_iff_faceNeighborhoodLift
+    (hboundary : BoundarySevenComparisonMapLandsInAffineBoundary) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ↔
+      BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism := by
+  unfold BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism
+  exact boundarySeven_integralComparison_iff_coverSmallLift
+    boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonFaceNeighborhood_isOpen
+    (boundarySevenComparisonFaceNeighborhood_iUnion hboundary)
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+
+/-- The two explicit remaining inputs imply the requested canonical integral comparison. -/
+public theorem boundarySeven_integralComparison_of_faceNeighborhoodLift
+    (hboundary : BoundarySevenComparisonMapLandsInAffineBoundary)
+    (hlift : BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  (boundarySeven_integralComparison_iff_faceNeighborhoodLift hboundary).2 hlift
+
+/-- Any open cover for which the cover-small lift is a quasi-isomorphism supplies the requested
+canonical integral comparison for `∂Δ[7]`. -/
+public theorem boundarySeven_integralComparison_of_coverSmallLift
+    (U : iota → Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})))
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) U)
+    (hlift : QuasiIso (simplicialToCoverSmallSingularChainMap
+      (∂Δ[7] : SSet.{0}) U hsmall)) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  (boundarySeven_integralComparison_iff_coverSmallLift
+    U hUopen hUcover hsmall).2 hlift
+
+/-- The exact remaining cover-level input for the integral boundary comparison: an open cover
+subordinate to all canonical simplicial simplices, on which the lifted comparison is a
+quasi-isomorphism. -/
+public def BoundarySevenIntegralCoverSmallComparison : Prop :=
+  ∃ (iota : Type)
+    (U : iota → Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})))
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) U),
+    (∀ i, IsOpen (U i)) ∧
+      ⋃ i, U i = Set.univ ∧
+      QuasiIso (simplicialToCoverSmallSingularChainMap
+        (∂Δ[7] : SSet.{0}) U hsmall)
+
+/-- The cover-level comparison input implies the requested canonical quasi-isomorphism. -/
+public theorem boundarySeven_integralComparison_of_coverSmallComparison
+    (h : BoundarySevenIntegralCoverSmallComparison) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) := by
+  obtain ⟨iota, U, hsmall, hUopen, hUcover, hlift⟩ := h
+  exact boundarySeven_integralComparison_of_coverSmallLift
+    U hUopen hUcover hsmall hlift
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSixSphereHomology.lean
+++ b/SphereSixComplex/Topology/SimplicialSixSphereHomology.lean
@@ -1,0 +1,212 @@
+module
+
+public import SphereSixComplex.Topology.SingularStandardSimplexCone
+public import Mathlib.AlgebraicTopology.SimplicialSet.Boundary
+
+/-!
+# Low-degree simplicial homology of the boundary of the seven-simplex
+
+The simplicial boundary `∂Δ[7]` is a finite combinatorial model of a six-sphere.  In degrees
+below six, prepending the zero vertex remains in the boundary and gives the usual cone
+contraction.  This file constructs that cone on Mathlib's actual coproduct chain groups, with an
+arbitrary coefficient object in `AddCommGrpCat`.
+
+This computes simplicial homology only.  Identifying the realization of `∂Δ[7]` with the
+topological six-sphere and comparing simplicial with singular homology are separate missing
+theorems.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- In low degrees, coning a simplex of `∂Δ[7]` to the zero vertex remains in `∂Δ[7]`. -/
+public noncomputable def boundarySevenZeroConeSimplex
+    (n : ℕ) (hn : n + 1 < 7)
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n))) :
+    (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk (n + 1))) :=
+  ⟨standardSimplexZeroConeSimplex 7 n x.1, by
+    rw [SSet.boundary_obj_eq_univ (n + 1) 7 hn]
+    exact Set.mem_univ _⟩
+
+/-- Removing the new cone vertex recovers the original boundary simplex. -/
+@[simp]
+public theorem boundarySevenZeroConeSimplex_delta_zero
+    (n : ℕ) (hn : n + 1 < 7)
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n))) :
+    (∂Δ[7] : SSet.{0}).δ 0 (boundarySevenZeroConeSimplex n hn x) = x := by
+  apply Subtype.ext
+  exact standardSimplexZeroConeSimplex_delta_zero 7 n x.1
+
+/-- Every later face of a low-degree boundary cone is the cone on the preceding face. -/
+@[simp]
+public theorem boundarySevenZeroConeSimplex_delta_succ
+    (n : ℕ) (hn : n + 2 < 7) (i : Fin (n + 2))
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk (n + 1)))) :
+    (∂Δ[7] : SSet.{0}).δ i.succ
+        (boundarySevenZeroConeSimplex (n + 1) hn x) =
+      boundarySevenZeroConeSimplex n (by omega)
+        ((∂Δ[7] : SSet.{0}).δ i x) := by
+  apply Subtype.ext
+  exact standardSimplexZeroConeSimplex_delta_succ 7 n i x.1
+
+/-- The zero-vertex cone on low-degree chains of `∂Δ[7]`. -/
+public noncomputable def boundarySevenZeroConeComponent
+    (R : AddCommGrpCat) (n : ℕ) (hn : n + 1 < 7) :
+    ((∂Δ[7] : SSet.{0}).chainComplex R).X n ⟶
+      ((∂Δ[7] : SSet.{0}).chainComplex R).X (n + 1) :=
+  Sigma.desc (fun x ↦
+    (∂Δ[7] : SSet.{0}).ιChainComplex
+      (boundarySevenZeroConeSimplex n hn x))
+
+@[reassoc (attr := simp)]
+public theorem iota_boundarySevenZeroConeComponent
+    (R : AddCommGrpCat) (n : ℕ) (hn : n + 1 < 7)
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n))) :
+    (∂Δ[7] : SSet.{0}).ιChainComplex x ≫
+        boundarySevenZeroConeComponent R n hn =
+      (∂Δ[7] : SSet.{0}).ιChainComplex
+        (boundarySevenZeroConeSimplex n hn x) := by
+  apply Sigma.ι_desc
+
+/-- In positive degrees below six, the boundary cone contracts the chain complex of `∂Δ[7]`.
+-/
+public theorem boundarySevenZeroConeComponent_boundary_succ
+    (R : AddCommGrpCat) (n : ℕ) (hn : n + 2 < 7) :
+    boundarySevenZeroConeComponent R (n + 1) hn ≫
+          ((∂Δ[7] : SSet.{0}).chainComplex R).d (n + 2) (n + 1) +
+        ((∂Δ[7] : SSet.{0}).chainComplex R).d (n + 1) n ≫
+          boundarySevenZeroConeComponent R n (by omega) =
+      𝟙 (((∂Δ[7] : SSet.{0}).chainComplex R).X (n + 1)) := by
+  apply (∂Δ[7] : SSet.{0}).chainComplex_hom_ext
+  intro x
+  simp only [Preadditive.comp_add, Category.comp_id]
+  rw [← Category.assoc, iota_boundarySevenZeroConeComponent,
+    SSet.ιChainComplex_d]
+  rw [← Category.assoc, SSet.ιChainComplex_d, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp, iota_boundarySevenZeroConeComponent]
+  rw [Fin.sum_univ_succ]
+  simp only [Fin.val_zero, pow_zero, one_zsmul,
+    boundarySevenZeroConeSimplex_delta_zero,
+    boundarySevenZeroConeSimplex_delta_succ, Fin.val_succ, pow_succ]
+  rw [add_assoc, ← Finset.sum_add_distrib]
+  simp
+
+/-- In degrees `4 → 3 → 2`, the identity of the boundary chain short complex is
+null-homotopic. -/
+public noncomputable def boundarySevenShortComplexIdentityHomotopyThree
+    (R : AddCommGrpCat) :
+    let K := (∂Δ[7] : SSet.{0}).chainComplex R
+    ShortComplex.Homotopy (𝟙 (K.sc' 4 3 2)) 0 := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  let c1 := boundarySevenZeroConeComponent R 1 (by omega)
+  let c2 := boundarySevenZeroConeComponent R 2 (by omega)
+  let c3 := boundarySevenZeroConeComponent R 3 (by omega)
+  let c4 := boundarySevenZeroConeComponent R 4 (by omega)
+  refine
+    { h₀ := c4 ≫ K.d 5 4
+      h₀_f := ?_
+      h₁ := c3
+      h₂ := c2
+      h₃ := K.d 2 1 ≫ c1
+      g_h₃ := ?_
+      comm₁ := ?_
+      comm₂ := ?_
+      comm₃ := ?_ }
+  · dsimp
+    change (c4 ≫ K.d 5 4) ≫ K.d 4 3 = 0
+    rw [Category.assoc, K.d_comp_d, comp_zero]
+  ·
+    change K.d 3 2 ≫ (K.d 2 1 ≫ c1) = 0
+    rw [← Category.assoc, K.d_comp_d, zero_comp]
+  · change 𝟙 (K.X 4) = K.d 4 3 ≫ c3 + c4 ≫ K.d 5 4 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 3 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 3) = K.d 3 2 ≫ c2 + c3 ≫ K.d 4 3 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 2 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 2) = K.d 2 1 ≫ c1 + c2 ≫ K.d 3 2 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 1 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+
+/-- The degree-three simplicial homology of the combinatorial six-sphere `∂Δ[7]` vanishes,
+with arbitrary coefficients in `AddCommGrpCat`. -/
+public theorem boundarySeven_simplicialHomology_three_isZero
+    (R : AddCommGrpCat) :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex R).homology 3) := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  rw [← K.exactAt_iff_isZero_homology]
+  apply (K.exactAt_iff' (i := 4) (j := 3) (k := 2) (by simp) (by simp)).2
+  rw [ShortComplex.exact_iff_isZero_homology, IsZero.iff_id_eq_zero]
+  have h := (boundarySevenShortComplexIdentityHomotopyThree R).homologyMap_congr
+  simpa only [ShortComplex.homologyMap_id, ShortComplex.homologyMap_zero] using h
+
+/-- In particular, degree-three simplicial homology of `∂Δ[7]` vanishes over `𝔽₂`. -/
+public theorem boundarySeven_simplicialHomology_three_zModTwo_isZero :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex
+      (AddCommGrpCat.of (ZMod 2))).homology 3) :=
+  boundarySeven_simplicialHomology_three_isZero (AddCommGrpCat.of (ZMod 2))
+
+/-- In degrees `3 → 2 → 1`, the same zero-vertex cone null-homotopes the identity. -/
+public noncomputable def boundarySevenShortComplexIdentityHomotopyTwo
+    (R : AddCommGrpCat) :
+    let K := (∂Δ[7] : SSet.{0}).chainComplex R
+    ShortComplex.Homotopy (𝟙 (K.sc' 3 2 1)) 0 := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  let c0 := boundarySevenZeroConeComponent R 0 (by omega)
+  let c1 := boundarySevenZeroConeComponent R 1 (by omega)
+  let c2 := boundarySevenZeroConeComponent R 2 (by omega)
+  let c3 := boundarySevenZeroConeComponent R 3 (by omega)
+  refine
+    { h₀ := c3 ≫ K.d 4 3
+      h₀_f := ?_
+      h₁ := c2
+      h₂ := c1
+      h₃ := K.d 1 0 ≫ c0
+      g_h₃ := ?_
+      comm₁ := ?_
+      comm₂ := ?_
+      comm₃ := ?_ }
+  · dsimp
+    change (c3 ≫ K.d 4 3) ≫ K.d 3 2 = 0
+    rw [Category.assoc, K.d_comp_d, comp_zero]
+  · change K.d 2 1 ≫ (K.d 1 0 ≫ c0) = 0
+    rw [← Category.assoc, K.d_comp_d, zero_comp]
+  · change 𝟙 (K.X 3) = K.d 3 2 ≫ c2 + c3 ≫ K.d 4 3 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 2 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 2) = K.d 2 1 ≫ c1 + c2 ≫ K.d 3 2 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 1 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 1) = K.d 1 0 ≫ c0 + c1 ≫ K.d 2 1 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 0 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+
+/-- Degree-two simplicial homology of `∂Δ[7]` also vanishes for arbitrary coefficients. -/
+public theorem boundarySeven_simplicialHomology_two_isZero
+    (R : AddCommGrpCat) :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex R).homology 2) := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  rw [← K.exactAt_iff_isZero_homology]
+  apply (K.exactAt_iff' (i := 3) (j := 2) (k := 1) (by simp) (by simp)).2
+  rw [ShortComplex.exact_iff_isZero_homology, IsZero.iff_id_eq_zero]
+  have h := (boundarySevenShortComplexIdentityHomotopyTwo R).homologyMap_congr
+  simpa only [ShortComplex.homologyMap_id, ShortComplex.homologyMap_zero] using h
+
+/-- In particular, degree-two simplicial homology of `∂Δ[7]` vanishes over `𝔽₂`. -/
+public theorem boundarySeven_simplicialHomology_two_zModTwo_isZero :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex
+      (AddCommGrpCat.of (ZMod 2))).homology 2) :=
+  boundarySeven_simplicialHomology_two_isZero (AddCommGrpCat.of (ZMod 2))
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularHomologyModTwo.lean
+++ b/SphereSixComplex/Topology/SingularHomologyModTwo.lean
@@ -1,0 +1,188 @@
+module
+
+public import SphereSixComplex.Topology.RelativeSingularHomology
+public import Mathlib.Algebra.Category.Grp.AB
+public import Mathlib.Data.ZMod.QuotientGroup
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- Multiplication by two on the integral coefficient object. -/
+public def integralCoefficientTimesTwo :
+    AddCommGrpCat.of ℤ ⟶ AddCommGrpCat.of ℤ :=
+  AddCommGrpCat.ofHom
+    { toFun := fun z ↦ 2 * z
+      map_zero' := by simp
+      map_add' := by simp [mul_add] }
+
+/-- Reduction of integral coefficients modulo two. -/
+public def integralCoefficientReductionModTwo :
+    AddCommGrpCat.of ℤ ⟶ AddCommGrpCat.of (ZMod 2) :=
+  AddCommGrpCat.ofHom (Int.castAddHom (ZMod 2))
+
+/-- The coefficient short complex `ℤ --2→ ℤ → ZMod 2`. -/
+public noncomputable def integralModTwoCoefficientShortComplex :
+    ShortComplex AddCommGrpCat :=
+  ShortComplex.mk integralCoefficientTimesTwo
+    integralCoefficientReductionModTwo (by
+      ext
+      simp [integralCoefficientTimesTwo,
+        integralCoefficientReductionModTwo]
+      decide)
+
+/-- The standard integral-to-mod-two coefficient sequence is short exact. -/
+public theorem integralModTwoCoefficientShortComplex_shortExact :
+    integralModTwoCoefficientShortComplex.ShortExact := by
+  refine
+    { exact := ?_
+      mono_f := ?_
+      epi_g := ?_ }
+  · rw [ShortComplex.ab_exact_iff]
+    change ∀ z : ℤ, (z : ZMod 2) = 0 → ∃ y : ℤ, 2 * y = z
+    intro z hz
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd] at hz
+    obtain ⟨y, rfl⟩ := hz
+    exact ⟨y, by simp⟩
+  · rw [AddCommGrpCat.mono_iff_injective]
+    change Function.Injective (fun z : ℤ ↦ 2 * z)
+    intro a b h
+    nlinarith
+  · rw [AddCommGrpCat.epi_iff_surjective]
+    change Function.Surjective (fun z : ℤ ↦ (z : ZMod 2))
+    exact ZMod.intCast_surjective
+
+/-- The functor taking an abelian group to a coproduct of copies indexed by `I`. -/
+public noncomputable def coefficientCoproductFunctor (I : Type) :
+    CategoryTheory.Functor AddCommGrpCat AddCommGrpCat :=
+  sigmaConst ⋙ (evaluation (Type) AddCommGrpCat).obj I
+
+public instance (I : Type) : (coefficientCoproductFunctor I).Additive := by
+  dsimp [coefficientCoproductFunctor]
+  infer_instance
+
+private noncomputable def coefficientCoproductFunctorExactModel (I : Type) :
+    CategoryTheory.Functor AddCommGrpCat AddCommGrpCat :=
+  (Functor.const (Discrete I) : CategoryTheory.Functor AddCommGrpCat
+      (CategoryTheory.Functor (Discrete I) AddCommGrpCat)) ⋙ colim
+
+private instance (I : Type) : PreservesFiniteLimits
+    (coefficientCoproductFunctorExactModel I) := by
+  dsimp [coefficientCoproductFunctorExactModel]
+  infer_instance
+
+private instance (I : Type) : PreservesFiniteColimits
+    (coefficientCoproductFunctorExactModel I) := by
+  dsimp [coefficientCoproductFunctorExactModel]
+  infer_instance
+
+private noncomputable def coefficientCoproductFunctorIso (I : Type) :
+    coefficientCoproductFunctor I ≅ coefficientCoproductFunctorExactModel I :=
+  NatIso.ofComponents
+    (fun A ↦ Limits.Sigma.isoColimit ((Functor.const (Discrete I)).obj A)) (by
+      intro A B f
+      apply Limits.Sigma.hom_ext
+      intro i
+      simp only [coefficientCoproductFunctor, coefficientCoproductFunctorExactModel,
+        Functor.comp_map, evaluation_obj_map, sigmaConst]
+      rw [Limits.Sigma.ι_map_assoc]
+      have hB :
+          Limits.Sigma.ι (fun _ : I ↦ B) i ≫
+            (Limits.Sigma.isoColimit ((Functor.const (Discrete I)).obj B)).hom =
+          colimit.ι ((Functor.const (Discrete I)).obj B) ⟨i⟩ := by
+        simpa only [Functor.const_obj_obj] using
+          Limits.Sigma.ι_isoColimit_hom ((Functor.const (Discrete I)).obj B) i
+      have hA :
+          Limits.Sigma.ι (fun _ : I ↦ A) i ≫
+            (Limits.Sigma.isoColimit ((Functor.const (Discrete I)).obj A)).hom =
+          colimit.ι ((Functor.const (Discrete I)).obj A) ⟨i⟩ := by
+        simpa only [Functor.const_obj_obj] using
+          Limits.Sigma.ι_isoColimit_hom ((Functor.const (Discrete I)).obj A) i
+      rw [hB, ← Category.assoc, hA]
+      change f ≫ colimit.ι ((Functor.const (Discrete I)).obj B) ⟨i⟩ =
+        colimit.ι ((Functor.const (Discrete I)).obj A) ⟨i⟩ ≫
+          colimMap ((Functor.const (Discrete I)).map f)
+      rw [ι_colimMap, Functor.const_map_app])
+
+/-- A coproduct of copies preserves the integral-to-mod-two coefficient short exact sequence. -/
+public theorem integralModTwoCoefficientShortComplex_map_coproduct_shortExact (I : Type) :
+    (integralModTwoCoefficientShortComplex.map
+      (coefficientCoproductFunctor I)).ShortExact := by
+  have hG := integralModTwoCoefficientShortComplex_shortExact.map_of_exact
+    (coefficientCoproductFunctorExactModel I)
+  exact ShortComplex.shortExact_of_iso
+    (integralModTwoCoefficientShortComplex.mapNatIso
+      (coefficientCoproductFunctorIso I).symm) hG
+
+/-- Singular chains of `X`, regarded as a functor of the coefficient object. -/
+public noncomputable def singularChainComplexCoefficientFunctor (X : TopCat) :
+    CategoryTheory.Functor AddCommGrpCat (ChainComplex AddCommGrpCat ℕ) :=
+  singularChainComplexFunctor AddCommGrpCat ⋙
+    (evaluation TopCat (ChainComplex AddCommGrpCat ℕ)).obj X
+
+public instance (X : TopCat) :
+    (singularChainComplexCoefficientFunctor X).Additive := by
+  dsimp [singularChainComplexCoefficientFunctor]
+  infer_instance
+
+/-- Singular chains with mod-two coefficients. -/
+public noncomputable abbrev ModTwoSingularChainComplexObj (X : TopCat) :
+    ChainComplex AddCommGrpCat ℕ :=
+  (singularChainComplexCoefficientFunctor X).obj (AddCommGrpCat.of (ZMod 2))
+
+/-- The coefficient short complex after applying singular chains of `X`. -/
+public noncomputable def integralModTwoSingularChainShortComplex (X : TopCat) :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  integralModTwoCoefficientShortComplex.map
+    (singularChainComplexCoefficientFunctor X)
+
+/-- Singular chains preserve the integral-to-mod-two coefficient short exact sequence. -/
+public theorem integralModTwoSingularChainShortComplex_shortExact (X : TopCat) :
+    (integralModTwoSingularChainShortComplex X).ShortExact := by
+  rw [HomologicalComplex.shortExact_iff_degreewise_shortExact]
+  intro n
+  unfold integralModTwoSingularChainShortComplex
+  rw [← ShortComplex.map_comp]
+  dsimp [singularChainComplexCoefficientFunctor, singularChainComplexFunctor,
+    SSet.chainComplexFunctor]
+  change (integralModTwoCoefficientShortComplex.map
+    (sigmaConst ⋙ (evaluation (Type) AddCommGrpCat).obj
+      ((TopCat.toSSet.obj X).obj (Opposite.op (SimplexCategory.mk n))))).ShortExact
+  exact integralModTwoCoefficientShortComplex_map_coproduct_shortExact _
+
+/-- The Bockstein reduction at degree three, assuming the coefficient short complex remains short
+exact after applying singular chains.  Vanishing of integral homology in degrees three and two
+then forces vanishing with mod-two coefficients in degree three. -/
+public theorem modTwoSingularHomologyThree_isZero_of_chainShortExact
+    (X : TopCat)
+    (hS : (integralModTwoSingularChainShortComplex X).ShortExact)
+    (h₃ : IsZero ((IntegralSingularChainComplexObj X).homology 3))
+    (h₂ : IsZero ((IntegralSingularChainComplexObj X).homology 2)) :
+    IsZero ((ModTwoSingularChainComplexObj X).homology 3) := by
+  have hexact := hS.homology_exact₃ 3 2
+    (ComplexShape.down_mk 3 2 (by omega))
+  have h₃' : IsZero ((integralModTwoSingularChainShortComplex X).X₂.homology 3) := by
+    simpa [integralModTwoSingularChainShortComplex,
+      integralModTwoCoefficientShortComplex,
+      singularChainComplexCoefficientFunctor] using h₃
+  have h₂' : IsZero ((integralModTwoSingularChainShortComplex X).X₁.homology 2) := by
+    simpa [integralModTwoSingularChainShortComplex,
+      integralModTwoCoefficientShortComplex,
+      singularChainComplexCoefficientFunctor] using h₂
+  exact hexact.isZero_X₂ (h₃'.eq_of_src _ _) (h₂'.eq_of_tgt _ _)
+
+/-- Integral homology vanishing in degrees three and two forces mod-two singular homology to
+vanish in degree three. -/
+public theorem modTwoSingularHomologyThree_isZero
+    (X : TopCat)
+    (h₃ : IsZero ((IntegralSingularChainComplexObj X).homology 3))
+    (h₂ : IsZero ((IntegralSingularChainComplexObj X).homology 2)) :
+    IsZero ((ModTwoSingularChainComplexObj X).homology 3) :=
+  modTwoSingularHomologyThree_isZero_of_chainShortExact X
+    (integralModTwoSingularChainShortComplex_shortExact X) h₃ h₂
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparison.lean
+++ b/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparison.lean
@@ -1,0 +1,217 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import SphereSixComplex.Topology.HomotopySphereHomology
+public import Mathlib.AlgebraicTopology.ExtraDegeneracy
+public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
+public import Mathlib.Analysis.Convex.Contractible
+public import Mathlib.Algebra.Homology.SingleHomology
+
+/-!
+# Simplicial--singular comparison for a standard simplex
+
+The realization of a standard simplex is contractible.  Both its simplicial chains and its
+singular chains therefore have zero positive-degree homology, while degree-zero homology is the
+coefficient group.  The canonical adjunction unit respects the degree-zero augmentations, so its
+chain map is a quasi-isomorphism in every degree.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- In a nonnegatively graded chain complex, degree-zero chains are canonically the degree-zero
+cycles, since the outgoing differential vanishes. -/
+public noncomputable def chainComplexXZeroIsoCyclesZero
+    (K : ChainComplex AddCommGrpCat ℕ) : K.X 0 ≅ K.cycles 0 where
+  hom := K.liftCycles (𝟙 _) 0 (by simp) (by simp)
+  inv := K.iCycles 0
+  hom_inv_id := by simp
+  inv_hom_id := by
+    rw [← cancel_mono (K.iCycles 0)]
+    simp
+
+/-- The canonical augmentation on degree-zero simplicial homology is natural in the simplicial
+set.  This is the residual naturality calculation needed in the standard-simplex comparison. -/
+public theorem simplicialHomologyZeroAugmentation_naturality
+    {X Y : SSet.{0}} (f : X ⟶ Y) :
+    SSet.homologyMap f (AddCommGrpCat.of ℤ) 0 ≫
+        Y.homology₀ε (AddCommGrpCat.of ℤ) =
+      X.homology₀ε (AddCommGrpCat.of ℤ) := by
+  let R := AddCommGrpCat.of ℤ
+  let K := X.chainComplex R
+  let L := Y.chainComplex R
+  let φ := SSet.chainComplexMap f R
+  let e₀ := chainComplexXZeroIsoCyclesZero K
+  apply (cancel_epi (K.homologyπ 0)).1
+  apply (cancel_epi e₀.hom).1
+  apply X.chainComplex_hom_ext
+  intro x
+  change X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫
+      HomologicalComplex.homologyMap φ 0 ≫ Y.homology₀ε R =
+    X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫ X.homology₀ε R
+  rw [HomologicalComplex.homologyπ_naturality_assoc]
+  change X.ιChainComplex x ≫
+      K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+        HomologicalComplex.cyclesMap φ 0 ≫ L.homologyπ 0 ≫
+          Y.homology₀ε R =
+    X.ιChainComplex x ≫ K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  simp only [← Category.assoc, HomologicalComplex.comp_liftCycles,
+    Category.comp_id]
+  simp only [HomologicalComplex.liftCycles_comp_cyclesMap]
+  change L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) ≫
+        L.homologyπ 0 ≫ Y.homology₀ε R =
+    K.liftCycles (X.ιChainComplex x) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  have hlift : L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) =
+      L.liftCycles (Y.ιChainComplex (f.app _ x)) 0 (by simp) (by simp) := by
+    apply (cancel_mono (L.iCycles 0)).1
+    simpa only [HomologicalComplex.liftCycles_i] using
+      SSet.ι_chainComplexMap_f X Y f R x
+  rw [hlift]
+  calc
+    _ = 𝟙 R := by
+      simpa only [] using
+        Y.liftCycles_ιChainComplex_homologyπ_homology₀ε R (f.app _ x)
+    _ = _ := by
+      symm
+      simpa only [] using
+        X.liftCycles_ιChainComplex_homologyπ_homology₀ε R x
+
+/-- Every standard simplex is connected as a simplicial set. -/
+public theorem standardSimplex_isConnected (n : ℕ) :
+    (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected := by
+  rw [SSet.isConnected_iff]
+  constructor
+  · constructor
+    intro a b
+    induction a using SSet.π₀.rec with
+    | mk x =>
+      induction b using SSet.π₀.rec with
+      | mk y =>
+        let i := SSet.stdSimplex.obj₀Equiv x
+        let j := SSet.stdSimplex.obj₀Equiv y
+        rcases le_total i j with hij | hji
+        · let s := SSet.stdSimplex.edge n i j hij
+          have hs : SSet.π₀.mk x = SSet.π₀.mk y := by
+            have hsrc : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 1 s = x := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            have htgt : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 0 s = y := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            simpa only [hsrc, htgt] using SSet.π₀.sound (SSet.Edge.mk' s)
+          exact hs
+        · let s := SSet.stdSimplex.edge n j i hji
+          have hs : SSet.π₀.mk y = SSet.π₀.mk x := by
+            have hsrc : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 1 s = y := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            have htgt : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 0 s = x := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            simpa only [hsrc, htgt] using SSet.π₀.sound (SSet.Edge.mk' s)
+          exact hs.symm
+  · exact ⟨SSet.stdSimplex.const n 0 _⟩
+
+/-- The geometric realization of every standard simplex is contractible. -/
+public theorem standardSimplexRealization_contractibleSpace (n : ℕ) :
+    ContractibleSpace
+      (SSet.toTop.obj (SSet.stdSimplex.obj (SimplexCategory.mk n)) : Type) := by
+  letI : ContractibleSpace (stdSimplex ℝ (Fin (n + 1))) :=
+    (convex_stdSimplex ℝ (Fin (n + 1))).contractibleSpace
+      ⟨stdSimplex.vertex (0 : Fin (n + 1)),
+        (stdSimplex.vertex (0 : Fin (n + 1))).2⟩
+  exact (SimplexCategory.toTopHomeo (SimplexCategory.mk n)).contractibleSpace
+
+/-- Simplicial chains of a standard simplex are exact in every positive degree, by the canonical
+extra degeneracy. -/
+public theorem standardSimplex_simplicialChains_exactAt
+    (n k : ℕ) (hk : k ≠ 0) :
+    ((Δ[n] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).ExactAt k := by
+  let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
+    (SimplexCategory.mk n)).map (sigmaConst.obj (AddCommGrpCat.of ℤ))
+  let e := ed.homotopyEquiv
+  exact (exactAt_iff_of_quasiIsoAt e.hom k).mpr
+    (HomologicalComplex.exactAt_single_obj _ _ _ _ hk)
+
+/-- Singular chains of the realization of a standard simplex are exact in every positive degree,
+by contractibility and homotopy invariance. -/
+public theorem standardSimplexRealization_singularChains_exactAt
+    (n k : ℕ) (hk : k ≠ 0) :
+    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex
+      (AddCommGrpCat.of ℤ)).ExactAt k := by
+  letI : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    standardSimplexRealization_contractibleSpace n
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type)
+  have hunit := AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+    AddCommGrpCat k (AddCommGrpCat.of ℤ) (TopCat.of Unit) hk
+  have hzero := hunit.of_iso (singularHomologyIsoOfHomotopyEquiv
+    (AddCommGrpCat.of ℤ) k e)
+  rw [HomologicalComplex.exactAt_iff_isZero_homology]
+  exact hzero
+
+/-- The canonical realization/singular adjunction-unit chain map is a quasi-isomorphism for every
+standard simplex. -/
+public theorem standardSimplex_simplicialToRealizationSingularChainMap_quasiIso
+    (n : ℕ) :
+    QuasiIso (simplicialToRealizationSingularChainMap
+      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)) := by
+  rw [quasiIso_iff]
+  intro k
+  by_cases hk : k = 0
+  · subst hk
+    rw [quasiIsoAt_iff_isIso_homologyMap]
+    letI : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
+      standardSimplex_isConnected n
+    letI : ContractibleSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+      standardSimplexRealization_contractibleSpace n
+    letI : PathConnectedSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) := inferInstance
+    letI : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
+      inferInstance
+    let φ := simplicialToRealizationSingularChainMap
+      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)
+    have hε : HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+          (AddCommGrpCat.of ℤ) =
+      (Δ[n] : SSet.{0}).homology₀ε (AddCommGrpCat.of ℤ) := by
+      exact simplicialHomologyZeroAugmentation_naturality
+        (sSetTopAdj.unit.app (Δ[n] : SSet.{0}))
+    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε
+        (AddCommGrpCat.of ℤ)) := inferInstance
+    let htarget : IsIso
+        ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+          (AddCommGrpCat.of ℤ)) :=
+      inferInstanceAs (IsIso ((TopCat.toSSet.obj
+        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε (AddCommGrpCat.of ℤ)))
+    have hcomp : IsIso (HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+          (AddCommGrpCat.of ℤ)) := by
+      rw [hε]
+      exact hsource
+    exact @IsIso.of_isIso_comp_right _ _ _ _ _
+      (HomologicalComplex.homologyMap φ 0)
+      ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+        (AddCommGrpCat.of ℤ)) htarget hcomp
+  · exact (quasiIsoAt_iff_exactAt _ k
+      (standardSimplex_simplicialChains_exactAt n k hk)).mpr
+        (standardSimplexRealization_singularChains_exactAt n k hk)
+
+/-- In the terminology used by the project, every standard simplex satisfies the canonical
+integral simplicial--singular comparison. -/
+public theorem standardSimplex_integralComparison (n : ℕ) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  standardSimplex_simplicialToRealizationSingularChainMap_quasiIso n
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparisonGeneral.lean
+++ b/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparisonGeneral.lean
@@ -1,0 +1,133 @@
+module
+
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparison
+
+/-!
+# Simplicial--singular comparison for a standard simplex with arbitrary coefficients
+
+The integral proof does not use a special property of `ℤ`.  This file records the coefficient-
+general statement, including the degree-zero augmentation calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The degree-zero simplicial augmentation is natural for an arbitrary coefficient object. -/
+public theorem simplicialHomologyZeroAugmentation_naturality_general
+    {X Y : SSet.{0}} (f : X ⟶ Y) (R : AddCommGrpCat) :
+    SSet.homologyMap f R 0 ≫ Y.homology₀ε R = X.homology₀ε R := by
+  let K := X.chainComplex R
+  let L := Y.chainComplex R
+  let φ := SSet.chainComplexMap f R
+  let e₀ := chainComplexXZeroIsoCyclesZero K
+  apply (cancel_epi (K.homologyπ 0)).1
+  apply (cancel_epi e₀.hom).1
+  apply X.chainComplex_hom_ext
+  intro x
+  change X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫
+      HomologicalComplex.homologyMap φ 0 ≫ Y.homology₀ε R =
+    X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫ X.homology₀ε R
+  rw [HomologicalComplex.homologyπ_naturality_assoc]
+  change X.ιChainComplex x ≫
+      K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+        HomologicalComplex.cyclesMap φ 0 ≫ L.homologyπ 0 ≫
+          Y.homology₀ε R =
+    X.ιChainComplex x ≫ K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  simp only [← Category.assoc, HomologicalComplex.comp_liftCycles,
+    Category.comp_id]
+  simp only [HomologicalComplex.liftCycles_comp_cyclesMap]
+  change L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) ≫
+        L.homologyπ 0 ≫ Y.homology₀ε R =
+    K.liftCycles (X.ιChainComplex x) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  have hlift : L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) =
+      L.liftCycles (Y.ιChainComplex (f.app _ x)) 0 (by simp) (by simp) := by
+    apply (cancel_mono (L.iCycles 0)).1
+    simpa only [HomologicalComplex.liftCycles_i] using
+      SSet.ι_chainComplexMap_f X Y f R x
+  rw [hlift]
+  calc
+    _ = 𝟙 R := by
+      simpa only [] using
+        Y.liftCycles_ιChainComplex_homologyπ_homology₀ε R (f.app _ x)
+    _ = _ := by
+      symm
+      simpa only [] using
+        X.liftCycles_ιChainComplex_homologyπ_homology₀ε R x
+
+/-- Simplicial chains of a standard simplex are exact in positive degrees for arbitrary
+coefficients. -/
+public theorem standardSimplex_simplicialChains_exactAt_general
+    (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
+    ((Δ[n] : SSet.{0}).chainComplex R).ExactAt k := by
+  let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
+    (SimplexCategory.mk n)).map (sigmaConst.obj R)
+  let e := ed.homotopyEquiv
+  exact (exactAt_iff_of_quasiIsoAt e.hom k).mpr
+    (HomologicalComplex.exactAt_single_obj _ _ _ _ hk)
+
+/-- Singular chains of the realization of a standard simplex are exact in positive degrees for
+arbitrary coefficients. -/
+public theorem standardSimplexRealization_singularChains_exactAt_general
+    (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
+    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex R).ExactAt k := by
+  letI : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    standardSimplexRealization_contractibleSpace n
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type)
+  have hunit := AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+    AddCommGrpCat k R (TopCat.of Unit) hk
+  have hzero := hunit.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
+  rw [HomologicalComplex.exactAt_iff_isZero_homology]
+  exact hzero
+
+/-- The canonical comparison for a standard simplex is a quasi-isomorphism with every
+coefficient object in `AddCommGrpCat`. -/
+public theorem standardSimplex_simplicialToRealizationSingularChainMap_quasiIso_general
+    (R : AddCommGrpCat) (n : ℕ) :
+    QuasiIso (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) := by
+  rw [quasiIso_iff]
+  intro k
+  by_cases hk : k = 0
+  · subst hk
+    rw [quasiIsoAt_iff_isIso_homologyMap]
+    letI : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
+      standardSimplex_isConnected n
+    letI : ContractibleSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+      standardSimplexRealization_contractibleSpace n
+    letI : PathConnectedSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) := inferInstance
+    letI : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
+      inferInstance
+    let φ := simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R
+    have hε : HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R =
+      (Δ[n] : SSet.{0}).homology₀ε R :=
+      simplicialHomologyZeroAugmentation_naturality_general
+        (sSetTopAdj.unit.app (Δ[n] : SSet.{0})) R
+    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε R) := inferInstance
+    let htarget : IsIso
+        ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) :=
+      inferInstanceAs (IsIso ((TopCat.toSSet.obj
+        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε R))
+    have hcomp : IsIso (HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) := by
+      rw [hε]
+      exact hsource
+    exact @IsIso.of_isIso_comp_right _ _ _ _ _
+      (HomologicalComplex.homologyMap φ 0)
+      ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) htarget hcomp
+  · exact (quasiIsoAt_iff_exactAt _ k
+      (standardSimplex_simplicialChains_exactAt_general R n k hk)).mpr
+        (standardSimplexRealization_singularChains_exactAt_general R n k hk)
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- transport homology across marked homotopy six-spheres
- add integral and mod-two coefficient foundations
- construct the canonical simplicial-to-singular comparison
- prove the standard-simplex comparison and boundary-seven realization injectivity

## Dependency

This is the first continuation PR on top of #58.

## Verification

- lake build SphereSixComplex.Topology.SimplicialSingularComparison SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparisonGeneral SphereSixComplex.Topology.BoundarySevenRealizationInjective
- Build completed successfully: 3036 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders in the 11 added files