### PR TITLE
Prove disk-seven relative homology reductions

### DIFF
--- a/SphereSixComplex/Topology/DiskSevenCoverGeometry.lean
+++ b/SphereSixComplex/Topology/DiskSevenCoverGeometry.lean
@@ -1,0 +1,616 @@
+module
+
+public import SphereSixComplex.Topology.SingularExcision
+public import SphereSixComplex.Topology.CollarHomotopyExtension
+public import Mathlib.Analysis.Normed.Module.Connected
+
+/-!
+# Geometry of the concrete two-member cover of the seven-disk
+
+This file records explicit radial geometry for `diskSevenExcisionCover`.  The true member is the
+open disk.  The false member is the disk with its centre removed, and radially deformation
+retracts onto the boundary.  Their intersection is the punctured open disk.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory ContinuousMap Function Metric Set Topology
+
+namespace SphereSixComplex
+
+/-- The true member is definitionally the complement of the disk boundary, hence is homeomorphic
+to the standard open seven-ball. -/
+public noncomputable def diskSevenCoverTrueHomeomorphBall :
+    (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7)) ≃ₜ
+      (TopCat.ball.{0} 7 : Type) := by
+  change CollapseComplement (TopCat.diskBoundaryInclusion.{0} 7) ≃ₜ _
+  exact diskSevenComplementBoundaryHomeomorphBall
+
+set_option linter.style.haveILetI false in
+/-- The true cover member is contractible. -/
+public theorem diskSevenCoverTrue_contractibleSpace :
+    ContractibleSpace (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7)) := by
+  letI : ContractibleSpace
+      (Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1) :=
+    Metric.contractibleSpace_ball (by norm_num)
+  letI : ContractibleSpace (TopCat.ball.{0} 7 : Type) := by
+    change ContractibleSpace
+      (ULift (Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1))
+    exact (Homeomorph.ulift :
+      ULift (Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1) ≃ₜ
+        Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1).contractibleSpace
+  exact diskSevenCoverTrueHomeomorphBall.contractibleSpace
+
+/-- The ambient Euclidean vector underlying a point of the seven-disk. -/
+public def diskSevenVector (x : TopCat.disk.{0} 7) :
+    EuclideanSpace ℝ (Fin 7) :=
+  x.down.1
+
+@[simp]
+public theorem diskSevenVector_center :
+    diskSevenVector diskSevenCenter = 0 := by
+  rfl
+
+/-- A point in the false cover member has a nonzero underlying vector. -/
+public theorem diskSevenVector_ne_zero_of_mem_false
+    (x : diskSevenExcisionCover false) : diskSevenVector x.1 ≠ 0 := by
+  intro hx
+  have hxc : x.1 = diskSevenCenter := by
+    apply ULift.ext
+    apply Subtype.ext
+    exact hx
+  have hxmem : x.1 ≠ diskSevenCenter := by
+    simpa [diskSevenExcisionCover] using x.2
+  exact hxmem hxc
+
+/-- A point in the false member has strictly positive radius. -/
+public theorem diskSevenNorm_pos_of_mem_false
+    (x : diskSevenExcisionCover false) : 0 < ‖diskSevenVector x.1‖ :=
+  norm_pos_iff.mpr (diskSevenVector_ne_zero_of_mem_false x)
+
+/-- Radial normalization from the punctured disk to its boundary sphere. -/
+public def diskSevenFalseRadialRetractionFunction
+    (x : diskSevenExcisionCover false) : TopCat.sphere.{0} 6 :=
+  ULift.up ⟨‖diskSevenVector x.1‖⁻¹ • diskSevenVector x.1, by
+    have hn := diskSevenNorm_pos_of_mem_false x
+    simp only [Metric.mem_sphere, dist_zero_right, norm_smul, Real.norm_eq_abs,
+      abs_inv, abs_norm]
+    exact inv_mul_cancel₀ hn.ne'⟩
+
+/-- Radial normalization is continuous on the disk with its centre removed. -/
+public theorem continuous_diskSevenFalseRadialRetractionFunction :
+    Continuous diskSevenFalseRadialRetractionFunction := by
+  unfold diskSevenFalseRadialRetractionFunction
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have hv : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  exact (hv.norm.inv₀ (fun x ↦
+    (diskSevenNorm_pos_of_mem_false x).ne')).smul hv
+
+/-- Radial normalization as a morphism of topological spaces. -/
+public noncomputable def diskSevenFalseRadialRetraction :
+    TopCat.of (diskSevenExcisionCover false) ⟶ TopCat.sphere.{0} 6 :=
+  TopCat.ofHom
+    ⟨diskSevenFalseRadialRetractionFunction,
+      continuous_diskSevenFalseRadialRetractionFunction⟩
+
+@[simp]
+public theorem diskSevenFalseRadialRetraction_down (x : diskSevenExcisionCover false) :
+    (diskSevenFalseRadialRetraction x).down.1 =
+      ‖diskSevenVector x.1‖⁻¹ • diskSevenVector x.1 :=
+  rfl
+
+@[simp]
+public theorem diskBoundaryToDiskSevenExcisionCoverFalse_vector
+    (x : TopCat.sphere.{0} 6) :
+    diskSevenVector (diskBoundaryToDiskSevenExcisionCoverFalse x).1 = x.down.1 :=
+  rfl
+
+/-- Radial normalization is a left inverse to the boundary inclusion into the false member. -/
+public theorem diskBoundaryToDiskSevenExcisionCoverFalse_comp_radialRetraction :
+    diskBoundaryToDiskSevenExcisionCoverFalse ≫
+        diskSevenFalseRadialRetraction =
+      𝟙 (TopCat.sphere.{0} 6) := by
+  ext x
+  apply ULift.ext
+  apply Subtype.ext
+  change ‖x.down.1‖⁻¹ • x.down.1 = x.down.1
+  have hx : ‖x.down.1‖ = 1 := by
+    simpa only [Metric.mem_sphere, dist_zero_right] using x.down.2
+  simp [hx]
+
+/-- Every disk point has radius at most one. -/
+public theorem diskSevenNorm_le_one (x : TopCat.disk.{0} 7) :
+    ‖diskSevenVector x‖ ≤ 1 := by
+  simpa only [diskSevenVector, Metric.mem_closedBall, dist_zero_right] using x.down.2
+
+/-- The radial homotopy interpolates between normalization and the original radius. -/
+public def diskSevenFalseRadialScale (t : unitInterval)
+    (x : diskSevenExcisionCover false) : ℝ :=
+  (t : ℝ) + (1 - (t : ℝ)) * ‖diskSevenVector x.1‖⁻¹
+
+/-- The radial scaling factor is always positive. -/
+public theorem diskSevenFalseRadialScale_pos (t : unitInterval)
+    (x : diskSevenExcisionCover false) :
+    0 < diskSevenFalseRadialScale t x := by
+  have hinv : 0 < ‖diskSevenVector x.1‖⁻¹ :=
+    inv_pos.mpr (diskSevenNorm_pos_of_mem_false x)
+  by_cases ht : (t : ℝ) = 0
+  · simp [diskSevenFalseRadialScale, ht, hinv]
+  · exact add_pos_of_pos_of_nonneg
+      (lt_of_le_of_ne t.2.1 (Ne.symm ht))
+      (mul_nonneg (sub_nonneg.mpr t.2.2) hinv.le)
+
+/-- Radial interpolation stays in the closed unit disk. -/
+public theorem norm_diskSevenFalseRadialScale_smul_le_one
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    ‖diskSevenFalseRadialScale t x • diskSevenVector x.1‖ ≤ 1 := by
+  have hn := diskSevenNorm_pos_of_mem_false x
+  rw [norm_smul, Real.norm_eq_abs,
+    abs_of_pos (diskSevenFalseRadialScale_pos t x)]
+  change (((t : ℝ) + (1 - (t : ℝ)) * ‖diskSevenVector x.1‖⁻¹) *
+    ‖diskSevenVector x.1‖) ≤ 1
+  rw [add_mul, mul_assoc, inv_mul_cancel₀ hn.ne', mul_one]
+  calc
+    (t : ℝ) * ‖diskSevenVector x.1‖ + (1 - (t : ℝ)) ≤
+        (t : ℝ) * 1 + (1 - (t : ℝ)) :=
+      add_le_add
+        (mul_le_mul_of_nonneg_left (diskSevenNorm_le_one x.1) t.2.1) le_rfl
+    _ = 1 := by ring
+
+/-- The explicit radial homotopy on the disk with its centre removed. -/
+public def diskSevenFalseRadialHomotopyFunction
+    (p : unitInterval × diskSevenExcisionCover false) :
+    diskSevenExcisionCover false :=
+  ⟨ULift.up ⟨diskSevenFalseRadialScale p.1 p.2 • diskSevenVector p.2.1,
+      by simpa only [Metric.mem_closedBall, dist_zero_right] using
+        norm_diskSevenFalseRadialScale_smul_le_one p.1 p.2⟩, by
+    change (ULift.up ⟨diskSevenFalseRadialScale p.1 p.2 •
+      diskSevenVector p.2.1, _⟩ : TopCat.disk.{0} 7) ≠ diskSevenCenter
+    intro h
+    have hv := congrArg diskSevenVector h
+    change diskSevenFalseRadialScale p.1 p.2 •
+      diskSevenVector p.2.1 = diskSevenVector diskSevenCenter at hv
+    rw [diskSevenVector_center] at hv
+    exact (smul_ne_zero (ne_of_gt (diskSevenFalseRadialScale_pos p.1 p.2))
+      (diskSevenVector_ne_zero_of_mem_false p.2)) hv⟩
+
+/-- The radial homotopy is jointly continuous in time and the punctured-disk point. -/
+public theorem continuous_diskSevenFalseRadialHomotopyFunction :
+    Continuous diskSevenFalseRadialHomotopyFunction := by
+  unfold diskSevenFalseRadialHomotopyFunction
+  apply Continuous.subtype_mk
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have hv₀ : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  have hv : Continuous (fun p : unitInterval × diskSevenExcisionCover false ↦
+      diskSevenVector p.2.1) := hv₀.comp continuous_snd
+  have ht : Continuous (fun p : unitInterval ×
+      diskSevenExcisionCover false ↦ (p.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have hninv : Continuous (fun p : unitInterval ×
+      diskSevenExcisionCover false ↦ ‖diskSevenVector p.2.1‖⁻¹) :=
+    hv.norm.inv₀ (fun p ↦ (diskSevenNorm_pos_of_mem_false p.2).ne')
+  exact (ht.add ((continuous_const.sub ht).mul hninv)).smul hv
+
+@[simp]
+public theorem diskSevenFalseRadialHomotopyFunction_vector
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseRadialHomotopyFunction (t, x)).1 =
+      diskSevenFalseRadialScale t x • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- At time zero the radial homotopy is radial normalization. -/
+@[simp]
+public theorem diskSevenFalseRadialHomotopyFunction_zero
+    (x : diskSevenExcisionCover false) :
+    diskSevenFalseRadialHomotopyFunction (0, x) =
+      diskBoundaryToDiskSevenExcisionCoverFalse
+        (diskSevenFalseRadialRetraction x) := by
+  apply Subtype.ext
+  apply ULift.ext
+  apply Subtype.ext
+  change diskSevenVector (diskSevenFalseRadialHomotopyFunction (0, x)).1 =
+    diskSevenVector (diskBoundaryToDiskSevenExcisionCoverFalse
+      (diskSevenFalseRadialRetraction x)).1
+  rw [diskSevenFalseRadialHomotopyFunction_vector,
+    diskBoundaryToDiskSevenExcisionCoverFalse_vector,
+    diskSevenFalseRadialRetraction_down]
+  simp [diskSevenFalseRadialScale]
+
+/-- At time one the radial homotopy is the identity. -/
+@[simp]
+public theorem diskSevenFalseRadialHomotopyFunction_one
+    (x : diskSevenExcisionCover false) :
+    diskSevenFalseRadialHomotopyFunction (1, x) = x := by
+  apply Subtype.ext
+  apply ULift.ext
+  apply Subtype.ext
+  simp [diskSevenFalseRadialHomotopyFunction, diskSevenFalseRadialScale,
+    diskSevenVector]
+
+/-- The radial homotopy from boundary normalization to the identity of the false member. -/
+public noncomputable def diskSevenFalseRadialHomotopy :
+    TopCat.Homotopy
+      (diskSevenFalseRadialRetraction ≫
+        diskBoundaryToDiskSevenExcisionCoverFalse)
+      (𝟙 (TopCat.of (diskSevenExcisionCover false))) where
+  toFun := diskSevenFalseRadialHomotopyFunction
+  continuous_toFun := continuous_diskSevenFalseRadialHomotopyFunction
+  map_zero_left := diskSevenFalseRadialHomotopyFunction_zero
+  map_one_left := diskSevenFalseRadialHomotopyFunction_one
+
+@[simp]
+public theorem diskSevenFalseRadialHomotopy_vector
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseRadialHomotopy (t, x)).1 =
+      diskSevenFalseRadialScale t x • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The radial homotopy fixes boundary points pointwise. -/
+public theorem diskSevenFalseRadialHomotopy_fixed
+    (t : unitInterval) (x : TopCat.sphere.{0} 6) :
+    diskSevenFalseRadialHomotopy
+      (t, diskBoundaryToDiskSevenExcisionCoverFalse x) =
+      diskBoundaryToDiskSevenExcisionCoverFalse x := by
+  apply Subtype.ext
+  apply ULift.ext
+  apply Subtype.ext
+  have hx : ‖x.down.1‖ = 1 := by
+    simpa only [Metric.mem_sphere, dist_zero_right] using x.down.2
+  change diskSevenVector
+      (diskSevenFalseRadialHomotopy
+        (t, diskBoundaryToDiskSevenExcisionCoverFalse x)).1 =
+    diskSevenVector (diskBoundaryToDiskSevenExcisionCoverFalse x).1
+  rw [diskSevenFalseRadialHomotopy_vector,
+    diskBoundaryToDiskSevenExcisionCoverFalse_vector]
+  have hnorm : ‖diskSevenVector
+      (diskBoundaryToDiskSevenExcisionCoverFalse x).1‖ = 1 := by
+    rw [diskBoundaryToDiskSevenExcisionCoverFalse_vector]
+    exact hx
+  simp [diskSevenFalseRadialScale, hnorm]
+
+/-- The boundary is a strong deformation retract of the false cover member. -/
+public noncomputable def diskSevenFalseStrongDeformationRetract :
+    TopCat.StrongDeformationRetractData
+      diskBoundaryToDiskSevenExcisionCoverFalse where
+  retraction := diskSevenFalseRadialRetraction
+  retract := diskBoundaryToDiskSevenExcisionCoverFalse_comp_radialRetraction
+  homotopy := diskSevenFalseRadialHomotopy
+  fixed := diskSevenFalseRadialHomotopy_fixed
+
+/-- The boundary inclusion into the false member is an explicit homotopy equivalence. -/
+public noncomputable def diskBoundaryToDiskSevenExcisionCoverFalseHomotopyEquiv :
+    (TopCat.sphere.{0} 6 : Type) ≃ₕ
+      (diskSevenExcisionCover false : Set (TopCat.disk.{0} 7)) :=
+  strongDeformationRetractHomotopyEquiv
+    diskSevenFalseStrongDeformationRetract
+
+/-- The intersection of the two concrete cover members. -/
+public abbrev DiskSevenCoverIntersection : Type :=
+  (diskSevenExcisionCover true ∩ diskSevenExcisionCover false :
+    Set (TopCat.disk.{0} 7))
+
+/-- Radius strictly below one characterizes membership in the true cover member. -/
+public theorem mem_diskSevenExcisionCover_true_of_norm_lt_one
+    (x : TopCat.disk.{0} 7) (hx : ‖diskSevenVector x‖ < 1) :
+    x ∈ diskSevenExcisionCover true := by
+  change x ∉ Set.range (TopCat.diskBoundaryInclusion.{0} 7)
+  rintro ⟨y, rfl⟩
+  have hy : ‖y.down.1‖ = 1 := by
+    simpa only [Metric.mem_sphere, dist_zero_right] using y.down.2
+  apply hx.ne
+  change ‖y.down.1‖ = 1
+  exact hy
+
+/-- Intersection points, being in the open disk, have radius strictly below one. -/
+public theorem diskSevenNorm_lt_one_of_mem_intersection
+    (x : DiskSevenCoverIntersection) : ‖diskSevenVector x.1‖ < 1 := by
+  have hx := x.2.1
+  change x.1 ∉ Set.range (TopCat.diskBoundaryInclusion.{0} 7) at hx
+  exact lt_of_le_of_ne (diskSevenNorm_le_one x.1) (fun h ↦ hx
+    ⟨ULift.up ⟨diskSevenVector x.1, by
+      simpa only [Metric.mem_sphere, dist_zero_right] using h⟩, by
+        apply ULift.ext
+        apply Subtype.ext
+        rfl⟩)
+
+/-- Forgetting the true-member condition, as a function to the false member. -/
+public def diskSevenIntersectionToFalseFunction
+    (x : DiskSevenCoverIntersection) : diskSevenExcisionCover false :=
+  ⟨x.1, x.2.2⟩
+
+/-- Forgetting the true-member condition includes the intersection in the false member. -/
+public noncomputable def diskSevenIntersectionToFalse :
+    TopCat.of DiskSevenCoverIntersection ⟶
+      TopCat.of (diskSevenExcisionCover false) :=
+  TopCat.ofHom ⟨diskSevenIntersectionToFalseFunction,
+    continuous_subtype_val.subtype_mk _⟩
+
+@[simp]
+public theorem diskSevenIntersectionToFalseFunction_vector
+    (x : DiskSevenCoverIntersection) :
+    diskSevenVector (diskSevenIntersectionToFalseFunction x).1 =
+      diskSevenVector x.1 :=
+  rfl
+
+/-- Halving the vector of a false-member point keeps it in the closed disk. -/
+public theorem norm_half_diskSevenVector_le_one
+    (x : diskSevenExcisionCover false) :
+    ‖(2 : ℝ)⁻¹ • diskSevenVector x.1‖ ≤ 1 := by
+  rw [norm_smul, Real.norm_eq_abs]
+  have habs : |(2 : ℝ)⁻¹| = (2 : ℝ)⁻¹ := abs_of_pos (by positivity)
+  rw [habs]
+  calc
+    (2 : ℝ)⁻¹ * ‖diskSevenVector x.1‖ ≤ (2 : ℝ)⁻¹ * 1 :=
+      mul_le_mul_of_nonneg_left (diskSevenNorm_le_one x.1) (by positivity)
+    _ ≤ 1 := by norm_num
+
+/-- Halving the vector of a false-member point puts it strictly inside the disk. -/
+public theorem norm_half_diskSevenVector_lt_one
+    (x : diskSevenExcisionCover false) :
+    ‖(2 : ℝ)⁻¹ • diskSevenVector x.1‖ < 1 := by
+  rw [norm_smul, Real.norm_eq_abs]
+  have habs : |(2 : ℝ)⁻¹| = (2 : ℝ)⁻¹ := abs_of_pos (by positivity)
+  rw [habs]
+  calc
+    (2 : ℝ)⁻¹ * ‖diskSevenVector x.1‖ ≤ (2 : ℝ)⁻¹ * 1 :=
+      mul_le_mul_of_nonneg_left (diskSevenNorm_le_one x.1) (by positivity)
+    _ < 1 := by norm_num
+
+/-- The closed-disk point obtained by radially halving a false-member point. -/
+public def diskSevenFalseHalfDiskPoint
+    (x : diskSevenExcisionCover false) : TopCat.disk.{0} 7 :=
+  ULift.up ⟨(2 : ℝ)⁻¹ • diskSevenVector x.1, by
+    simpa only [Metric.mem_closedBall, dist_zero_right] using
+      norm_half_diskSevenVector_le_one x⟩
+
+@[simp]
+public theorem diskSevenFalseHalfDiskPoint_vector
+    (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseHalfDiskPoint x) =
+      (2 : ℝ)⁻¹ • diskSevenVector x.1 :=
+  rfl
+
+/-- Radially halve a false-member point; the result lies in the punctured open disk. -/
+public def diskSevenFalseToIntersectionHalfFunction
+    (x : diskSevenExcisionCover false) : DiskSevenCoverIntersection :=
+  ⟨diskSevenFalseHalfDiskPoint x, ⟨by
+    apply mem_diskSevenExcisionCover_true_of_norm_lt_one
+    rw [diskSevenFalseHalfDiskPoint_vector]
+    exact norm_half_diskSevenVector_lt_one x
+  , by
+    change diskSevenFalseHalfDiskPoint x ≠ diskSevenCenter
+    intro h
+    have hv := congrArg diskSevenVector h
+    rw [diskSevenFalseHalfDiskPoint_vector, diskSevenVector_center] at hv
+    exact (smul_ne_zero (by norm_num) (diskSevenVector_ne_zero_of_mem_false x)) hv⟩⟩
+
+/-- Radial halving is continuous. -/
+public theorem continuous_diskSevenFalseToIntersectionHalfFunction :
+    Continuous diskSevenFalseToIntersectionHalfFunction := by
+  unfold diskSevenFalseToIntersectionHalfFunction diskSevenFalseHalfDiskPoint
+  apply Continuous.subtype_mk
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have hv : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  have hc : Continuous (fun _ : diskSevenExcisionCover false ↦ (2 : ℝ)⁻¹) :=
+    continuous_const
+  exact hc.smul hv
+
+/-- Radial halving as a topological map from the false member to the intersection. -/
+public noncomputable def diskSevenFalseToIntersectionHalf :
+    TopCat.of (diskSevenExcisionCover false) ⟶
+      TopCat.of DiskSevenCoverIntersection :=
+  TopCat.ofHom ⟨diskSevenFalseToIntersectionHalfFunction,
+    continuous_diskSevenFalseToIntersectionHalfFunction⟩
+
+/-- Scaling coefficient from one half at time zero to one at time one. -/
+public def diskSevenHalfToIdentityScale (t : unitInterval) : ℝ :=
+  (1 + (t : ℝ)) / 2
+
+public theorem diskSevenHalfToIdentityScale_pos (t : unitInterval) :
+    0 < diskSevenHalfToIdentityScale t := by
+  dsimp [diskSevenHalfToIdentityScale]
+  linarith [t.2.1]
+
+public theorem diskSevenHalfToIdentityScale_le_one (t : unitInterval) :
+    diskSevenHalfToIdentityScale t ≤ 1 := by
+  dsimp [diskSevenHalfToIdentityScale]
+  linarith [t.2.2]
+
+/-- The half-radius-to-identity homotopy on the false member. -/
+public def diskSevenFalseHalfHomotopyFunction
+    (p : unitInterval × diskSevenExcisionCover false) :
+    diskSevenExcisionCover false :=
+  ⟨ULift.up ⟨diskSevenHalfToIdentityScale p.1 • diskSevenVector p.2.1, by
+      have hnorm : ‖diskSevenHalfToIdentityScale p.1 • diskSevenVector p.2.1‖ ≤ 1 := by
+        rw [norm_smul, Real.norm_eq_abs,
+          abs_of_pos (diskSevenHalfToIdentityScale_pos p.1)]
+        exact (mul_le_mul_of_nonneg_right
+          (diskSevenHalfToIdentityScale_le_one p.1)
+          (norm_nonneg _)).trans (by simpa using diskSevenNorm_le_one p.2.1)
+      simpa only [Metric.mem_closedBall, dist_zero_right] using hnorm⟩, by
+    change (ULift.up ⟨diskSevenHalfToIdentityScale p.1 •
+      diskSevenVector p.2.1, _⟩ : TopCat.disk.{0} 7) ≠ diskSevenCenter
+    intro h
+    have hv := congrArg diskSevenVector h
+    change diskSevenHalfToIdentityScale p.1 • diskSevenVector p.2.1 =
+      diskSevenVector diskSevenCenter at hv
+    rw [diskSevenVector_center] at hv
+    exact (smul_ne_zero (ne_of_gt (diskSevenHalfToIdentityScale_pos p.1))
+      (diskSevenVector_ne_zero_of_mem_false p.2)) hv⟩
+
+public theorem continuous_diskSevenFalseHalfHomotopyFunction :
+    Continuous diskSevenFalseHalfHomotopyFunction := by
+  unfold diskSevenFalseHalfHomotopyFunction
+  apply Continuous.subtype_mk
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have ht : Continuous (fun p : unitInterval × diskSevenExcisionCover false ↦
+      diskSevenHalfToIdentityScale p.1) := by
+    unfold diskSevenHalfToIdentityScale
+    fun_prop
+  have hv₀ : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  exact ht.smul (hv₀.comp continuous_snd)
+
+@[simp]
+public theorem diskSevenFalseHalfHomotopyFunction_vector
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseHalfHomotopyFunction (t, x)).1 =
+      diskSevenHalfToIdentityScale t • diskSevenVector x.1 :=
+  rfl
+
+@[simp]
+public theorem diskSevenFalseToIntersectionHalfFunction_vector
+    (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseToIntersectionHalfFunction x).1 =
+      (2 : ℝ)⁻¹ • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- On the false member, halving followed by inclusion is homotopic to the identity. -/
+public noncomputable def diskSevenFalseHalfHomotopy :
+    TopCat.Homotopy
+      (diskSevenFalseToIntersectionHalf ≫ diskSevenIntersectionToFalse)
+      (𝟙 (TopCat.of (diskSevenExcisionCover false))) where
+  toFun := diskSevenFalseHalfHomotopyFunction
+  continuous_toFun := continuous_diskSevenFalseHalfHomotopyFunction
+  map_zero_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    change diskSevenVector (diskSevenFalseHalfHomotopyFunction (0, x)).1 =
+      diskSevenVector (diskSevenIntersectionToFalseFunction
+        (diskSevenFalseToIntersectionHalfFunction x)).1
+    rw [diskSevenFalseHalfHomotopyFunction_vector,
+      diskSevenIntersectionToFalseFunction_vector,
+      diskSevenFalseToIntersectionHalfFunction_vector]
+    simp [diskSevenHalfToIdentityScale]
+  map_one_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    simp [diskSevenFalseHalfHomotopyFunction,
+      diskSevenHalfToIdentityScale, diskSevenVector]
+
+/-- Restrict the same radial homotopy to the punctured open disk. -/
+public def diskSevenIntersectionHalfHomotopyFunction
+    (p : unitInterval × DiskSevenCoverIntersection) :
+    DiskSevenCoverIntersection :=
+  ⟨(diskSevenFalseHalfHomotopyFunction
+      (p.1, diskSevenIntersectionToFalseFunction p.2)).1, ⟨by
+    apply mem_diskSevenExcisionCover_true_of_norm_lt_one
+    rw [diskSevenFalseHalfHomotopyFunction_vector,
+      diskSevenIntersectionToFalseFunction_vector, norm_smul, Real.norm_eq_abs,
+      abs_of_pos (diskSevenHalfToIdentityScale_pos p.1)]
+    calc
+      diskSevenHalfToIdentityScale p.1 * ‖diskSevenVector p.2.1‖ ≤
+          1 * ‖diskSevenVector p.2.1‖ :=
+        mul_le_mul_of_nonneg_right (diskSevenHalfToIdentityScale_le_one p.1)
+          (norm_nonneg _)
+      _ < 1 := by simpa using diskSevenNorm_lt_one_of_mem_intersection p.2
+  , by
+    exact (diskSevenFalseHalfHomotopyFunction
+      (p.1, diskSevenIntersectionToFalseFunction p.2)).2⟩⟩
+
+public theorem continuous_diskSevenIntersectionHalfHomotopyFunction :
+    Continuous diskSevenIntersectionHalfHomotopyFunction := by
+  unfold diskSevenIntersectionHalfHomotopyFunction
+  apply Continuous.subtype_mk
+  apply continuous_subtype_val.comp
+  apply continuous_diskSevenFalseHalfHomotopyFunction.comp
+  have hi : Continuous diskSevenIntersectionToFalseFunction :=
+    continuous_subtype_val.subtype_mk _
+  exact continuous_fst.prodMk (hi.comp continuous_snd)
+
+@[simp]
+public theorem diskSevenIntersectionHalfHomotopyFunction_vector
+    (t : unitInterval) (x : DiskSevenCoverIntersection) :
+    diskSevenVector (diskSevenIntersectionHalfHomotopyFunction (t, x)).1 =
+      diskSevenHalfToIdentityScale t • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- On the intersection, inclusion followed by radial halving is homotopic to the identity. -/
+public noncomputable def diskSevenIntersectionHalfHomotopy :
+    TopCat.Homotopy
+      (diskSevenIntersectionToFalse ≫ diskSevenFalseToIntersectionHalf)
+      (𝟙 (TopCat.of DiskSevenCoverIntersection)) where
+  toFun := diskSevenIntersectionHalfHomotopyFunction
+  continuous_toFun := continuous_diskSevenIntersectionHalfHomotopyFunction
+  map_zero_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    change diskSevenVector
+        (diskSevenIntersectionHalfHomotopyFunction (0, x)).1 =
+      diskSevenVector (diskSevenFalseToIntersectionHalfFunction
+        (diskSevenIntersectionToFalseFunction x)).1
+    rw [diskSevenIntersectionHalfHomotopyFunction_vector,
+      diskSevenFalseToIntersectionHalfFunction_vector,
+      diskSevenIntersectionToFalseFunction_vector]
+    simp [diskSevenHalfToIdentityScale]
+  map_one_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    change diskSevenVector
+        (diskSevenIntersectionHalfHomotopyFunction (1, x)).1 =
+      diskSevenVector x.1
+    rw [diskSevenIntersectionHalfHomotopyFunction_vector]
+    simp [diskSevenHalfToIdentityScale]
+
+/-- Radial halving and inclusion give a homotopy equivalence between the punctured closed and
+punctured open disks. -/
+public noncomputable def diskSevenFalseIntersectionHomotopyEquiv :
+    (diskSevenExcisionCover false : Set (TopCat.disk.{0} 7)) ≃ₕ
+      DiskSevenCoverIntersection where
+  toFun := diskSevenFalseToIntersectionHalf.hom
+  invFun := diskSevenIntersectionToFalse.hom
+  left_inv := ⟨diskSevenFalseHalfHomotopy⟩
+  right_inv := ⟨diskSevenIntersectionHalfHomotopy⟩
+
+/-- The punctured open disk, i.e. the cover intersection, is homotopy equivalent to the standard
+six-sphere. -/
+public noncomputable def diskSevenCoverIntersectionHomotopyEquivSphereSix :
+    DiskSevenCoverIntersection ≃ₕ (TopCat.sphere.{0} 6 : Type) :=
+  (diskBoundaryToDiskSevenExcisionCoverFalseHomotopyEquiv.trans
+    diskSevenFalseIntersectionHomotopyEquiv).symm
+
+/-- The forward map of the intersection-sphere equivalence is exactly radial normalization after
+forgetting the open-disk condition. -/
+@[simp]
+public theorem diskSevenCoverIntersectionHomotopyEquivSphereSix_apply
+    (x : DiskSevenCoverIntersection) :
+    diskSevenCoverIntersectionHomotopyEquivSphereSix x =
+      diskSevenFalseRadialRetraction (diskSevenIntersectionToFalse x) :=
+  rfl
+
+/-- The inverse map first includes the boundary in the punctured closed disk and then halves its
+radius, landing in the punctured interior. -/
+@[simp]
+public theorem diskSevenCoverIntersectionHomotopyEquivSphereSix_symm_apply
+    (x : TopCat.sphere.{0} 6) :
+    diskSevenCoverIntersectionHomotopyEquivSphereSix.symm x =
+      diskSevenFalseToIntersectionHalf
+        (diskBoundaryToDiskSevenExcisionCoverFalse x) :=
+  rfl
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenCoverRangeGeometryChains.lean
+++ b/SphereSixComplex/Topology/DiskSevenCoverRangeGeometryChains.lean
@@ -1,0 +1,459 @@
+module
+
+public import SphereSixComplex.Topology.DiskSevenCoverGeometry
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLowAcyclic
+public import Mathlib.Algebra.Homology.HomologicalComplexBiprod
+public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Geometric identifications of the seven-disk cover range complexes
+
+This file transfers the explicit topology of `diskSevenExcisionCover` to the range subcomplexes
+used by the local relative Mayer--Vietoris calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap Set
+
+namespace SphereSixComplex
+
+/-- Inclusion of either cover member into the disk is a monomorphism. -/
+public instance diskSevenCoverSubsetInclusion_mono (b : Bool) :
+    Mono (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b)) := by
+  rw [TopCat.mono_iff_injective]
+  exact Subtype.val_injective
+
+/-- The induced map of singular simplicial sets is a monomorphism. -/
+public instance diskSevenCoverSubsetSingularSetInclusion_mono (b : Bool) :
+    Mono (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b))) := by
+  apply Functor.map_mono
+
+/-- Because subspace inclusion is injective, its singular simplicial set is isomorphic to its
+range subcomplex. -/
+public instance diskSevenCoverMemberToRangeSingularSet_isIso (b : Bool) :
+    IsIso (diskSevenCoverMemberToRangeSingularSet b) := by
+  change IsIso (SSet.Subcomplex.toRange
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b))))
+  infer_instance
+
+/-- The singular simplicial set of a cover member, identified with its range in the disk. -/
+public noncomputable def diskSevenCoverMemberRangeSingularSetIso (b : Bool) :
+    TopCat.toSSet.obj (TopCat.of (diskSevenExcisionCover b)) ≅
+      (diskSevenCoverRangeSubcomplex b : SSet) :=
+  asIso (diskSevenCoverMemberToRangeSingularSet b)
+
+/-- The chain map from a cover member to its range complex. -/
+public noncomputable def diskSevenCoverMemberToRangeChains (b : Bool) :
+    IntegralSingularChainComplexObj (TopCat.of (diskSevenExcisionCover b)) ⟶
+      DiskSevenCoverRangeChainComplex b :=
+  SSet.chainComplexMap (diskSevenCoverMemberToRangeSingularSet b)
+    (AddCommGrpCat.of ℤ)
+
+/-- Integral singular chains of a cover member are isomorphic to chains on the corresponding
+range subcomplex. -/
+public noncomputable def diskSevenCoverMemberRangeChainsIso (b : Bool) :
+    IntegralSingularChainComplexObj (TopCat.of (diskSevenExcisionCover b)) ≅
+      DiskSevenCoverRangeChainComplex b :=
+  ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).mapIso
+    (diskSevenCoverMemberRangeSingularSetIso b)
+
+@[simp]
+public theorem diskSevenCoverMemberRangeChainsIso_hom (b : Bool) :
+    (diskSevenCoverMemberRangeChainsIso b).hom =
+      diskSevenCoverMemberToRangeChains b :=
+  rfl
+
+/-- The induced degreewise homology identification for a cover member and its range. -/
+public noncomputable def diskSevenCoverMemberRangeHomologyIso (b : Bool) (k : ℕ) :
+    (IntegralSingularChainComplexObj
+        (TopCat.of (diskSevenExcisionCover b))).homology k ≅
+      (DiskSevenCoverRangeChainComplex b).homology k :=
+  (HomologicalComplex.homologyFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) k).mapIso (diskSevenCoverMemberRangeChainsIso b)
+
+/-- Singular homology objects are invariant under a specified topological homotopy equivalence. -/
+public noncomputable def integralSingularHomologyIsoOfHomotopyEquiv
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (k : ℕ) (e : X ≃ₕ Y) :
+    (((singularHomologyFunctor AddCommGrpCat k).obj
+        (AddCommGrpCat.of ℤ)).obj (TopCat.of X)) ≅
+      (((singularHomologyFunctor AddCommGrpCat k).obj
+        (AddCommGrpCat.of ℤ)).obj (TopCat.of Y)) := by
+  let F := (singularHomologyFunctor AddCommGrpCat k).obj (AddCommGrpCat.of ℤ)
+  let f : TopCat.of X ⟶ TopCat.of Y := TopCat.ofHom e.toFun
+  let g : TopCat.of Y ⟶ TopCat.of X := TopCat.ofHom e.invFun
+  exact CategoryTheory.Iso.mk (F.map f) (F.map g) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.left_inv.some (AddCommGrpCat.of ℤ) k) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.right_inv.some (AddCommGrpCat.of ℤ) k)
+
+/-- Every positive-degree integral homology object of the true range vanishes. -/
+public theorem diskSevenCoverTrueRange_homology_isZero
+    (k : ℕ) (hk : k ≠ 0) :
+    IsZero ((DiskSevenCoverRangeChainComplex true).homology k) := by
+  let _ : ContractibleSpace
+      (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7)) :=
+    diskSevenCoverTrue_contractibleSpace
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7))
+  have hunit :=
+    AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+      AddCommGrpCat k (AddCommGrpCat.of ℤ) (TopCat.of Unit) hk
+  have hmember : IsZero
+      ((IntegralSingularChainComplexObj
+        (TopCat.of (diskSevenExcisionCover true))).homology k) :=
+    by
+      change IsZero (((singularHomologyFunctor AddCommGrpCat k).obj
+        (AddCommGrpCat.of ℤ)).obj
+          (TopCat.of (diskSevenExcisionCover true)))
+      exact hunit.of_iso (integralSingularHomologyIsoOfHomotopyEquiv k e)
+  exact hmember.of_iso (diskSevenCoverMemberRangeHomologyIso true k).symm
+
+/-- The boundary inclusion into the false member is a chain-homotopy equivalence. -/
+public noncomputable def diskBoundaryToDiskSevenFalseMemberChainsHomotopyEquiv :
+    HomotopyEquiv
+      (IntegralSingularChainComplexObj (TopCat.sphere.{0} 6))
+      (IntegralSingularChainComplexObj
+        (TopCat.of (diskSevenExcisionCover false))) where
+  hom := integralSingularChainMapObj
+    diskBoundaryToDiskSevenExcisionCoverFalse
+  inv := integralSingularChainMapObj diskSevenFalseRadialRetraction
+  homotopyHomInvId := by
+    let F := (singularChainComplexFunctor AddCommGrpCat).obj
+      (AddCommGrpCat.of ℤ)
+    let h₁ : Homotopy
+        (F.map diskBoundaryToDiskSevenExcisionCoverFalse ≫
+          F.map diskSevenFalseRadialRetraction)
+        (F.map (𝟙 (TopCat.sphere.{0} 6))) :=
+      Homotopy.ofEq (by
+        rw [← F.map_comp,
+          diskBoundaryToDiskSevenExcisionCoverFalse_comp_radialRetraction])
+    let h₂ : Homotopy (F.map (𝟙 (TopCat.sphere.{0} 6))) (𝟙 _) :=
+      Homotopy.ofEq (F.map_id _)
+    simpa only [integralSingularChainMapObj] using h₁.trans h₂
+  homotopyInvHomId := by
+    let F := (singularChainComplexFunctor AddCommGrpCat).obj
+      (AddCommGrpCat.of ℤ)
+    let h₀ : Homotopy
+        (F.map diskSevenFalseRadialRetraction ≫
+          F.map diskBoundaryToDiskSevenExcisionCoverFalse)
+        (F.map (diskSevenFalseRadialRetraction ≫
+          diskBoundaryToDiskSevenExcisionCoverFalse)) :=
+      Homotopy.ofEq (F.map_comp _ _).symm
+    let h₁ := diskSevenFalseRadialHomotopy.singularChainComplexFunctorObjMap
+      (AddCommGrpCat.of ℤ)
+    let h₂ : Homotopy
+        (F.map (𝟙 (TopCat.of (diskSevenExcisionCover false)))) (𝟙 _) :=
+      Homotopy.ofEq (F.map_id _)
+    simpa only [integralSingularChainMapObj] using h₀.trans (h₁.trans h₂)
+
+/-- Composing the preceding equivalence with the member-range chain isomorphism gives the exact
+boundary-to-false-range chain map used by the relative complex. -/
+public noncomputable def diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv :
+    HomotopyEquiv
+      (IntegralSingularChainComplexObj (TopCat.sphere.{0} 6))
+      (DiskSevenCoverRangeChainComplex false) :=
+  diskBoundaryToDiskSevenFalseMemberChainsHomotopyEquiv.trans
+    (HomotopyEquiv.ofIso (diskSevenCoverMemberRangeChainsIso false))
+
+@[simp]
+public theorem diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv_hom :
+    diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv.hom =
+      diskBoundaryToDiskSevenFalseRangeChains :=
+  rfl
+
+/-- The boundary-to-false-range map is a quasi-isomorphism. -/
+public theorem diskBoundaryToDiskSevenFalseRangeChains_quasiIso :
+    QuasiIso diskBoundaryToDiskSevenFalseRangeChains := by
+  rw [← diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv_hom]
+  infer_instance
+
+/-- The boundary-to-false-member map is a monomorphism. -/
+public instance diskBoundaryToDiskSevenExcisionCoverFalse_mono :
+    Mono diskBoundaryToDiskSevenExcisionCoverFalse := by
+  rw [TopCat.mono_iff_injective]
+  intro x y h
+  apply ULift.ext
+  apply Subtype.ext
+  exact congrArg (fun z ↦ z.1.down.1) h
+
+/-- The boundary-to-false-range chain map is degreewise injective. -/
+public instance diskBoundaryToDiskSevenFalseRangeChains_mono :
+    Mono diskBoundaryToDiskSevenFalseRangeChains := by
+  let _ : Mono (integralSingularChainMapObj
+      diskBoundaryToDiskSevenExcisionCoverFalse) := by
+    dsimp [integralSingularChainMapObj]
+    apply Functor.map_mono
+  let _ : Mono (diskSevenCoverMemberToRangeChains false) := by
+    rw [← diskSevenCoverMemberRangeChainsIso_hom]
+    infer_instance
+  change Mono
+    (integralSingularChainMapObj diskBoundaryToDiskSevenExcisionCoverFalse ≫
+      diskSevenCoverMemberToRangeChains false)
+  infer_instance
+
+/-- The standard cokernel sequence defining the false relative range complex. -/
+public noncomputable def diskSevenFalseRangeRelativeShortComplex :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  ShortComplex.mk diskBoundaryToDiskSevenFalseRangeChains
+    diskSevenFalseRangeRelativeProjection
+    (cokernel.condition diskBoundaryToDiskSevenFalseRangeChains)
+
+/-- That cokernel sequence is short exact. -/
+public theorem diskSevenFalseRangeRelativeShortComplex_shortExact :
+    diskSevenFalseRangeRelativeShortComplex.ShortExact :=
+  { exact := ShortComplex.exact_cokernel
+      diskBoundaryToDiskSevenFalseRangeChains
+    mono_f := by
+      dsimp [diskSevenFalseRangeRelativeShortComplex]
+      infer_instance
+    epi_g := by
+      dsimp [diskSevenFalseRangeRelativeShortComplex,
+        diskSevenFalseRangeRelativeProjection]
+      constructor
+      intro Z g h w
+      exact Cofork.IsColimit.hom_ext
+        (cokernelIsCokernel diskBoundaryToDiskSevenFalseRangeChains) w }
+
+/-- The false-range relative chain complex is acyclic in every degree. -/
+public theorem diskSevenFalseRangeRelativeChainComplex_acyclic :
+    DiskSevenFalseRangeRelativeChainComplex.Acyclic := by
+  have hq : QuasiIso diskSevenFalseRangeRelativeShortComplex.f := by
+    exact diskBoundaryToDiskSevenFalseRangeChains_quasiIso
+  exact diskSevenFalseRangeRelativeShortComplex_shortExact.acyclic_X₃ hq
+
+/-- Consequently every homology object of the false-range relative complex vanishes. -/
+public theorem diskSevenFalseRangeRelativeChainComplex_homology_isZero (k : ℕ) :
+    IsZero (DiskSevenFalseRangeRelativeChainComplex.homology k) := by
+  rw [← HomologicalComplex.exactAt_iff_isZero_homology]
+  exact diskSevenFalseRangeRelativeChainComplex_acyclic k
+
+/-- Homology of the local relative middle complex is the biproduct of the homologies of its two
+summands. -/
+public noncomputable def diskSevenCoverLocalRelativeMiddleHomologyIso (k : ℕ) :
+    DiskSevenCoverLocalRelativeMiddleChainComplex.homology k ≅
+      (DiskSevenCoverRangeChainComplex true).homology k ⊞
+        DiskSevenFalseRangeRelativeChainComplex.homology k :=
+  by
+    let F := HomologicalComplex.homologyFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) k
+    letI : F.Additive := inferInstance
+    letI : PreservesFiniteBiproducts F := inferInstance
+    letI : PreservesBinaryBiproducts F :=
+      preservesBinaryBiproducts_of_preservesBiproducts F
+    exact F.mapBiprod _ _
+
+/-- The local relative middle homology vanishes in every positive degree. -/
+public theorem diskSevenCoverLocalRelativeMiddle_homology_isZero
+    (k : ℕ) (hk : k ≠ 0) :
+    IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology k) := by
+  have hsum : IsZero
+      ((DiskSevenCoverRangeChainComplex true).homology k ⊞
+        DiskSevenFalseRangeRelativeChainComplex.homology k) :=
+    (biprod_isZero_iff _ _).2
+      ⟨diskSevenCoverTrueRange_homology_isZero k hk,
+        diskSevenFalseRangeRelativeChainComplex_homology_isZero k⟩
+  exact hsum.of_iso (diskSevenCoverLocalRelativeMiddleHomologyIso k)
+
+/-- The two middle homology objects needed by local relative Mayer--Vietoris vanish. -/
+public theorem diskSevenCoverLocalRelativeMiddle_low_isZero :
+    IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 3) ∧
+      IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 4) :=
+  ⟨diskSevenCoverLocalRelativeMiddle_homology_isZero 3 (by omega),
+    diskSevenCoverLocalRelativeMiddle_homology_isZero 4 (by omega)⟩
+
+/-! ## The range intersection -/
+
+/-- Forgetting the false-member condition includes the punctured interior in the true member. -/
+public noncomputable def diskSevenIntersectionToTrue :
+    TopCat.of DiskSevenCoverIntersection ⟶
+      TopCat.of (diskSevenExcisionCover true) :=
+  TopCat.ofHom ⟨fun x ↦ ⟨x.1, x.2.1⟩,
+    continuous_subtype_val.subtype_mk _⟩
+
+/-- Direct inclusion of the punctured interior in the ambient disk. -/
+public noncomputable def diskSevenCoverIntersectionToDisk :
+    TopCat.of DiskSevenCoverIntersection ⟶ TopCat.disk.{0} 7 :=
+  topologicalSubsetInclusion (TopCat.disk.{0} 7)
+    (diskSevenExcisionCover true ∩ diskSevenExcisionCover false)
+
+@[reassoc (attr := simp)]
+public theorem diskSevenIntersectionToTrue_comp_disk :
+    diskSevenIntersectionToTrue ≫
+        topologicalSubsetInclusion (TopCat.disk.{0} 7)
+          (diskSevenExcisionCover true) =
+      diskSevenCoverIntersectionToDisk := by
+  rfl
+
+@[reassoc (attr := simp)]
+public theorem diskSevenIntersectionToFalse_comp_disk :
+    diskSevenIntersectionToFalse ≫
+        topologicalSubsetInclusion (TopCat.disk.{0} 7)
+          (diskSevenExcisionCover false) =
+      diskSevenCoverIntersectionToDisk := by
+  rfl
+
+/-- Singular simplices of the punctured interior land in both member ranges. -/
+public theorem diskSevenCoverIntersection_range_le_rangeIntersection :
+    SSet.Subcomplex.range
+        (TopCat.toSSet.map diskSevenCoverIntersectionToDisk) ≤
+      diskSevenCoverRangeIntersectionSubcomplex := by
+  apply le_inf
+  · rw [← diskSevenIntersectionToTrue_comp_disk,
+      Functor.map_comp]
+    exact Subfunctor.range_comp_le _ _
+  · rw [← diskSevenIntersectionToFalse_comp_disk,
+      Functor.map_comp]
+    exact Subfunctor.range_comp_le _ _
+
+/-- The singular simplicial set of the punctured interior, lifted to the intersection of the two
+member ranges. -/
+public noncomputable def diskSevenCoverIntersectionToRangeIntersectionSingularSet :
+    TopCat.toSSet.obj (TopCat.of DiskSevenCoverIntersection) ⟶
+      (diskSevenCoverRangeIntersectionSubcomplex : SSet) :=
+  SSet.Subcomplex.lift (TopCat.toSSet.map diskSevenCoverIntersectionToDisk)
+    diskSevenCoverIntersection_range_le_rangeIntersection
+
+/-- Direct inclusion of the punctured interior is a monomorphism. -/
+public instance diskSevenCoverIntersectionToDisk_mono :
+    Mono diskSevenCoverIntersectionToDisk := by
+  rw [TopCat.mono_iff_injective]
+  exact Subtype.val_injective
+
+/-- Its lift to the intersection range remains a monomorphism. -/
+public instance diskSevenCoverIntersectionToRangeIntersectionSingularSet_mono :
+    Mono diskSevenCoverIntersectionToRangeIntersectionSingularSet := by
+  apply mono_of_mono_fac
+    (SSet.Subcomplex.lift_ι
+      (TopCat.toSSet.map diskSevenCoverIntersectionToDisk)
+      diskSevenCoverIntersection_range_le_rangeIntersection)
+
+/-- Every simplex in both member ranges has a unique lift to the punctured interior. -/
+public theorem diskSevenCoverIntersectionToRangeIntersection_app_surjective
+    (n : SimplexCategoryᵒᵖ) :
+    Function.Surjective
+      (diskSevenCoverIntersectionToRangeIntersectionSingularSet.app n) := by
+  intro z
+  have hz := z.2
+  change
+    z.1 ∈ (diskSevenCoverRangeSubcomplex true).obj n ∧
+      z.1 ∈ (diskSevenCoverRangeSubcomplex false).obj n at hz
+  rcases hz with ⟨hzTrue, hzFalse⟩
+  change z.1 ∈ (SSet.Subcomplex.range
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover true)))).obj n at hzTrue
+  change z.1 ∈ (SSet.Subcomplex.range
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover false)))).obj n at hzFalse
+  rw [Subfunctor.range_obj] at hzTrue hzFalse
+  obtain ⟨yTrue, hyTrue⟩ := hzTrue
+  obtain ⟨yFalse, hyFalse⟩ := hzFalse
+  let fTrue := (TopCat.of (diskSevenExcisionCover true)).toSSetObjEquiv n yTrue
+  let fFalse := (TopCat.of (diskSevenExcisionCover false)).toSSetObjEquiv n yFalse
+  have hpoint (p : stdSimplex ℝ (Fin (n.unop.len + 1))) :
+      (fTrue p).1 = (fFalse p).1 := by
+    have h := congrArg (fun q ↦
+      (TopCat.disk.{0} 7).toSSetObjEquiv n q p)
+        (hyTrue.trans hyFalse.symm)
+    exact h
+  let f : C(stdSimplex ℝ (Fin (n.unop.len + 1)),
+      DiskSevenCoverIntersection) :=
+    ⟨fun p ↦ ⟨(fTrue p).1, ⟨(fTrue p).2, by
+        rw [hpoint p]
+        exact (fFalse p).2⟩⟩,
+      (continuous_subtype_val.comp fTrue.continuous).subtype_mk _⟩
+  let y := (TopCat.of DiskSevenCoverIntersection).toSSetObjEquiv n |>.symm f
+  refine ⟨y, ?_⟩
+  apply Subtype.ext
+  change (TopCat.toSSet.map diskSevenCoverIntersectionToDisk).app n y = z.1
+  rw [← hyTrue]
+  apply (TopCat.disk.{0} 7).toSSetObjEquiv n |>.injective
+  ext p
+  rfl
+
+/-- The lift from punctured-interior singular simplices onto the range intersection is epi. -/
+public instance diskSevenCoverIntersectionToRangeIntersectionSingularSet_epi :
+    Epi diskSevenCoverIntersectionToRangeIntersectionSingularSet := by
+  rw [NatTrans.epi_iff_epi_app]
+  intro n
+  rw [CategoryTheory.epi_iff_surjective]
+  exact diskSevenCoverIntersectionToRangeIntersection_app_surjective n
+
+/-- Hence the lift is an isomorphism of simplicial sets. -/
+public instance diskSevenCoverIntersectionToRangeIntersectionSingularSet_isIso :
+    IsIso diskSevenCoverIntersectionToRangeIntersectionSingularSet :=
+  isIso_of_mono_of_epi _
+
+/-- The singular simplicial set of the punctured interior is exactly the infimum of the two
+member ranges. -/
+public noncomputable def diskSevenCoverIntersectionRangeSingularSetIso :
+    TopCat.toSSet.obj (TopCat.of DiskSevenCoverIntersection) ≅
+      (diskSevenCoverRangeIntersectionSubcomplex : SSet) :=
+  asIso diskSevenCoverIntersectionToRangeIntersectionSingularSet
+
+/-- The resulting integral singular-chain isomorphism. -/
+public noncomputable def diskSevenCoverIntersectionRangeChainsIso :
+    IntegralSingularChainComplexObj (TopCat.of DiskSevenCoverIntersection) ≅
+      DiskSevenCoverRangeIntersectionChainComplex :=
+  ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).mapIso
+    diskSevenCoverIntersectionRangeSingularSetIso
+
+/-- Homology of the range intersection is homology of the actual punctured interior. -/
+public noncomputable def diskSevenCoverIntersectionRangeHomologyIso (k : ℕ) :
+    (IntegralSingularChainComplexObj
+        (TopCat.of DiskSevenCoverIntersection)).homology k ≅
+      DiskSevenCoverRangeIntersectionChainComplex.homology k :=
+  (HomologicalComplex.homologyFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) k).mapIso diskSevenCoverIntersectionRangeChainsIso
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Combining the range identification with radial normalization identifies intersection-range
+homology with the integral singular homology of the standard six-sphere. -/
+public noncomputable def diskSevenCoverRangeIntersectionHomologyIsoSphereSix (k : ℕ) :
+    DiskSevenCoverRangeIntersectionChainComplex.homology k ≅
+      (IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology k :=
+  (diskSevenCoverIntersectionRangeHomologyIso k).symm ≪≫
+    integralSingularHomologyIsoOfHomotopyEquiv k
+      diskSevenCoverIntersectionHomotopyEquivSphereSix
+
+/-- Vanishing of range-intersection homology is exactly vanishing of standard-sphere homology. -/
+public theorem diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix
+    (k : ℕ) :
+    IsZero (DiskSevenCoverRangeIntersectionChainComplex.homology k) ↔
+      IsZero ((IntegralSingularChainComplexObj
+        (TopCat.sphere.{0} 6)).homology k) :=
+  (diskSevenCoverRangeIntersectionHomologyIsoSphereSix k).isZero_iff
+
+/-- The entire local acyclicity obligation now consists precisely of the two standard-sphere
+homology groups in degrees two and three: the local middle terms have vanished unconditionally. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_iff_sphereSix_low_isZero :
+    DiskSevenCoverLocalRelativeLowAcyclic ↔
+      IsZero ((IntegralSingularChainComplexObj
+        (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj
+        (TopCat.sphere.{0} 6)).homology 3) := by
+  constructor
+  · intro h
+    exact
+      ⟨(diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 2).mp
+          h.2.2.1,
+        (diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 3).mp
+          h.2.2.2⟩
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨diskSevenCoverLocalRelativeMiddle_low_isZero.1,
+        diskSevenCoverLocalRelativeMiddle_low_isZero.2,
+        (diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 2).mpr h₂,
+        (diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 3).mpr h₃⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyLow.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyLow.lean
@@ -1,0 +1,251 @@
+module
+
+public import SphereSixComplex.Topology.SingularExcisionOpenCover
+public import Mathlib.Algebra.Homology.HomologySequenceLemmas
+
+/-!
+# Low-degree relative homology of the seven-disk
+
+This file replaces the full singular chains of the seven-disk by chains subordinate to the
+concrete two-set excision cover.  The replacement remains valid after quotienting by the boundary
+chains: this follows formally from the unconditional small-chain approximation and the long
+exact homology sequences of the two cokernel complexes.
+
+The remaining geometric calculation is thereby isolated as acyclicity in degrees three and four
+of one explicit cover-small relative chain complex.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- The literal identification `S⁶ = ∂D⁷`, transported to integral singular chains. -/
+public noncomputable def sphereSixChainsIsoDiskBoundarySevenChains :
+    IntegralSingularChainComplexObj (TopCat.sphere 6) ≅
+      IntegralSingularChainComplexObj (TopCat.diskBoundary 7) := by
+  let F := (singularChainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  exact F.mapIso (eqToIso topCatSphereSix_eq_diskBoundarySeven)
+
+public theorem sphereSixChainsIsoDiskBoundarySevenChains_hom_comp_boundary :
+    sphereSixChainsIsoDiskBoundarySevenChains.hom ≫
+        integralSingularChainMapObj (TopCat.diskBoundaryInclusion 7) =
+      diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+        diskSevenCoverSmallIntegralSingularChainInclusion := by
+  rw [diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_comp_inclusion]
+  dsimp [sphereSixChainsIsoDiskBoundarySevenChains,
+    integralSingularChainMapObj]
+  rw [← Functor.map_comp]
+  apply Functor.congr_map
+  ext x
+  rfl
+
+public theorem sphereSixChainsIsoDiskBoundarySevenChains_hom_quasiIso :
+    QuasiIso sphereSixChainsIsoDiskBoundarySevenChains.hom := by
+  rw [quasiIso_iff]
+  intro n
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  infer_instance
+
+/-- Cover-small disk chains modulo the boundary chains. -/
+public noncomputable def DiskSevenCoverSmallRelativeIntegralSingularChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  cokernel diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+
+/-- The quotient map from cover-small disk chains to the cover-small relative complex. -/
+public noncomputable def diskSevenCoverSmallRelativeChainProjection :
+    DiskSevenCoverSmallIntegralSingularChainComplex ⟶
+      DiskSevenCoverSmallRelativeIntegralSingularChainComplex :=
+  cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+
+/-- The boundary-to-small-chain map is mono, since its composite with the small-chain inclusion
+is the ordinary boundary inclusion on singular chains. -/
+public instance diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_mono :
+    Mono diskBoundaryToDiskSevenCoverSmallIntegralSingularChains := by
+  let _ : Mono (diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+      diskSevenCoverSmallIntegralSingularChainInclusion) := by
+    rw [diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_comp_inclusion]
+    exact diskSevenSphereSix_relativeIntegralSingularShortComplex_shortExact.mono_f
+  exact mono_of_mono diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+    diskSevenCoverSmallIntegralSingularChainInclusion
+
+/-- The short exact sequence defining cover-small relative chains. -/
+public noncomputable def diskSevenCoverSmallRelativeShortComplex :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  ShortComplex.mk diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+    diskSevenCoverSmallRelativeChainProjection
+    (cokernel.condition diskBoundaryToDiskSevenCoverSmallIntegralSingularChains)
+
+public theorem diskSevenCoverSmallRelativeShortComplex_shortExact :
+    diskSevenCoverSmallRelativeShortComplex.ShortExact := by
+  dsimp [diskSevenCoverSmallRelativeShortComplex,
+    diskSevenCoverSmallRelativeChainProjection]
+  exact
+    { exact := ShortComplex.exact_cokernel
+        diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+      mono_f := by
+        change Mono diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+        infer_instance
+      epi_g := by
+        change Epi (cokernel.π
+          diskBoundaryToDiskSevenCoverSmallIntegralSingularChains)
+        infer_instance }
+
+/-- The inclusion of cover-small disk chains induces the canonical map from the cover-small
+relative complex to the ordinary relative complex of `(D⁷,S⁶)`. -/
+public noncomputable def diskSevenCoverSmallRelativeChainComparison :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex ⟶
+      DiskSevenSphereSixRelativeIntegralSingularChainComplex :=
+  cokernel.map diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+    (integralSingularChainMapObj (TopCat.diskBoundaryInclusion 7))
+    sphereSixChainsIsoDiskBoundarySevenChains.hom
+      diskSevenCoverSmallIntegralSingularChainInclusion
+      sphereSixChainsIsoDiskBoundarySevenChains_hom_comp_boundary.symm
+
+@[reassoc (attr := simp)]
+public theorem diskSevenCoverSmallRelativeChainProjection_comp_comparison :
+    diskSevenCoverSmallRelativeChainProjection ≫
+        diskSevenCoverSmallRelativeChainComparison =
+      diskSevenCoverSmallIntegralSingularChainInclusion ≫
+        relativeIntegralSingularChainProjection
+          (TopCat.diskBoundaryInclusion 7) := by
+  change cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+      cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+        (diskSevenCoverSmallIntegralSingularChainInclusion ≫
+          cokernel.π (integralSingularChainMapObj
+            (TopCat.diskBoundaryInclusion 7))) _ =
+    diskSevenCoverSmallIntegralSingularChainInclusion ≫
+      cokernel.π (integralSingularChainMapObj
+        (TopCat.diskBoundaryInclusion 7))
+  exact cokernel.π_desc _ _ _
+
+/-- The defining short exact sequence for cover-small relative chains maps to the usual relative
+singular-chain short exact sequence. -/
+public noncomputable def diskSevenCoverSmallRelativeShortComplexComparison :
+    diskSevenCoverSmallRelativeShortComplex ⟶
+      relativeIntegralSingularShortComplex (TopCat.diskBoundaryInclusion 7) where
+  τ₁ := sphereSixChainsIsoDiskBoundarySevenChains.hom
+  τ₂ := diskSevenCoverSmallIntegralSingularChainInclusion
+  τ₃ := diskSevenCoverSmallRelativeChainComparison
+  comm₁₂ := by
+    exact sphereSixChainsIsoDiskBoundarySevenChains_hom_comp_boundary
+  comm₂₃ := diskSevenCoverSmallRelativeChainProjection_comp_comparison.symm
+
+/-- The unconditional small-chain approximation makes the inclusion of cover-small disk chains
+a quasi-isomorphism. -/
+public theorem diskSevenCoverSmallIntegralSingularChainInclusion_quasiIso :
+    QuasiIso diskSevenCoverSmallIntegralSingularChainInclusion := by
+  change QuasiIso (coverSmallIntegralSingularChainInclusion
+    (TopCat.disk.{0} 7) diskSevenExcisionCover)
+  rw [← coverSmallChainHomotopyEquiv_hom
+    (TopCat.disk.{0} 7) diskSevenExcisionCover diskSevenSmallChainApproximation]
+  infer_instance
+
+/-- Quotienting by the unchanged boundary complex preserves the small-chain quasi-isomorphism.
+This is the formal excision reduction supplied by the two long exact homology sequences. -/
+public theorem diskSevenCoverSmallRelativeChainComparison_quasiIso :
+    QuasiIso diskSevenCoverSmallRelativeChainComparison := by
+  apply HomologicalComplex.HomologySequence.quasiIso_τ₃
+    diskSevenCoverSmallRelativeShortComplexComparison
+    diskSevenCoverSmallRelativeShortComplex_shortExact
+    diskSevenSphereSix_relativeIntegralSingularShortComplex_shortExact
+  · dsimp [diskSevenCoverSmallRelativeShortComplexComparison]
+    exact sphereSixChainsIsoDiskBoundarySevenChains_hom_quasiIso
+  · dsimp [diskSevenCoverSmallRelativeShortComplexComparison]
+    exact diskSevenCoverSmallIntegralSingularChainInclusion_quasiIso
+
+/-- Cover-small relative homology computes the usual relative homology of `(D⁷,S⁶)`. -/
+public noncomputable def diskSevenCoverSmallRelativeHomologyIso (n : ℕ) :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology n ≅
+      DiskSevenSphereSixRelativeIntegralSingularChainComplex.homology n := by
+  let _ : QuasiIso diskSevenCoverSmallRelativeChainComparison :=
+    diskSevenCoverSmallRelativeChainComparison_quasiIso
+  exact isoOfQuasiIsoAt diskSevenCoverSmallRelativeChainComparison n
+
+/-- In every positive sphere degree, cover-small relative homology in the next degree is the
+integral singular homology of the standard sphere. -/
+public noncomputable def diskSevenCoverSmallRelativeBoundaryIso
+    (n : ℕ) (hn : n ≠ 0) :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology (n + 1) ≅
+      (IntegralSingularChainComplexObj (TopCat.diskBoundary 7)).homology n :=
+  diskSevenCoverSmallRelativeHomologyIso (n + 1) ≪≫
+    diskSevenSphereSix_relativeBoundaryIso n hn
+
+/-- The same boundary isomorphism, with the target written as the standard categorical sphere
+rather than the definitionally identified disk boundary. -/
+public noncomputable def diskSevenCoverSmallRelativeStandardSphereBoundaryIso
+    (n : ℕ) (hn : n ≠ 0) :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology (n + 1) ≅
+      (IntegralSingularChainComplexObj (TopCat.sphere 6)).homology n :=
+  diskSevenCoverSmallRelativeBoundaryIso n hn ≪≫
+    (HomologicalComplex.homologyMapIso
+      sphereSixChainsIsoDiskBoundarySevenChains n).symm
+
+/-- The exact remaining low-degree chain calculation. -/
+public def DiskSevenCoverSmallRelativeLowAcyclic : Prop :=
+  IsZero (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 3) ∧
+    IsZero (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 4)
+
+/-- Acyclicity of the explicit cover-small relative complex in degree three gives `H₂(S⁶;ℤ)=0`.
+-/
+public theorem topCatSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 3)) :
+    IsZero ((IntegralSingularChainComplexObj
+      (TopCat.diskBoundary 7)).homology 2) :=
+  h.of_iso (diskSevenCoverSmallRelativeBoundaryIso 2 (by omega)).symm
+
+/-- Acyclicity of the explicit cover-small relative complex in degree four gives `H₃(S⁶;ℤ)=0`.
+-/
+public theorem topCatSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 4)) :
+    IsZero ((IntegralSingularChainComplexObj
+      (TopCat.diskBoundary 7)).homology 3) :=
+  h.of_iso (diskSevenCoverSmallRelativeBoundaryIso 3 (by omega)).symm
+
+/-- The two concrete cover-small calculations imply both required low-degree vanishings. -/
+public theorem topCatSphereSix_integralSingularHomology_low_isZero_of_coverSmallRelative
+    (h : DiskSevenCoverSmallRelativeLowAcyclic) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.diskBoundary 7)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.diskBoundary 7)).homology 3) :=
+  ⟨topCatSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative h.1,
+    topCatSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative h.2⟩
+
+/-- Degree-two vanishing, stated directly for `TopCat.sphere 6`. -/
+public theorem standardSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 3)) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) :=
+  h.of_iso
+    (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 2 (by omega)).symm
+
+/-- Degree-three vanishing, stated directly for `TopCat.sphere 6`. -/
+public theorem standardSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 4)) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) :=
+  h.of_iso
+    (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 3 (by omega)).symm
+
+/-- Thus the two remaining cover-small relative calculations are exactly equivalent to the two
+desired standard-sphere vanishings; the small-chain and long-exact-sequence reductions lose no
+information. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_iff_standardSphereSix_low_isZero :
+    DiskSevenCoverSmallRelativeLowAcyclic ↔
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+        IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) := by
+  constructor
+  · intro h
+    exact
+      ⟨standardSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative h.1,
+        standardSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative h.2⟩
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨h₂.of_iso (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 2 (by omega)),
+        h₃.of_iso (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 3 (by omega))⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
@@ -1,0 +1,680 @@
+module
+
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLow
+public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits
+public import Mathlib.CategoryTheory.Abelian.CommSq
+public import Mathlib.CategoryTheory.Adjunction.Limits
+public import Mathlib.CategoryTheory.Limits.Preserves.SigmaConst
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Pasting
+
+/-!
+# A local Mayer--Vietoris reduction for the seven-disk pair
+
+This file decomposes the concrete cover-small relative complex into the two range subcomplexes of
+the disk cover.  It proves the resulting relative Mayer--Vietoris sequence short exact from
+pushout squares, leaving only acyclicity of explicit local and intersection complexes in the
+low-degree calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set
+
+namespace SphereSixComplex
+
+/-- A concrete chain-contraction identity at one positive degree. -/
+public structure ChainContractionAt
+    (K : ChainComplex AddCommGrpCat ℕ) (n : ℕ) where
+  upper : K.X n ⟶ K.X (n + 1)
+  lower : K.X (n - 1) ⟶ K.X n
+  identity : upper ≫ K.d (n + 1) n + K.d n (n - 1) ≫ lower = 𝟙 _
+
+/-- A contraction identity makes every cycle in that degree an explicit boundary. -/
+public theorem ChainContractionAt.exactAt
+    {K : ChainComplex AddCommGrpCat ℕ} {n : ℕ} (h : ChainContractionAt K n)
+    (hn : n ≠ 0) : K.ExactAt n := by
+  rw [K.exactAt_iff' (i := n + 1) (j := n) (k := n - 1)
+    (ChainComplex.prev ℕ n)
+    ((ComplexShape.down ℕ).next_eq'
+      (ComplexShape.down_mk n (n - 1) (by omega)))]
+  rw [ShortComplex.ab_exact_iff_function_exact]
+  change Function.Exact (K.d (n + 1) n).hom (K.d n (n - 1)).hom
+  intro x
+  constructor
+  · intro hx
+    refine ⟨h.upper x, ?_⟩
+    have hid := ConcreteCategory.congr_hom h.identity x
+    simp only [AddCommGrpCat.hom_add_apply, ConcreteCategory.comp_apply, hx,
+      map_zero, add_zero, CategoryTheory.ConcreteCategory.id_apply] at hid
+    exact hid
+  · rintro ⟨y, rfl⟩
+    exact ConcreteCategory.congr_hom (K.d_comp_d (n + 1) n (n - 1)) y
+
+/-- A contraction identity implies vanishing of homology in that degree. -/
+public theorem ChainContractionAt.isZero_homology
+    {K : ChainComplex AddCommGrpCat ℕ} {n : ℕ} (h : ChainContractionAt K n)
+    (hn : n ≠ 0) : IsZero (K.homology n) :=
+  (h.exactAt hn).isZero_homology
+
+/-- The singular subcomplex consisting of simplices coming from one member of the concrete disk
+cover. -/
+public noncomputable def diskSevenCoverRangeSubcomplex (b : Bool) :
+    (TopCat.toSSet.obj (TopCat.disk.{0} 7)).Subcomplex :=
+  SSet.Subcomplex.range (TopCat.toSSet.map
+    (topologicalSubsetInclusion (TopCat.disk.{0} 7) (diskSevenExcisionCover b)))
+
+/-- The intersection of the two range subcomplexes. -/
+public noncomputable def diskSevenCoverRangeIntersectionSubcomplex :
+    (TopCat.toSSet.obj (TopCat.disk.{0} 7)).Subcomplex :=
+  diskSevenCoverRangeSubcomplex true ⊓ diskSevenCoverRangeSubcomplex false
+
+/-- The intersection, the two cover-member ranges, and the cover-small subcomplex form the
+tautological bicartesian square in the lattice of subcomplexes. -/
+public theorem diskSevenCoverRangeSubcomplex_bicartSq :
+    SSet.Subcomplex.BicartSq
+      diskSevenCoverRangeIntersectionSubcomplex
+      (diskSevenCoverRangeSubcomplex true)
+      (diskSevenCoverRangeSubcomplex false)
+      (coverSmallSingularSubcomplex (TopCat.disk.{0} 7)
+        diskSevenExcisionCover) := by
+  constructor
+  · simpa [diskSevenCoverRangeSubcomplex,
+      coverSmallSingularSubcomplex] using
+      (iSup_bool_eq (f := fun b ↦ SSet.Subcomplex.range (TopCat.toSSet.map
+        (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+          (diskSevenExcisionCover b))))).symm
+  · rfl
+
+/-- Integral chains on one range subcomplex. -/
+public noncomputable abbrev DiskSevenCoverRangeChainComplex (b : Bool) :
+    ChainComplex AddCommGrpCat ℕ :=
+  (diskSevenCoverRangeSubcomplex b : SSet).chainComplex (AddCommGrpCat.of ℤ)
+
+/-- Integral chains on the intersection of the two range subcomplexes. -/
+public noncomputable abbrev DiskSevenCoverRangeIntersectionChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  (diskSevenCoverRangeIntersectionSubcomplex : SSet).chainComplex
+    (AddCommGrpCat.of ℤ)
+
+/-- A member range is contained in the cover-small singular subcomplex. -/
+public theorem diskSevenCoverRangeSubcomplex_le_coverSmall (b : Bool) :
+    diskSevenCoverRangeSubcomplex b ≤
+      coverSmallSingularSubcomplex (TopCat.disk.{0} 7) diskSevenExcisionCover := by
+  exact le_iSup (fun c ↦ SSet.Subcomplex.range (TopCat.toSSet.map
+    (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover c)))) b
+
+/-- Inclusion of one member range into cover-small simplices. -/
+public noncomputable def diskSevenCoverRangeToSmallSingularSet (b : Bool) :
+    (diskSevenCoverRangeSubcomplex b : SSet) ⟶
+      coverSmallSingularSubcomplex (TopCat.disk.{0} 7) diskSevenExcisionCover :=
+  SSet.Subcomplex.homOfLE (diskSevenCoverRangeSubcomplex_le_coverSmall b)
+
+/-- The induced inclusion on chains. -/
+public noncomputable def diskSevenCoverRangeToSmallChains (b : Bool) :
+    DiskSevenCoverRangeChainComplex b ⟶
+      DiskSevenCoverSmallIntegralSingularChainComplex :=
+  SSet.chainComplexMap (diskSevenCoverRangeToSmallSingularSet b)
+    (AddCommGrpCat.of ℤ)
+
+/-- The intersection includes into either member range. -/
+public noncomputable def diskSevenCoverRangeIntersectionToRangeSingularSet (b : Bool) :
+    (diskSevenCoverRangeIntersectionSubcomplex : SSet) ⟶
+      (diskSevenCoverRangeSubcomplex b : SSet) :=
+  match b with
+  | true => SSet.Subcomplex.homOfLE inf_le_left
+  | false => SSet.Subcomplex.homOfLE inf_le_right
+
+/-- The intersection inclusion on chains. -/
+public noncomputable def diskSevenCoverRangeIntersectionToRangeChains (b : Bool) :
+    DiskSevenCoverRangeIntersectionChainComplex ⟶
+      DiskSevenCoverRangeChainComplex b :=
+  SSet.chainComplexMap (diskSevenCoverRangeIntersectionToRangeSingularSet b)
+    (AddCommGrpCat.of ℤ)
+
+/-- The two range inclusions form a pushout square of simplicial sets. -/
+public theorem diskSevenCoverRangeSingularSet_isPushout :
+    IsPushout
+      (diskSevenCoverRangeIntersectionToRangeSingularSet true)
+      (diskSevenCoverRangeIntersectionToRangeSingularSet false)
+      (diskSevenCoverRangeToSmallSingularSet true)
+      (diskSevenCoverRangeToSmallSingularSet false) := by
+  simpa [diskSevenCoverRangeIntersectionToRangeSingularSet,
+    diskSevenCoverRangeToSmallSingularSet] using
+    diskSevenCoverRangeSubcomplex_bicartSq.isPushout
+
+/-- Both routes from the intersection to cover-small chains agree. -/
+public theorem diskSevenCoverRangeIntersectionToSmallChains_eq :
+    diskSevenCoverRangeIntersectionToRangeChains true ≫
+        diskSevenCoverRangeToSmallChains true =
+      diskSevenCoverRangeIntersectionToRangeChains false ≫
+        diskSevenCoverRangeToSmallChains false := by
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeIntersectionToRangeSingularSet true) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeToSmallSingularSet true) =
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeIntersectionToRangeSingularSet false) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeToSmallSingularSet false)
+  rw [← Functor.map_comp, ← Functor.map_comp]
+  apply Functor.congr_map
+  ext n x
+  apply Subtype.ext
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Integral simplicial chains preserve the preceding pushout square. -/
+public theorem diskSevenCoverRangeChains_isPushout :
+    IsPushout
+      (diskSevenCoverRangeIntersectionToRangeChains true)
+      (diskSevenCoverRangeIntersectionToRangeChains false)
+      (diskSevenCoverRangeToSmallChains true)
+      (diskSevenCoverRangeToSmallChains false) := by
+  have hdegree (n : ℕ) : IsPushout
+      ((diskSevenCoverRangeIntersectionToRangeChains true).f n)
+      ((diskSevenCoverRangeIntersectionToRangeChains false).f n)
+      ((diskSevenCoverRangeToSmallChains true).f n)
+      ((diskSevenCoverRangeToSmallChains false).f n) := by
+    have hType := diskSevenCoverRangeSingularSet_isPushout.map
+      ((evaluation SimplexCategoryᵒᵖ Type).obj (Opposite.op (SimplexCategory.mk n)))
+    have hAb := hType.map (sigmaConst.obj (AddCommGrpCat.of ℤ))
+    simpa [diskSevenCoverRangeIntersectionToRangeChains,
+      diskSevenCoverRangeToSmallChains, SSet.chainComplexMap,
+      SSet.chainComplexFunctor, SimplicialObject.whiskering,
+      AlgebraicTopology.alternatingFaceMapComplex,
+      AlgebraicTopology.AlternatingFaceMapComplex.map] using hAb
+  refine ⟨⟨diskSevenCoverRangeIntersectionToSmallChains_eq⟩,
+    ⟨PushoutCocone.IsColimit.mk _ ?_ ?_ ?_ ?_⟩⟩
+  · intro s
+    exact
+      { f := fun n ↦ (hdegree n).desc (s.inl.f n) (s.inr.f n)
+          (HomologicalComplex.congr_hom s.condition n)
+        comm' := by
+          intro i j _
+          apply (hdegree i).hom_ext
+          · simp
+          · simp }
+  · intro s
+    apply HomologicalComplex.Hom.ext
+    funext n
+    exact (hdegree n).inl_desc _ _ _
+  · intro s
+    apply HomologicalComplex.Hom.ext
+    funext n
+    exact (hdegree n).inr_desc _ _ _
+  · intro s m hm₁ hm₂
+    apply HomologicalComplex.Hom.ext
+    funext n
+    apply (hdegree n).hom_ext
+    · rw [(hdegree n).inl_desc]
+      exact HomologicalComplex.congr_hom hm₁ n
+    · rw [(hdegree n).inr_desc]
+      exact HomologicalComplex.congr_hom hm₂ n
+
+/-- The singular set of a cover member, lifted to its range subcomplex. -/
+public noncomputable def diskSevenCoverMemberToRangeSingularSet (b : Bool) :
+    TopCat.toSSet.obj (TopCat.of (diskSevenExcisionCover b)) ⟶
+      (diskSevenCoverRangeSubcomplex b : SSet) :=
+  SSet.Subcomplex.lift
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b))) le_rfl
+
+/-- Lifting a cover member first to its range and then to the cover-small subcomplex is the
+canonical cover-member lift. -/
+public theorem diskSevenCoverMemberToRange_comp_small (b : Bool) :
+    diskSevenCoverMemberToRangeSingularSet b ≫
+        diskSevenCoverRangeToSmallSingularSet b =
+      coverMemberToSmallSingularSet
+        (TopCat.disk.{0} 7) diskSevenExcisionCover b := by
+  ext n x
+  apply Subtype.ext
+  rfl
+
+/-- The boundary chain map lifted specifically to the `false` member range. -/
+public noncomputable def diskBoundaryToDiskSevenFalseRangeChains :
+    IntegralSingularChainComplexObj (TopCat.sphere.{0} 6) ⟶
+      DiskSevenCoverRangeChainComplex false :=
+  SSet.chainComplexMap
+      (TopCat.toSSet.map diskBoundaryToDiskSevenExcisionCoverFalse)
+      (AddCommGrpCat.of ℤ) ≫
+    SSet.chainComplexMap (diskSevenCoverMemberToRangeSingularSet false)
+      (AddCommGrpCat.of ℤ)
+
+set_option backward.isDefEq.respectTransparency false
+/-- The boundary-to-small map factors through the false member range. -/
+public theorem diskBoundaryToDiskSevenFalseRangeChains_comp_small :
+    diskBoundaryToDiskSevenFalseRangeChains ≫
+        diskSevenCoverRangeToSmallChains false =
+      diskBoundaryToDiskSevenCoverSmallIntegralSingularChains := by
+  rw [diskBoundaryToDiskSevenFalseRangeChains,
+    diskBoundaryToDiskSevenCoverSmallIntegralSingularChains,
+    diskSevenCoverRangeToSmallChains,
+    coverMemberToSmallIntegralSingularChains,
+    integralSingularChainMapObj,
+    Category.assoc]
+  congr 1
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverMemberToRangeSingularSet false) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeToSmallSingularSet false) =
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+        (coverMemberToSmallSingularSet
+          (TopCat.disk.{0} 7) diskSevenExcisionCover false)
+  rw [← Functor.map_comp, diskSevenCoverMemberToRange_comp_small]
+set_option backward.isDefEq.respectTransparency true
+
+/-- The false range modulo boundary chains. -/
+public noncomputable def DiskSevenFalseRangeRelativeChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  cokernel diskBoundaryToDiskSevenFalseRangeChains
+
+/-- Projection to the false-range relative complex. -/
+public noncomputable def diskSevenFalseRangeRelativeProjection :
+    DiskSevenCoverRangeChainComplex false ⟶
+      DiskSevenFalseRangeRelativeChainComplex :=
+  cokernel.π diskBoundaryToDiskSevenFalseRangeChains
+
+/-- The false-range relative complex maps canonically to the cover-small relative complex. -/
+public noncomputable def diskSevenFalseRangeRelativeToCoverSmallRelative :
+    DiskSevenFalseRangeRelativeChainComplex ⟶
+      DiskSevenCoverSmallRelativeIntegralSingularChainComplex :=
+  cokernel.map diskBoundaryToDiskSevenFalseRangeChains
+    diskBoundaryToDiskSevenCoverSmallIntegralSingularChains (𝟙 _)
+      (diskSevenCoverRangeToSmallChains false) (by
+        rw [Category.id_comp]
+        exact diskBoundaryToDiskSevenFalseRangeChains_comp_small)
+
+@[reassoc (attr := simp)]
+public theorem diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative :
+    diskSevenFalseRangeRelativeProjection ≫
+        diskSevenFalseRangeRelativeToCoverSmallRelative =
+      diskSevenCoverRangeToSmallChains false ≫
+        diskSevenCoverSmallRelativeChainProjection := by
+  change cokernel.π diskBoundaryToDiskSevenFalseRangeChains ≫
+      cokernel.desc diskBoundaryToDiskSevenFalseRangeChains
+        (diskSevenCoverRangeToSmallChains false ≫
+          cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains) _ = _
+  exact cokernel.π_desc _ _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Quotienting the false range and the total cover-small complex by the same boundary chains
+is a pushout square. -/
+public theorem diskSevenFalseRangeRelativeSquare_isPushout :
+    IsPushout
+      (diskSevenCoverRangeToSmallChains false)
+      diskSevenFalseRangeRelativeProjection
+      diskSevenCoverSmallRelativeChainProjection
+      diskSevenFalseRangeRelativeToCoverSmallRelative := by
+  let _ : Epi diskSevenFalseRangeRelativeProjection := by
+    dsimp [diskSevenFalseRangeRelativeProjection]
+    infer_instance
+  let _ : Epi diskSevenCoverSmallRelativeChainProjection := by
+    dsimp [diskSevenCoverSmallRelativeChainProjection]
+    infer_instance
+  refine ⟨⟨diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative.symm⟩,
+    ⟨PushoutCocone.IsColimit.mk _ ?_ ?_ ?_ ?_⟩⟩
+  · intro s
+    exact cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+      s.inl (by
+        rw [← diskBoundaryToDiskSevenFalseRangeChains_comp_small,
+          Category.assoc, s.condition]
+        simp [diskSevenFalseRangeRelativeProjection])
+  · intro s
+    exact cokernel.π_desc _ _ _
+  · intro s
+    apply (cancel_epi diskSevenFalseRangeRelativeProjection).1
+    rw [← Category.assoc,
+      diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative,
+      Category.assoc]
+    change diskSevenCoverRangeToSmallChains false ≫
+        (cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+          cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+            s.inl _) =
+      diskSevenFalseRangeRelativeProjection ≫ s.inr
+    rw [cokernel.π_desc]
+    exact s.condition
+  · intro s m hm₁ _
+    apply (cancel_epi diskSevenCoverSmallRelativeChainProjection).1
+    rw [hm₁]
+    change s.inl =
+      cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+        cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+          s.inl _
+    exact (cokernel.π_desc _ _ _).symm
+
+/-- The local middle term: true-range chains together with false-range chains modulo boundary. -/
+public noncomputable abbrev DiskSevenCoverLocalRelativeMiddleChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  DiskSevenCoverRangeChainComplex true ⊞
+    DiskSevenFalseRangeRelativeChainComplex
+
+/-- Before quotienting the false range by boundary chains, the two range complexes sum onto the
+cover-small chain complex. -/
+public noncomputable def diskSevenCoverRangeSum :
+    (DiskSevenCoverRangeChainComplex true ⊞
+      DiskSevenCoverRangeChainComplex false) ⟶
+      DiskSevenCoverSmallIntegralSingularChainComplex :=
+  biprod.desc (diskSevenCoverRangeToSmallChains true)
+    (diskSevenCoverRangeToSmallChains false)
+
+set_option backward.isDefEq.respectTransparency false
+/-- Every cover-small simplex belongs to one of the two range subcomplexes, so the range-sum map
+is an epimorphism. -/
+public theorem diskSevenCoverRangeSum_epi : Epi diskSevenCoverRangeSum := by
+  constructor
+  intro Z g h heq
+  apply HomologicalComplex.Hom.ext
+  funext n
+  apply (coverSmallSingularSubcomplex
+    (TopCat.disk.{0} 7) diskSevenExcisionCover : SSet).chainComplex_hom_ext
+  intro x
+  obtain ⟨b, hb⟩ :=
+    (mem_coverSmallSingularSubcomplex_iff
+      (TopCat.disk.{0} 7) diskSevenExcisionCover x.1).mp x.2
+  let xb : (diskSevenCoverRangeSubcomplex b).obj
+      (Opposite.op (SimplexCategory.mk n)) := ⟨x.1, hb⟩
+  have heqn : (diskSevenCoverRangeSum.f n) ≫ g.f n =
+      (diskSevenCoverRangeSum.f n) ≫ h.f n := by
+    exact congrArg (fun q ↦ q.f n) heq
+  cases b with
+  | false =>
+      have hx := congrArg
+        (fun q ↦ ((diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+          (biprod.inr : DiskSevenCoverRangeChainComplex false ⟶
+            (DiskSevenCoverRangeChainComplex true ⊞
+              DiskSevenCoverRangeChainComplex false)).f n) ≫ q) heqn
+      have hx' :
+          ((diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains false).f n) ≫ g.f n =
+            ((diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains false).f n) ≫ h.f n := by
+        simpa [diskSevenCoverRangeSum, Category.assoc] using hx
+      have hι :
+          (diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains false).f n =
+            (coverSmallSingularSubcomplex (TopCat.disk.{0} 7)
+              diskSevenExcisionCover : SSet).ιChainComplex x := by
+        rw [diskSevenCoverRangeToSmallChains, SSet.ι_chainComplexMap_f]
+        congr 1
+      rw [hι] at hx'
+      exact hx'
+  | true =>
+      have hx := congrArg
+        (fun q ↦ ((diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+          (biprod.inl : DiskSevenCoverRangeChainComplex true ⟶
+            (DiskSevenCoverRangeChainComplex true ⊞
+              DiskSevenCoverRangeChainComplex false)).f n) ≫ q) heqn
+      have hx' :
+          ((diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains true).f n) ≫ g.f n =
+            ((diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains true).f n) ≫ h.f n := by
+        simpa [diskSevenCoverRangeSum, Category.assoc] using hx
+      have hι :
+          (diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains true).f n =
+            (coverSmallSingularSubcomplex (TopCat.disk.{0} 7)
+              diskSevenExcisionCover : SSet).ιChainComplex x := by
+        rw [diskSevenCoverRangeToSmallChains, SSet.ι_chainComplexMap_f]
+        congr 1
+      rw [hι] at hx'
+      exact hx'
+set_option backward.isDefEq.respectTransparency true
+
+/-- Quotienting the false summand sends the absolute two-range middle term to the relative
+middle term. -/
+public noncomputable def diskSevenCoverRangeSumToLocalRelativeMiddle :
+    (DiskSevenCoverRangeChainComplex true ⊞
+      DiskSevenCoverRangeChainComplex false) ⟶
+      DiskSevenCoverLocalRelativeMiddleChainComplex :=
+  biprod.map (𝟙 _) diskSevenFalseRangeRelativeProjection
+
+/-- Difference map from intersection chains to the local relative middle term. -/
+public noncomputable def diskSevenCoverLocalRelativeDifference :
+    DiskSevenCoverRangeIntersectionChainComplex ⟶
+      DiskSevenCoverLocalRelativeMiddleChainComplex :=
+  biprod.lift
+    (diskSevenCoverRangeIntersectionToRangeChains true)
+    (-(diskSevenCoverRangeIntersectionToRangeChains false ≫
+      diskSevenFalseRangeRelativeProjection))
+
+/-- The local difference map is mono: its true-range component is the inclusion of the
+intersection subcomplex. -/
+public theorem diskSevenCoverLocalRelativeDifference_mono :
+    Mono diskSevenCoverLocalRelativeDifference := by
+  have hinter : Mono (diskSevenCoverRangeIntersectionToRangeChains true) := by
+    let _ : Mono (diskSevenCoverRangeIntersectionToRangeSingularSet true) := by
+      dsimp [diskSevenCoverRangeIntersectionToRangeSingularSet]
+      exact SSet.Subcomplex.mono_homOfLE inf_le_left
+    dsimp [diskSevenCoverRangeIntersectionToRangeChains, SSet.chainComplexMap,
+      SSet.chainComplexFunctor]
+    apply +allowSynthFailures Functor.map_mono
+    apply +allowSynthFailures Functor.map_mono
+    dsimp [SSet, SimplicialObject.whiskering, SimplicialObject]
+    infer_instance
+  let _ : Mono (diskSevenCoverLocalRelativeDifference ≫
+      (biprod.fst : DiskSevenCoverLocalRelativeMiddleChainComplex ⟶
+        DiskSevenCoverRangeChainComplex true)) := by
+    rw [diskSevenCoverLocalRelativeDifference, biprod.lift_fst]
+    exact hinter
+  exact mono_of_mono diskSevenCoverLocalRelativeDifference biprod.fst
+
+/-- Sum map from the local relative middle term to cover-small relative chains. -/
+public noncomputable def diskSevenCoverLocalRelativeSum :
+    DiskSevenCoverLocalRelativeMiddleChainComplex ⟶
+      DiskSevenCoverSmallRelativeIntegralSingularChainComplex :=
+  biprod.desc
+    (diskSevenCoverRangeToSmallChains true ≫
+      diskSevenCoverSmallRelativeChainProjection)
+    diskSevenFalseRangeRelativeToCoverSmallRelative
+
+/-- The relative local sum is the quotient of the absolute range-sum decomposition. -/
+public theorem diskSevenCoverRangeSumToLocalRelativeMiddle_comp_sum :
+    diskSevenCoverRangeSumToLocalRelativeMiddle ≫
+        diskSevenCoverLocalRelativeSum =
+      diskSevenCoverRangeSum ≫
+        diskSevenCoverSmallRelativeChainProjection := by
+  apply biprod.hom_ext'
+  · simp [diskSevenCoverRangeSumToLocalRelativeMiddle,
+      diskSevenCoverLocalRelativeSum, diskSevenCoverRangeSum]
+  · simp [diskSevenCoverRangeSumToLocalRelativeMiddle,
+      diskSevenCoverLocalRelativeSum, diskSevenCoverRangeSum]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The local relative sum is epi.  This is already forced by the explicit absolute
+range-sum decomposition, after projection to relative chains. -/
+public theorem diskSevenCoverLocalRelativeSum_epi :
+    Epi diskSevenCoverLocalRelativeSum := by
+  let _ : Epi diskSevenCoverRangeSum :=
+    diskSevenCoverRangeSum_epi
+  let _ : Epi diskSevenCoverSmallRelativeChainProjection := by
+    dsimp [diskSevenCoverSmallRelativeChainProjection]
+    infer_instance
+  exact epi_of_epi_fac
+    diskSevenCoverRangeSumToLocalRelativeMiddle_comp_sum
+
+/-- Pasting the absolute two-range pushout with the false-range quotient pushout gives the
+relative two-range pushout. -/
+public theorem diskSevenCoverLocalRelativeSquare_isPushout :
+    IsPushout
+      (diskSevenCoverRangeIntersectionToRangeChains true)
+      (diskSevenCoverRangeIntersectionToRangeChains false ≫
+        diskSevenFalseRangeRelativeProjection)
+      (diskSevenCoverRangeToSmallChains true ≫
+        diskSevenCoverSmallRelativeChainProjection)
+      diskSevenFalseRangeRelativeToCoverSmallRelative :=
+  IsPushout.paste_vert diskSevenCoverRangeChains_isPushout
+    diskSevenFalseRangeRelativeSquare_isPushout
+
+/-- The local difference and sum maps compose to zero. -/
+public theorem diskSevenCoverLocalRelativeDifference_comp_sum :
+    diskSevenCoverLocalRelativeDifference ≫
+      diskSevenCoverLocalRelativeSum = 0 := by
+  rw [diskSevenCoverLocalRelativeDifference,
+    diskSevenCoverLocalRelativeSum, biprod.lift_desc,
+    Preadditive.neg_comp, Category.assoc,
+    diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative,
+    ← Category.assoc, ← Category.assoc,
+    diskSevenCoverRangeIntersectionToSmallChains_eq, add_neg_cancel]
+
+/-- The explicit local Mayer--Vietoris short complex for the pair `(D⁷,S⁶)`. -/
+public noncomputable def diskSevenCoverSmallRelativeMayerVietorisShortComplex :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  ShortComplex.mk diskSevenCoverLocalRelativeDifference
+    diskSevenCoverLocalRelativeSum
+    diskSevenCoverLocalRelativeDifference_comp_sum
+
+/-- The remaining chain-level Mayer--Vietoris assertion for the concrete two-set cover. -/
+public def DiskSevenCoverSmallRelativeMayerVietoris : Prop :=
+  diskSevenCoverSmallRelativeMayerVietorisShortComplex.ShortExact
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Exactness of the relative Mayer--Vietoris short complex follows from the concrete pasted
+pushout square. -/
+public theorem diskSevenCoverSmallRelativeMayerVietoris_exact :
+    diskSevenCoverSmallRelativeMayerVietorisShortComplex.Exact := by
+  apply diskSevenCoverSmallRelativeMayerVietorisShortComplex.exact_of_g_is_cokernel
+  let h := diskSevenCoverLocalRelativeSquare_isPushout
+  refine Cofork.IsColimit.mk _
+    (fun s ↦ h.desc (biprod.inl ≫ s.π) (biprod.inr ≫ s.π) (by
+      rw [← sub_eq_zero, ← Category.assoc,
+        ← Category.assoc
+          (diskSevenCoverRangeIntersectionToRangeChains false ≫
+            diskSevenFalseRangeRelativeProjection) biprod.inr s.π,
+        ← Preadditive.sub_comp]
+      rw [show
+        diskSevenCoverRangeIntersectionToRangeChains true ≫ biprod.inl -
+            (diskSevenCoverRangeIntersectionToRangeChains false ≫
+              diskSevenFalseRangeRelativeProjection) ≫ biprod.inr =
+          diskSevenCoverLocalRelativeDifference by
+        apply biprod.hom_ext
+        · simp [diskSevenCoverLocalRelativeDifference]
+        · simp [diskSevenCoverLocalRelativeDifference]]
+      change diskSevenCoverLocalRelativeDifference ≫ s.π = 0
+      have hs := s.condition
+      change diskSevenCoverLocalRelativeDifference ≫ s.π = 0 ≫ s.π at hs
+      rw [zero_comp] at hs
+      exact hs))
+    (fun s ↦ by
+      apply biprod.hom_ext'
+      · simp [diskSevenCoverSmallRelativeMayerVietorisShortComplex,
+          diskSevenCoverLocalRelativeSum]
+      · simp [diskSevenCoverSmallRelativeMayerVietorisShortComplex,
+          diskSevenCoverLocalRelativeSum])
+    (fun s m hm ↦ by
+      change diskSevenCoverLocalRelativeSum ≫ m = s.π at hm
+      apply h.hom_ext
+      · replace hm := biprod.inl ≫= hm
+        simp only [diskSevenCoverLocalRelativeSum,
+          biprod.inl_desc_assoc, Category.assoc] at hm
+        rw [h.inl_desc]
+        simpa only [Category.assoc] using hm
+      · replace hm := biprod.inr ≫= hm
+        simp only [diskSevenCoverLocalRelativeSum,
+          biprod.inr_desc_assoc] at hm
+        rw [h.inr_desc]
+        simpa only [Category.assoc] using hm)
+
+/-- The concrete cover-small relative Mayer--Vietoris sequence is short exact, with no extra
+topological or homological hypothesis. -/
+public theorem diskSevenCoverSmallRelativeMayerVietoris :
+    DiskSevenCoverSmallRelativeMayerVietoris :=
+  { exact := diskSevenCoverSmallRelativeMayerVietoris_exact
+    mono_f := diskSevenCoverLocalRelativeDifference_mono
+    epi_g := diskSevenCoverLocalRelativeSum_epi }
+
+/-- A useful characterization of the Mayer--Vietoris structure in terms of its exactness and
+surjectivity fields.  Both fields are proved unconditionally above. -/
+public theorem diskSevenCoverSmallRelativeMayerVietoris_iff :
+    DiskSevenCoverSmallRelativeMayerVietoris ↔
+      diskSevenCoverSmallRelativeMayerVietorisShortComplex.Exact ∧
+        Epi diskSevenCoverLocalRelativeSum := by
+  constructor
+  · intro h
+    exact ⟨h.exact, h.epi_g⟩
+  · rintro ⟨hexact, hepi⟩
+    exact
+      { exact := hexact
+        mono_f := diskSevenCoverLocalRelativeDifference_mono
+        epi_g := hepi }
+
+/-- The explicit local homology groups whose vanishing suffices in degrees two through four. -/
+public def DiskSevenCoverLocalRelativeLowAcyclic : Prop :=
+  IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 3) ∧
+    IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 4) ∧
+    IsZero (DiskSevenCoverRangeIntersectionChainComplex.homology 2) ∧
+    IsZero (DiskSevenCoverRangeIntersectionChainComplex.homology 3)
+
+/-- Fully explicit local chain-contraction data.  These are four additive degree-raising maps,
+each satisfying `hd + dh = 1` in the indicated degree. -/
+public def DiskSevenCoverLocalRelativeLowContractions : Prop :=
+  Nonempty (ChainContractionAt DiskSevenCoverLocalRelativeMiddleChainComplex 3) ∧
+    Nonempty (ChainContractionAt DiskSevenCoverLocalRelativeMiddleChainComplex 4) ∧
+    Nonempty (ChainContractionAt DiskSevenCoverRangeIntersectionChainComplex 2) ∧
+    Nonempty (ChainContractionAt DiskSevenCoverRangeIntersectionChainComplex 3)
+
+/-- The explicit contractions imply all four local homology vanishings. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_of_contractions
+    (h : DiskSevenCoverLocalRelativeLowContractions) :
+    DiskSevenCoverLocalRelativeLowAcyclic :=
+  ⟨h.1.some.isZero_homology (by omega),
+    h.2.1.some.isZero_homology (by omega),
+    h.2.2.1.some.isZero_homology (by omega),
+    h.2.2.2.some.isZero_homology (by omega)⟩
+
+/-- Mayer--Vietoris exactness and the four explicit local vanishings imply the two remaining
+cover-small relative vanishings. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_of_local
+    (hMV : DiskSevenCoverSmallRelativeMayerVietoris)
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    DiskSevenCoverSmallRelativeLowAcyclic := by
+  constructor
+  · exact (hMV.homology_exact₃ 3 2
+      (ComplexShape.down_mk 3 2 (by omega))).isZero_X₂
+        (hlocal.1.eq_of_src _ _) (hlocal.2.2.1.eq_of_tgt _ _)
+  · exact (hMV.homology_exact₃ 4 3
+      (ComplexShape.down_mk 4 3 (by omega))).isZero_X₂
+      (hlocal.2.1.eq_of_src _ _) (hlocal.2.2.2.eq_of_tgt _ _)
+
+/-- Thus the four local vanishings are the only remaining input: Mayer--Vietoris exactness for
+the concrete cover has already been proved above. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_of_localAcyclic
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    DiskSevenCoverSmallRelativeLowAcyclic :=
+  diskSevenCoverSmallRelativeLowAcyclic_of_local
+    diskSevenCoverSmallRelativeMayerVietoris hlocal
+
+/-- Consequently, the local Mayer--Vietoris calculation gives the desired standard-sphere
+vanishings. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_local
+    (hMV : DiskSevenCoverSmallRelativeMayerVietoris)
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) := by
+  rw [← diskSevenCoverSmallRelativeLowAcyclic_iff_standardSphereSix_low_isZero]
+  exact diskSevenCoverSmallRelativeLowAcyclic_of_local hMV hlocal
+
+/-- The four explicit local homology vanishings alone imply the desired standard-sphere
+vanishings. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_localAcyclic
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) :=
+  standardSphereSix_integralSingularHomology_low_isZero_of_local
+    diskSevenCoverSmallRelativeMayerVietoris hlocal
+
+/-- A chain-level endpoint: concrete Mayer--Vietoris exactness plus four displayed contraction
+identities proves both desired low-degree sphere vanishings. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_localContractions
+    (h : DiskSevenCoverLocalRelativeLowContractions) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) :=
+  standardSphereSix_integralSingularHomology_low_isZero_of_localAcyclic
+    (diskSevenCoverLocalRelativeLowAcyclic_of_contractions h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
@@ -454,9 +454,6 @@ public theorem diskSevenCoverLocalRelativeDifference_mono :
     dsimp [diskSevenCoverRangeIntersectionToRangeChains, SSet.chainComplexMap,
       SSet.chainComplexFunctor]
     apply +allowSynthFailures Functor.map_mono
-    apply +allowSynthFailures Functor.map_mono
-    dsimp [SSet, SimplicialObject.whiskering, SimplicialObject]
-    infer_instance
   let _ : Mono (diskSevenCoverLocalRelativeDifference ≫
       (biprod.fst : DiskSevenCoverLocalRelativeMiddleChainComplex ⟶
         DiskSevenCoverRangeChainComplex true)) := by

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyModTwo.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyModTwo.lean
@@ -1,0 +1,52 @@
+module
+
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLow
+public import SphereSixComplex.Topology.HomotopySphereHomology
+public import SphereSixComplex.Topology.SingularHomologyModTwo
+
+/-!
+# From the cover-small disk pair to mod-two middle homology
+
+This file connects the explicit relative-chain reduction for `(D⁷,S⁶)` to the exact mod-two
+homology input used by the Kervaire route.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- The two explicit low-degree cover-small relative calculations imply the required mod-two
+middle-homology vanishing for the project's standard six-sphere. -/
+public theorem sixSphere_modTwoHomology_three_isZero_of_coverSmallRelative
+    (h : DiskSevenCoverSmallRelativeLowAcyclic) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) := by
+  have h₂ : IsZero ((IntegralSingularChainComplexObj
+      (TopCat.sphere 6)).homology 2) :=
+    standardSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative h.1
+  have h₃ : IsZero ((IntegralSingularChainComplexObj
+      (TopCat.sphere 6)).homology 3) :=
+    standardSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative h.2
+  have hmod : IsZero ((ModTwoSingularChainComplexObj
+      (TopCat.sphere 6)).homology 3) :=
+    modTwoSingularHomologyThree_isZero (TopCat.sphere 6) h₃ h₂
+  exact hmod.of_iso
+    (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).mapIso
+        (TopCat.isoOfHomeo sixSphereHomeomorphTopCatSphereSix))
+
+/-- The same two local relative calculations give the Kervaire homology input for every marked
+smooth homotopy six-sphere. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_of_coverSmallRelative
+    (h : DiskSevenCoverSmallRelativeLowAcyclic)
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (sixSphere_modTwoHomology_three_isZero_of_coverSmallRelative h) S
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- develop the low-degree relative disk homology algebra
- prove local relative acyclicity through the explicit two-range decomposition
- formalize the disk-cover range geometry
- derive the mod-two middle-homology reduction used by the H3 endpoint

## Dependency

This is the second continuation PR, stacked on #59.

## Verification

- lake build SphereSixComplex.Topology.DiskSevenRelativeHomologyLowAcyclic SphereSixComplex.Topology.DiskSevenCoverRangeGeometryChains SphereSixComplex.Topology.DiskSevenRelativeHomologyModTwo
- Build completed successfully: 3158 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders in the 5 added files