### PR TITLE
Build the boundary-seven face-local comparison

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodComparison.lean
@@ -1,0 +1,467 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparisonProof
+public import Mathlib.Algebra.Category.Grp.Adjunctions
+public import Mathlib.Algebra.Homology.TotalComplex
+public import Mathlib.AlgebraicTopology.CechNerve
+public import Mathlib.AlgebraicTopology.ExtraDegeneracy
+
+/-!
+# The face-neighborhood Čech reduction for `∂Δ[7]`
+
+This file develops the concrete finite-cover input for the comparison map.  The eight open sets
+are the inverse images of the inequalities `x i < 1 / 8`.  Their total intersection is empty,
+and the canonical presentation of the cover-small singular set is degreewise surjective.  Thus,
+after evaluating in any singular degree, its augmented Čech nerve has an extra degeneracy and
+its alternating complex contracts onto the cover-small chain group in that degree.
+
+The final structure below isolates the remaining totalization/local-comparison step: a map from
+the boundary chains to the Čech--singular total complex and the standard Čech augmentation,
+both quasi-isomorphisms and with the expected composite.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The intersection of the affine face neighborhoods indexed by `s`. -/
+public def boundarySevenFaceNeighborhoodIntersection (s : Finset (Fin 8)) :
+    Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
+  ⋂ i ∈ s, boundarySevenComparisonFaceNeighborhood i
+
+@[simp]
+public theorem mem_boundarySevenFaceNeighborhoodIntersection_iff
+    (s : Finset (Fin 8)) (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
+    x ∈ boundarySevenFaceNeighborhoodIntersection s ↔
+      ∀ i ∈ s, boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8 := by
+  simp [boundarySevenFaceNeighborhoodIntersection,
+    boundarySevenComparisonFaceNeighborhood]
+
+/-- Every finite intersection of the eight face neighborhoods is open. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_isOpen (s : Finset (Fin 8)) :
+    IsOpen (boundarySevenFaceNeighborhoodIntersection s) := by
+  apply isOpen_biInter_finset
+  intro i _
+  exact boundarySevenComparisonFaceNeighborhood_isOpen i
+
+/-- All eight face neighborhoods have empty intersection. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_univ_eq_empty :
+    boundarySevenFaceNeighborhoodIntersection Finset.univ = ∅ := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  intro x hx
+  have hcoord :=
+    (mem_boundarySevenFaceNeighborhoodIntersection_iff Finset.univ x).mp hx
+  have hsum :
+      ∑ i : Fin 8, boundarySevenComparisonToStdSimplex x i <
+        ∑ _i : Fin 8, (1 : ℝ) / 8 := by
+    apply Finset.sum_lt_sum
+    · intro i _
+      exact (hcoord i (Finset.mem_univ i)).le
+    · exact ⟨0, Finset.mem_univ 0, hcoord 0 (Finset.mem_univ 0)⟩
+  rw [stdSimplex.sum_eq_one] at hsum
+  norm_num at hsum
+
+/-- Every point of the realized simplicial boundary is represented by a point of one of its
+codimension-one faces.  This is the concrete joint-surjectivity consequence of the canonical
+colimit presentation of a presheaf by representables. -/
+public theorem boundarySevenRealization_exists_face_representation
+    (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
+    ∃ (i : Fin 8) (y : SSet.toTop.obj (Δ[6] : SSet.{0})),
+      SSet.toTop.map (SSet.boundary.ι i) y = x := by
+  let c := SSet.toTop.mapCocone
+    (Presheaf.coconeOfRepresentable (∂Δ[7] : SSet.{0}))
+  let hc : IsColimit c := isColimitOfPreserves SSet.toTop
+    (Presheaf.colimitOfRepresentable (∂Δ[7] : SSet.{0}))
+  obtain ⟨j, z, hz⟩ := Concrete.isColimit_exists_rep _ hc x
+  let a := j.unop.2
+  have ha := a.2
+  simp only [SSet.boundary_eq_iSup, SSet.stdSimplex.face_singleton_compl,
+    Subfunctor.iSup_obj, Set.mem_iUnion,
+    SSet.Subcomplex.mem_ofSimplex_obj_iff, Opposite.op_unop] at ha
+  obtain ⟨i, ⟨y, hy⟩⟩ := ha
+  let y' : (Δ[6] : SSet.{0}).obj j.unop.1 := SSet.stdSimplex.objEquiv.symm y
+  have hay : (SSet.boundary.ι i).app j.unop.1 y' = a := by
+    apply Subtype.ext
+    change (SSet.stdSimplex.map (SimplexCategory.δ i)).app j.unop.1 y' = a.1
+    exact hy
+  refine ⟨i, SSet.toTop.map (SSet.yonedaEquiv.symm y') z, ?_⟩
+  have hcomp :
+      SSet.toTop.map (SSet.yonedaEquiv.symm y') ≫
+          SSet.toTop.map (SSet.boundary.ι i) =
+        SSet.toTop.map (SSet.yonedaEquiv.symm a) := by
+    rw [← SSet.toTop.map_comp, SSet.yonedaEquiv_symm_comp, hay]
+  have happ := ConcreteCategory.congr_hom hcomp z
+  change SSet.toTop.map (SSet.boundary.ι i)
+      (SSet.toTop.map (SSet.yonedaEquiv.symm y') z) =
+        SSet.toTop.map (SSet.yonedaEquiv.symm a) z at happ
+  change SSet.toTop.map (SSet.yonedaEquiv.symm a) z = x at hz
+  exact happ.trans hz
+
+/-- The comparison map from the realization really lands in the affine boundary. -/
+public theorem boundarySevenComparisonMapLandsInAffineBoundary :
+    BoundarySevenComparisonMapLandsInAffineBoundary := by
+  intro x
+  obtain ⟨i, y, rfl⟩ := boundarySevenRealization_exists_face_representation x
+  refine ⟨i, ?_⟩
+  rw [boundarySevenComparisonToStdSimplex_face]
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  apply Finset.sum_eq_zero
+  intro j hj
+  exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+
+/-- Consequently, the eight explicit face neighborhoods cover the whole realization. -/
+public theorem boundarySevenComparisonFaceNeighborhood_iUnion_unconditional :
+    ⋃ i, boundarySevenComparisonFaceNeighborhood i = Set.univ :=
+  boundarySevenComparisonFaceNeighborhood_iUnion
+    boundarySevenComparisonMapLandsInAffineBoundary
+
+/-- With the global cover assertion discharged, the canonical integral comparison is
+unconditionally equivalent to the explicit face-neighborhood lift. -/
+public theorem boundarySeven_integralComparison_iff_faceNeighborhoodLift_unconditional :
+    SimplicialToSingularComparisonQuasiIsomorphism
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ↔
+      BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism :=
+  boundarySeven_integralComparison_iff_faceNeighborhoodLift
+    boundarySevenComparisonMapLandsInAffineBoundary
+
+/-- The coproduct of the eight standard simplicial faces. -/
+public noncomputable abbrev boundarySevenSimplicialFacePresentationSource : SSet.{0} :=
+  sigmaObj (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0}))
+
+/-- The canonical simplicial face presentation of `∂Δ[7]`. -/
+public noncomputable def boundarySevenSimplicialFacePresentation :
+    boundarySevenSimplicialFacePresentationSource ⟶ (∂Δ[7] : SSet.{0}) :=
+  Sigma.desc fun i ↦ SSet.boundary.ι i
+
+/-- The simplicial face presentation is degreewise surjective. -/
+public theorem boundarySevenSimplicialFacePresentation_app_surjective
+    (n : SimplexCategoryᵒᵖ) :
+    Function.Surjective (boundarySevenSimplicialFacePresentation.app n) := by
+  intro x
+  have hx := x.2
+  simp only [SSet.boundary_eq_iSup, SSet.stdSimplex.face_singleton_compl,
+    Subfunctor.iSup_obj, Set.mem_iUnion,
+    SSet.Subcomplex.mem_ofSimplex_obj_iff, Opposite.op_unop] at hx
+  obtain ⟨i, ⟨y, hy⟩⟩ := hx
+  let y' : (Δ[6] : SSet.{0}).obj n := SSet.stdSimplex.objEquiv.symm y
+  refine ⟨(Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i).app n y', ?_⟩
+  apply Subtype.ext
+  change ((Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i ≫
+    boundarySevenSimplicialFacePresentation).app n y').1 = x.1
+  rw [boundarySevenSimplicialFacePresentation, Sigma.ι_desc]
+  exact hy
+
+/-- The simplicial face presentation is an epimorphism. -/
+public instance boundarySevenSimplicialFacePresentation_epi :
+    Epi boundarySevenSimplicialFacePresentation := by
+  rw [NatTrans.epi_iff_epi_app]
+  intro n
+  rw [CategoryTheory.epi_iff_surjective]
+  exact boundarySevenSimplicialFacePresentation_app_surjective n
+
+/-- The coproduct of the singular simplicial sets of the eight face neighborhoods. -/
+public noncomputable abbrev boundarySevenFaceNeighborhoodPresentationSource : SSet.{0} :=
+  sigmaObj (fun i : Fin 8 ↦
+    TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i)))
+
+/-- The canonical presentation of the face-neighborhood-small singular simplicial set. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentation :
+    boundarySevenFaceNeighborhoodPresentationSource ⟶
+      coverSmallSingularSubcomplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood :=
+  Sigma.desc fun i ↦
+    coverMemberToSmallSingularSet
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood i
+
+/-- In every simplicial degree, the face-neighborhood presentation is surjective. -/
+public theorem boundarySevenFaceNeighborhoodPresentation_app_surjective
+    (n : SimplexCategoryᵒᵖ) :
+    Function.Surjective (boundarySevenFaceNeighborhoodPresentation.app n) := by
+  intro z
+  obtain ⟨i, y, hy⟩ :=
+    (mem_coverSmallSingularSubcomplex_iff_exists_preimage
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood z.1).mp z.2
+  refine ⟨(Sigma.ι (fun i : Fin 8 ↦
+    TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i).app n y, ?_⟩
+  apply Subtype.ext
+  have hcat :
+      Sigma.ι (fun i : Fin 8 ↦
+          TopCat.toSSet.obj
+            (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i ≫
+          boundarySevenFaceNeighborhoodPresentation ≫
+          (coverSmallSingularSubcomplex
+            (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+            boundarySevenComparisonFaceNeighborhood).ι =
+        TopCat.toSSet.map
+          (topologicalSubsetInclusion (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+            (boundarySevenComparisonFaceNeighborhood i)) := by
+    rw [boundarySevenFaceNeighborhoodPresentation, ← Category.assoc, Sigma.ι_desc,
+      coverMemberToSmallSingularSet_comp_inclusion]
+  have happ := ConcreteCategory.congr_hom (congr_app hcat n) y
+  exact happ.trans hy
+
+/-- The cover presentation is an epimorphism of simplicial sets. -/
+public instance boundarySevenFaceNeighborhoodPresentation_epi :
+    Epi boundarySevenFaceNeighborhoodPresentation := by
+  rw [NatTrans.epi_iff_epi_app]
+  intro n
+  rw [CategoryTheory.epi_iff_surjective]
+  exact boundarySevenFaceNeighborhoodPresentation_app_surjective n
+
+/-- Facewise, the realized simplicial unit maps the coproduct of standard faces to the
+coproduct of singular sets of the corresponding open neighborhoods. -/
+public noncomputable def boundarySevenFacePresentationSourceMap :
+    boundarySevenSimplicialFacePresentationSource ⟶
+      boundarySevenFaceNeighborhoodPresentationSource :=
+  Sigma.desc fun i ↦
+    sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+      TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i) ≫
+        Sigma.ι (fun i : Fin 8 ↦
+          TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenSimplicialFacePresentation_iota (i : Fin 8) :
+    Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i ≫
+        boundarySevenSimplicialFacePresentation =
+      SSet.boundary.ι i := by
+  apply Sigma.ι_desc
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenFacePresentationSourceMap_iota (i : Fin 8) :
+    Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i ≫
+        boundarySevenFacePresentationSourceMap =
+      sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+        TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i) ≫
+          Sigma.ι (fun i : Fin 8 ↦
+            TopCat.toSSet.obj
+              (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i := by
+  apply Sigma.ι_desc
+
+/-- The facewise presentation map commutes with the two augmentations. -/
+public theorem boundarySevenFacePresentationSourceMap_comp_presentation :
+    boundarySevenFacePresentationSourceMap ≫
+        boundarySevenFaceNeighborhoodPresentation =
+      boundarySevenSimplicialFacePresentation ≫
+        simplicialToCoverSmallSingularSet
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods := by
+  apply Sigma.hom_ext
+  intro i
+  simp only [← Category.assoc,
+    boundarySevenFacePresentationSourceMap_iota,
+    boundarySevenSimplicialFacePresentation_iota]
+  rw [Category.assoc, Category.assoc]
+  rw [boundarySevenFaceNeighborhoodPresentation, Sigma.ι_desc]
+  change boundarySevenFaceUnitToSmallSingularSet i =
+    SSet.boundary.ι i ≫
+      simplicialToCoverSmallSingularSet
+        (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+        boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  apply (cancel_mono
+    (coverSmallSingularSubcomplex
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood).ι).mp
+  rw [boundarySevenFaceUnitToSmallSingularSet_comp_inclusion,
+    Category.assoc, simplicialToCoverSmallSingularSet_comp_inclusion]
+
+/-- The preceding commuting square as a morphism of arrows. -/
+public noncomputable def boundarySevenFacePresentationArrowMap :
+    Arrow.mk boundarySevenSimplicialFacePresentation ⟶
+      Arrow.mk boundarySevenFaceNeighborhoodPresentation where
+  left := boundarySevenFacePresentationSourceMap
+  right := simplicialToCoverSmallSingularSet
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  w := boundarySevenFacePresentationSourceMap_comp_presentation
+
+/-- The presentation evaluated at one singular degree, as an arrow of types. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+    (n : SimplexCategoryᵒᵖ) : Arrow (Type 0) :=
+  Arrow.mk (boundarySevenFaceNeighborhoodPresentation.app n)
+
+/-- A chosen splitting of the evaluated presentation.  Choice is harmless here: this splitting
+is used only horizontally, to contract one Čech row. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentationEvaluationSplitEpi
+    (n : SimplexCategoryᵒᵖ) :
+    SplitEpi (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n).hom := by
+  let h := boundarySevenFaceNeighborhoodPresentation_app_surjective n
+  exact
+    { section_ := ↾fun z ↦ Function.surjInv h z
+      id := by
+        ext z
+        exact Function.rightInverse_surjInv h z }
+
+/-- The evaluated augmented Čech nerve has an extra degeneracy. -/
+public noncomputable def boundarySevenFaceNeighborhoodEvaluationExtraDegeneracy
+    (n : SimplexCategoryᵒᵖ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n).augmentedCechNerve :=
+  Arrow.AugmentedCechNerve.extraDegeneracy
+    (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n)
+    (boundarySevenFaceNeighborhoodPresentationEvaluationSplitEpi n)
+
+/-- Apply the free abelian group functor to an evaluated augmented Čech nerve. -/
+public noncomputable abbrev boundarySevenFaceNeighborhoodFreeEvaluationCech
+    (n : SimplexCategoryᵒᵖ) : SimplicialObject.Augmented AddCommGrpCat :=
+  ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    AddCommGrpCat.free).obj
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n).augmentedCechNerve
+
+/-- The free-abelian evaluated Čech nerve retains the extra degeneracy. -/
+public noncomputable def boundarySevenFaceNeighborhoodFreeEvaluationExtraDegeneracy
+    (n : SimplexCategoryᵒᵖ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenFaceNeighborhoodFreeEvaluationCech n) :=
+  (boundarySevenFaceNeighborhoodEvaluationExtraDegeneracy n).map AddCommGrpCat.free
+
+/-- Rowwise Čech exactness: in every singular degree, the alternating Čech complex is
+chain-homotopy equivalent to the free group on the cover-small simplices in that degree. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechRowHomotopyEquiv
+    (n : SimplexCategoryᵒᵖ) :
+    HomotopyEquiv
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodFreeEvaluationCech n)))
+      ((ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenFaceNeighborhoodFreeEvaluationCech n))) :=
+  (boundarySevenFaceNeighborhoodFreeEvaluationExtraDegeneracy n).homotopyEquiv
+
+/-- The same evaluated Čech nerve with the coefficient functor actually used by integral
+simplicial chains: a coproduct of copies of `ℤ`. -/
+public noncomputable abbrev boundarySevenFaceNeighborhoodIntegralEvaluationCech
+    (k : ℕ) : SimplicialObject.Augmented AddCommGrpCat :=
+  ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk k))).augmentedCechNerve
+
+/-- The integral evaluated Čech nerve has the same row contraction. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralEvaluationExtraDegeneracy
+    (k : ℕ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenFaceNeighborhoodIntegralEvaluationCech k) :=
+  (boundarySevenFaceNeighborhoodEvaluationExtraDegeneracy
+    (Opposite.op (SimplexCategory.mk k))).map
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))
+
+/-- Rowwise exactness in the precise coefficient model used by the singular chain complex. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralCechRowHomotopyEquiv
+    (k : ℕ) :
+    HomotopyEquiv
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)))
+      ((ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k))) :=
+  (boundarySevenFaceNeighborhoodIntegralEvaluationExtraDegeneracy k).homotopyEquiv
+
+/-- The target of the integral row contraction is definitionally the degree-`k` group of the
+cover-small singular chain complex. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralEvaluationPointIso
+    (k : ℕ) :
+    SimplicialObject.Augmented.point.obj
+        (boundarySevenFaceNeighborhoodIntegralEvaluationCech k) ≅
+      (CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood).X k :=
+  Iso.refl _
+
+/-- Equivalently, every horizontal integral Čech-row augmentation is a
+quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodIntegralCechRowAugmentation_quasiIso
+    (k : ℕ) :
+    QuasiIso (AlternatingFaceMapComplex.ε.app
+      (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)) :=
+  (boundarySevenFaceNeighborhoodIntegralCechRowHomotopyEquiv k).quasiIso_hom
+
+/-- The face-neighborhood presentation, bundled as an arrow of simplicial sets. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentationArrow : Arrow SSet :=
+  Arrow.mk boundarySevenFaceNeighborhoodPresentation
+
+/-- The augmented Čech nerve of the face-neighborhood presentation. -/
+public noncomputable def boundarySevenFaceNeighborhoodAugmentedCechNerve :
+    SimplicialObject.Augmented SSet :=
+  boundarySevenFaceNeighborhoodPresentationArrow.augmentedCechNerve
+
+/-- Apply integral simplicial chains in the singular direction to the augmented Čech nerve. -/
+public noncomputable def boundarySevenFaceNeighborhoodAugmentedCechChains :
+    SimplicialObject.Augmented (ChainComplex AddCommGrpCat ℕ) :=
+  ((SimplicialObject.Augmented.whiskering SSet
+    (ChainComplex AddCommGrpCat ℕ)).obj
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ))).obj
+        boundarySevenFaceNeighborhoodAugmentedCechNerve
+
+/-- The Čech--singular bicomplex for the eight explicit face neighborhoods. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechBicomplex :
+    HomologicalComplex₂ AddCommGrpCat (ComplexShape.down ℕ) (ComplexShape.down ℕ) :=
+  AlternatingFaceMapComplex.obj
+    (SimplicialObject.Augmented.drop.obj
+      boundarySevenFaceNeighborhoodAugmentedCechChains)
+
+/-- The direct-sum total Čech--singular complex for the eight explicit face neighborhoods. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechTotal :
+    ChainComplex AddCommGrpCat ℕ :=
+  boundarySevenFaceNeighborhoodCechBicomplex.total (ComplexShape.down ℕ)
+
+/-- The canonical outer Čech augmentation before totalization.  Its target is the horizontal
+degree-zero complex on the cover-small singular chain complex. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechOuterAugmentation :
+    boundarySevenFaceNeighborhoodCechBicomplex ⟶
+      (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).obj
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood) :=
+  AlternatingFaceMapComplex.ε.app
+    boundarySevenFaceNeighborhoodAugmentedCechChains
+
+/-- Exact data still needed to turn rowwise Čech exactness and the local face contractions
+into the comparison theorem.  The first map is the local face/intersection comparison; the
+second is the totalized canonical Čech augmentation. -/
+public structure BoundarySevenFaceNeighborhoodCechTotalComparison where
+  boundaryToCech :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenFaceNeighborhoodCechTotal
+  augmentation :
+    boundarySevenFaceNeighborhoodCechTotal ⟶
+      CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood
+  fac : boundaryToCech ≫ augmentation =
+    simplicialToCoverSmallSingularChainMap
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  boundaryToCech_quasiIso : QuasiIso boundaryToCech
+  augmentation_quasiIso : QuasiIso augmentation
+
+/-- A Čech total comparison supplies the remaining face-neighborhood lift
+quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodLiftQuasiIsomorphism_of_cechTotalComparison
+    (h : BoundarySevenFaceNeighborhoodCechTotalComparison) :
+    BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism := by
+  unfold BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism
+  rw [← h.fac]
+  let _ : QuasiIso h.boundaryToCech := h.boundaryToCech_quasiIso
+  let _ : QuasiIso h.augmentation := h.augmentation_quasiIso
+  infer_instance
+
+/-- The Čech total comparison also gives the original canonical integral comparison, since the
+global affine-boundary cover assertion was proved above. -/
+public theorem boundarySeven_integralComparison_of_cechTotalComparison
+    (h : BoundarySevenFaceNeighborhoodCechTotalComparison) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  boundarySeven_integralComparison_of_faceNeighborhoodLift
+    boundarySevenComparisonMapLandsInAffineBoundary
+    (boundarySevenFaceNeighborhoodLiftQuasiIsomorphism_of_cechTotalComparison h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodDeformation.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodDeformation.lean
@@ -1,0 +1,426 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenRealizationInjective
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodComparison
+public import SphereSixComplex.Topology.HomotopySphereHomology
+
+/-!
+# Deformation of a boundary-face neighbourhood onto its face
+
+For a fixed barycentric coordinate `i`, the open subset `w i < 1 / 8` of the boundary of the
+standard seven-simplex deformation retracts onto the face `w i = 0`.  The retraction sets the
+`i`-th coordinate to zero and divides all other coordinates by `1 - w i`.
+
+This file develops the affine formula independently of the total-complex argument.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The ordinary barycentric version of the `i`-th open face neighbourhood. -/
+public def standardBoundarySevenFaceNeighborhood (i : Fin 8) :
+    Set (StandardSimplexBoundary 7) :=
+  {w | w.1 i < (1 : ℝ) / 8}
+
+/-- On the `i`-th face neighbourhood, the sum of the other coordinates is positive. -/
+public theorem standardBoundarySevenFaceNeighborhood_one_sub_pos
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    0 < 1 - w.1.1 i := by
+  have hw : w.1.1 i < (1 : ℝ) / 8 := w.2
+  linarith
+
+/-- Delete the `i`-th coordinate and renormalize the remaining seven coordinates. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodRetractionCoordinates
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    stdSimplex ℝ (Fin 7) := by
+  let d : ℝ := 1 - w.1.1 i
+  have hd : 0 < d := standardBoundarySevenFaceNeighborhood_one_sub_pos i w
+  refine ⟨fun j ↦ w.1.1 (i.succAbove j) / d, ⟨?_, ?_⟩⟩
+  · intro j
+    exact div_nonneg (w.1.1.2.1 _) hd.le
+  · have hsum := w.1.1.2.2
+    change (∑ k : Fin 8, w.1.1 k) = 1 at hsum
+    have hother : (∑ j : Fin 7, w.1.1 (i.succAbove j)) = d := by
+      rw [Fin.sum_univ_succAbove (fun k ↦ w.1.1 k) i] at hsum
+      dsimp [d]
+      linarith
+    rw [← Finset.sum_div, hother, div_self hd.ne']
+
+/-- The retraction coordinates vary continuously over the open face neighbourhood. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodRetractionCoordinates
+    (i : Fin 8) :
+    Continuous (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i) := by
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro j
+  exact (((continuous_apply (i.succAbove j)).comp
+      (continuous_subtype_val.comp continuous_subtype_val)).comp
+        continuous_subtype_val).div
+    (continuous_const.sub
+      (((continuous_apply i).comp
+        (continuous_subtype_val.comp continuous_subtype_val)).comp
+          continuous_subtype_val))
+    (fun w ↦ (standardBoundarySevenFaceNeighborhood_one_sub_pos i w).ne')
+
+/-- The normalized point, reinserted as a point of the ordinary boundary. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodProjection
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    StandardSimplexBoundary 7 :=
+  ⟨stdSimplex.map i.succAbove
+      (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w),
+    ⟨i, stdSimplex_map_succAbove_apply_self i _⟩⟩
+
+/-- The projection varies continuously. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodProjection
+    (i : Fin 8) :
+    Continuous (standardBoundarySevenFaceNeighborhoodProjection i) := by
+  apply Continuous.subtype_mk
+  exact (stdSimplex.continuous_map i.succAbove).comp
+    (continuous_standardBoundarySevenFaceNeighborhoodRetractionCoordinates i)
+
+/-- The projected point still belongs to the same open face neighbourhood. -/
+public theorem standardBoundarySevenFaceNeighborhoodProjection_mem
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhoodProjection i w ∈
+      standardBoundarySevenFaceNeighborhood i := by
+  change (standardBoundarySevenFaceNeighborhoodProjection i w).1 i < (1 : ℝ) / 8
+  rw [standardBoundarySevenFaceNeighborhoodProjection,
+    stdSimplex_map_succAbove_apply_self]
+  norm_num
+
+/-- The projection, as a self-map of the open neighbourhood. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodProjectionSelf
+    (i : Fin 8) :
+    C(standardBoundarySevenFaceNeighborhood i,
+      standardBoundarySevenFaceNeighborhood i) :=
+  ⟨fun w ↦ ⟨standardBoundarySevenFaceNeighborhoodProjection i w,
+      standardBoundarySevenFaceNeighborhoodProjection_mem i w⟩,
+    (continuous_standardBoundarySevenFaceNeighborhoodProjection i).subtype_mk _⟩
+
+/-- Every coordinate which vanishes before projection also vanishes after projection. -/
+public theorem standardBoundarySevenFaceNeighborhoodProjection_apply_eq_zero
+    (i k : Fin 8) (w : standardBoundarySevenFaceNeighborhood i)
+    (hk : w.1.1 k = 0) :
+    (standardBoundarySevenFaceNeighborhoodProjection i w).1 k = 0 := by
+  rcases Fin.eq_self_or_eq_succAbove i k with hik | ⟨j, hj⟩
+  · subst k
+    exact stdSimplex_map_succAbove_apply_self i _
+  · subst k
+    rw [standardBoundarySevenFaceNeighborhoodProjection,
+      stdSimplex_map_apply_of_injective i.succAbove
+        Fin.succAbove_right_injective]
+    change w.1.1 (i.succAbove j) /
+      (1 - w.1.1 i) = 0
+    rw [hk, zero_div]
+
+/-- Linear interpolation from a point of the neighbourhood to its normalized face projection. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodHomotopyPoint
+    (i : Fin 8) (q : unitInterval × standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhood i := by
+  let t : ℝ := q.1
+  let w := q.2
+  let p := standardBoundarySevenFaceNeighborhoodProjection i w
+  let z : Fin 8 → ℝ := fun k ↦ (1 - t) * w.1.1 k + t * p.1 k
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    exact add_nonneg
+      (mul_nonneg (sub_nonneg.mpr q.1.2.2) (w.1.1.2.1 k))
+      (mul_nonneg q.1.2.1 (p.1.2.1 k))
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    have hw_sum : (∑ k : Fin 8, w.1.1 k) = 1 := w.1.1.2.2
+    have hp_sum : (∑ k : Fin 8, p.1 k) = 1 := p.1.2.2
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      hw_sum, hp_sum]
+    ring
+  have hz_boundary : ∃ k, z k = 0 := by
+    obtain ⟨k, hk⟩ := w.1.2
+    refine ⟨k, ?_⟩
+    dsimp [z]
+    rw [hk, standardBoundarySevenFaceNeighborhoodProjection_apply_eq_zero i k w hk]
+    ring
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  let zb : StandardSimplexBoundary 7 := ⟨zs, hz_boundary⟩
+  refine ⟨zb, ?_⟩
+  have hpi : p.1 i = 0 := stdSimplex_map_succAbove_apply_self i _
+  have hwi_nonneg : 0 ≤ w.1.1 i := w.1.1.2.1 i
+  have hwi_lt : w.1.1 i < (1 : ℝ) / 8 := w.2
+  have ht0 : 0 ≤ t := q.1.2.1
+  have ht1 : t ≤ 1 := q.1.2.2
+  change z i < (1 : ℝ) / 8
+  dsimp [z]
+  rw [hpi, mul_zero, add_zero]
+  nlinarith
+
+/-- The affine neighbourhood deformation is continuous. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodHomotopyPoint
+    (i : Fin 8) :
+    Continuous (standardBoundarySevenFaceNeighborhoodHomotopyPoint i) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  change Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦
+        (1 - (q.1 : ℝ)) * q.2.1.1 k +
+          (q.1 : ℝ) *
+            (standardBoundarySevenFaceNeighborhoodProjection i q.2).1 k)
+  have ct : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦ (q.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have cw : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦ q.2.1.1 k) :=
+    ((((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp continuous_subtype_val).comp continuous_snd
+  have cp : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦
+        (standardBoundarySevenFaceNeighborhoodProjection i q.2).1 k) :=
+    (((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp
+        ((continuous_standardBoundarySevenFaceNeighborhoodProjection i).comp continuous_snd)
+  exact (continuous_const.sub ct).mul cw |>.add (ct.mul cp)
+
+/-- At time zero the affine deformation is the identity. -/
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodHomotopyPoint_zero
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhoodHomotopyPoint i (0, w) = w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (0 : ℝ)) * w.1.1 k + 0 *
+      (standardBoundarySevenFaceNeighborhoodProjection i w).1 k = w.1.1 k
+  ring
+
+/-- At time one the affine deformation is the normalized face projection. -/
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodHomotopyPoint_one
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhoodHomotopyPoint i (1, w) =
+      standardBoundarySevenFaceNeighborhoodProjectionSelf i w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (1 : ℝ)) * w.1.1 k + 1 *
+      (standardBoundarySevenFaceNeighborhoodProjection i w).1 k =
+        (standardBoundarySevenFaceNeighborhoodProjection i w).1 k
+  ring
+
+/-- The explicit deformation from the identity to the face projection. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodHomotopy
+    (i : Fin 8) :
+    ContinuousMap.Homotopy (ContinuousMap.id _)
+      (standardBoundarySevenFaceNeighborhoodProjectionSelf i) where
+  toFun := standardBoundarySevenFaceNeighborhoodHomotopyPoint i
+  continuous_toFun := continuous_standardBoundarySevenFaceNeighborhoodHomotopyPoint i
+  map_zero_left := standardBoundarySevenFaceNeighborhoodHomotopyPoint_zero i
+  map_one_left := standardBoundarySevenFaceNeighborhoodHomotopyPoint_one i
+
+/-! ## The face inclusion is a homotopy equivalence -/
+
+/-- Insert a realized standard six-simplex as the `i`-th affine face, regarded as a point of the
+open face neighbourhood. -/
+public noncomputable def realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood
+    (i : Fin 8) :
+    C((SSet.toTop.obj (Δ[6] : SSet.{0}) : Type),
+      standardBoundarySevenFaceNeighborhood i) := by
+  refine ⟨fun y ↦ ⟨⟨stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y),
+      ⟨i, stdSimplex_map_succAbove_apply_self i _⟩⟩, ?_⟩, ?_⟩
+  · change stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) i < (1 : ℝ) / 8
+    rw [stdSimplex_map_succAbove_apply_self]
+    norm_num
+  · apply Continuous.subtype_mk
+    apply Continuous.subtype_mk
+    exact (stdSimplex.continuous_map i.succAbove).comp
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).continuous
+
+/-- Normalize away the distinguished coordinate and return to the realized standard face. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex
+    (i : Fin 8) :
+    C(standardBoundarySevenFaceNeighborhood i,
+      (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :=
+  ⟨fun w ↦ (SimplexCategory.toTopHomeo
+      (SimplexCategory.mk 6)).symm
+        (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm.continuous.comp
+      (continuous_standardBoundarySevenFaceNeighborhoodRetractionCoordinates i)⟩
+
+/-- Normalizing a point already on the face returns its original face coordinates. -/
+public theorem standardBoundarySevenFaceNeighborhoodRetractionCoordinates_face
+    (i : Fin 8) (y : SSet.toTop.obj (Δ[6] : SSet.{0})) :
+    standardBoundarySevenFaceNeighborhoodRetractionCoordinates i
+        (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i y) =
+      SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y := by
+  apply stdSimplex.ext
+  funext j
+  rw [standardBoundarySevenFaceNeighborhoodRetractionCoordinates]
+  change stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) (i.succAbove j) /
+        (1 - stdSimplex.map i.succAbove
+          (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) i) = _
+  rw [stdSimplex_map_apply_of_injective i.succAbove
+      Fin.succAbove_right_injective,
+    stdSimplex_map_succAbove_apply_self]
+  simp
+
+/-- The retraction is a strict left inverse to the face inclusion. -/
+public theorem standardBoundarySevenFaceNeighborhoodToRealized_comp_inclusion :
+    (standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex i).comp
+        (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i) =
+      ContinuousMap.id _ := by
+  ext y
+  apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+  simp [standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex,
+    standardBoundarySevenFaceNeighborhoodRetractionCoordinates_face]
+
+/-- Inclusion after retraction is exactly the normalized affine face projection. -/
+public theorem realizedStandardSixSimplexToStandardBoundary_comp_retraction :
+    (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i).comp
+        (standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex i) =
+      standardBoundarySevenFaceNeighborhoodProjectionSelf i := by
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)
+        ((SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm
+          (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w))) k =
+    stdSimplex.map i.succAbove
+      (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w) k
+  rw [Homeomorph.apply_symm_apply]
+
+/-- The affine face inclusion is a homotopy equivalence, with the explicit normalized
+retraction as inverse. -/
+public noncomputable def realizedStandardSixSimplexStandardBoundaryFaceNeighborhoodHomotopyEquiv
+    (i : Fin 8) :
+    (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ≃ₕ
+      standardBoundarySevenFaceNeighborhood i where
+  toFun := realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i
+  invFun := standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex i
+  left_inv := by
+    rw [standardBoundarySevenFaceNeighborhoodToRealized_comp_inclusion]
+  right_inv := by
+    rw [realizedStandardSixSimplexToStandardBoundary_comp_retraction]
+    exact ⟨(standardBoundarySevenFaceNeighborhoodHomotopy i).symm⟩
+
+/-! ## Transport back to the geometric realization -/
+
+/-- The canonical barycentric homeomorphism, now available unconditionally. -/
+public noncomputable def boundarySevenRealizationHomeomorphStandardBoundary :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ StandardSimplexBoundary 7 :=
+  boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+    boundarySevenRealizationToBoundary_injective
+
+@[simp]
+public theorem boundarySevenRealizationHomeomorphStandardBoundary_apply_val
+    (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
+    (boundarySevenRealizationHomeomorphStandardBoundary x :
+        stdSimplex ℝ (Fin 8)) = boundarySevenComparisonToStdSimplex x :=
+  rfl
+
+/-- The actual realization face neighbourhood is homeomorphic to its ordinary barycentric
+counterpart. -/
+public noncomputable def boundarySevenFaceNeighborhoodHomeomorphStandard
+    (i : Fin 8) :
+    boundarySevenComparisonFaceNeighborhood i ≃ₜ
+      standardBoundarySevenFaceNeighborhood i :=
+  boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
+    change boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8 ↔
+      (boundarySevenRealizationHomeomorphStandardBoundary x :
+        stdSimplex ℝ (Fin 8)) i < (1 : ℝ) / 8
+    rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+
+/-- The forward continuous map of the barycentric neighbourhood homeomorphism. -/
+public noncomputable def boundarySevenFaceNeighborhoodToStandardContinuousMap
+    (i : Fin 8) :
+    C(boundarySevenComparisonFaceNeighborhood i,
+      standardBoundarySevenFaceNeighborhood i) :=
+  ⟨boundarySevenFaceNeighborhoodHomeomorphStandard i,
+    (boundarySevenFaceNeighborhoodHomeomorphStandard i).continuous⟩
+
+/-- Under barycentric coordinates, the existing realized-face map is the affine face
+inclusion used above. -/
+public theorem boundarySevenFaceNeighborhoodHomeomorphStandard_comp_face
+    (i : Fin 8) :
+    (boundarySevenFaceNeighborhoodToStandardContinuousMap i).comp
+        (boundarySevenFaceToComparisonFaceNeighborhood i).hom =
+      realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i := by
+  apply ContinuousMap.ext
+  intro y
+  apply Subtype.ext
+  apply Subtype.ext
+  change boundarySevenComparisonToStdSimplex
+      (SSet.toTop.map (SSet.boundary.ι i) y) =
+    stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)
+  exact boundarySevenComparisonToStdSimplex_face i y
+
+/-- Every canonical realized face is a homotopy equivalence onto its open affine
+neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodHomotopyEquiv
+    (i : Fin 8) :
+    (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ≃ₕ
+      boundarySevenComparisonFaceNeighborhood i :=
+  (realizedStandardSixSimplexStandardBoundaryFaceNeighborhoodHomotopyEquiv i).trans
+    (boundarySevenFaceNeighborhoodHomeomorphStandard i).symm.toHomotopyEquiv
+
+/-- The forward function of the preceding homotopy equivalence is the face map already used by
+the comparison construction. -/
+public theorem boundarySevenFaceNeighborhoodHomotopyEquiv_apply
+    (i : Fin 8) (y : SSet.toTop.obj (Δ[6] : SSet.{0})) :
+    boundarySevenFaceNeighborhoodHomotopyEquiv i y =
+      boundarySevenFaceToComparisonFaceNeighborhood i y := by
+  change (boundarySevenFaceNeighborhoodHomeomorphStandard i).symm
+      (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i y) =
+    boundarySevenFaceToComparisonFaceNeighborhood i y
+  apply (boundarySevenFaceNeighborhoodHomeomorphStandard i).injective
+  rw [Homeomorph.apply_symm_apply]
+  exact ContinuousMap.congr_fun
+    (boundarySevenFaceNeighborhoodHomeomorphStandard_comp_face i).symm y
+
+/-- The singular-chain map induced by inclusion of a realized face into its neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralSingularChainMap
+    (i : Fin 8) :
+    IntegralSingularChainComplexObj
+        (SSet.toTop.obj (Δ[6] : SSet.{0})) ⟶
+      IntegralSingularChainComplexObj
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood i)) :=
+  integralSingularChainMapObj
+    (boundarySevenFaceToComparisonFaceNeighborhood i)
+
+/-- Since the face inclusion is an explicit homotopy equivalence, its integral singular-chain
+map is a quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodIntegralSingularChainMap_quasiIso
+    (i : Fin 8) :
+    QuasiIso (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) := by
+  let e := boundarySevenFaceNeighborhoodHomotopyEquiv i
+  have hmap : TopCat.ofHom e.toFun =
+      boundarySevenFaceToComparisonFaceNeighborhood i := by
+    ext y
+    exact congrArg Subtype.val
+      (boundarySevenFaceNeighborhoodHomotopyEquiv_apply i y)
+  rw [quasiIso_iff]
+  intro k
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  change IsIso (((singularHomologyFunctor AddCommGrpCat k).obj
+    (AddCommGrpCat.of ℤ)).map
+      (boundarySevenFaceToComparisonFaceNeighborhood i))
+  rw [← hmap]
+  change IsIso (singularHomologyIsoOfHomotopyEquiv
+    (AddCommGrpCat.of ℤ) k e).hom
+  infer_instance
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersectionHomology.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersectionHomology.lean
@@ -1,0 +1,50 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersections
+public import SphereSixComplex.Topology.ContractibleSingularMapQuasiIso
+
+/-!
+# Homology of finite face-neighbourhood intersections
+
+The explicit strong deformation retractions of the affine intersections imply their positive-
+degree singular homology vanishes.  More strongly, every specified map from a realized standard
+simplex into such an intersection induces a quasi-isomorphism on singular chains.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+/-- A nonempty proper face-neighbourhood intersection has zero positive-degree singular homology,
+with arbitrary coefficients. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_singularHomology_isZero
+    (R : AddCommGrpCat) (s : Finset (Fin 8)) (hsne : s.Nonempty)
+    (hsproper : s ≠ Finset.univ) (k : ℕ) (hk : k ≠ 0) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj
+      (TopCat.of (boundarySevenFaceNeighborhoodIntersection s))) := by
+  let _ : ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) :=
+    boundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hsproper
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (boundarySevenFaceNeighborhoodIntersection s)
+  have hunit :=
+    AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+      AddCommGrpCat k R (TopCat.of Unit) hk
+  exact hunit.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
+
+/-- Any continuous map from a realized standard simplex to a nonempty proper intersection
+induces a singular-chain quasi-isomorphism. -/
+public theorem standardSimplexToBoundarySevenFaceNeighborhoodIntersection_quasiIso
+    (R : AddCommGrpCat) (n : ℕ) (s : Finset (Fin 8))
+    (hsne : s.Nonempty) (hsproper : s ≠ Finset.univ)
+    (f : C((SSet.toTop.obj (Δ[n] : SSet.{0}) : Type),
+      boundarySevenFaceNeighborhoodIntersection s)) :
+    QuasiIso (standardSimplexToContractibleSingularChainMap R n f) := by
+  let _ : ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) :=
+    boundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hsproper
+  exact standardSimplexToContractibleSingularChainMap_quasiIso R n f
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersections.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersections.lean
@@ -1,0 +1,760 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodDeformation
+
+/-!
+# Intersections of the boundary-seven face neighbourhoods
+
+Every nonempty proper intersection of the affine open sets `x i < 1 / 8` retracts onto
+the face on which all of the indexed coordinates vanish.  The retraction simultaneously
+sets those coordinates to zero and renormalizes the complementary coordinates.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open ContinuousMap Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The barycentric model of an intersection of face neighbourhoods. -/
+public def standardBoundarySevenFaceNeighborhoodIntersection (s : Finset (Fin 8)) :
+    Set (StandardSimplexBoundary 7) :=
+  {w | ∀ i ∈ s, w.1 i < (1 : ℝ) / 8}
+
+/-- The affine face on which every coordinate indexed by `s` vanishes. -/
+public def standardBoundarySevenAffineFace (s : Finset (Fin 8)) :
+    Set (StandardSimplexBoundary 7) :=
+  {w | ∀ i ∈ s, w.1 i = 0}
+
+/-- A proper subset of the eight coordinates contains at most seven coordinates. -/
+public theorem boundarySeven_finset_card_le_seven
+    {s : Finset (Fin 8)} (hs : s ≠ Finset.univ) : s.card ≤ 7 := by
+  have hss : s ⊂ Finset.univ := Finset.ssubset_univ_iff.mpr hs
+  have hc := Finset.card_lt_card hss
+  simp only [Finset.card_univ, Fintype.card_fin] at hc
+  omega
+
+/-- The complementary mass used in simultaneous normalization is positive. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersection_one_sub_sum_pos
+    {s : Finset (Fin 8)} (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    0 < 1 - ∑ i ∈ s, w.1.1 i := by
+  have hlt : (∑ i ∈ s, w.1.1 i) < ∑ _i ∈ s, (1 : ℝ) / 8 := by
+    apply Finset.sum_lt_sum
+    · intro i hi
+      exact (w.2 i hi).le
+    · obtain ⟨i, hi⟩ := hsne
+      exact ⟨i, hi, w.2 i hi⟩
+  have hc : s.card ≤ 7 := boundarySeven_finset_card_le_seven hs
+  have hconst : (∑ _i ∈ s, (1 : ℝ) / 8) ≤ (7 : ℝ) / 8 := by
+    simp only [Finset.sum_const, nsmul_eq_mul]
+    have hc' : (s.card : ℝ) ≤ 7 := by exact_mod_cast hc
+    calc
+      (s.card : ℝ) * ((1 : ℝ) / 8) ≤
+          7 * ((1 : ℝ) / 8) :=
+        mul_le_mul_of_nonneg_right hc' (by norm_num)
+      _ = (7 : ℝ) / 8 := by ring
+  linarith
+
+/-- Simultaneously set the coordinates in `s` to zero and renormalize the complement. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionProjection
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    StandardSimplexBoundary 7 := by
+  let d : ℝ := 1 - ∑ i ∈ s, w.1.1 i
+  have hd : 0 < d :=
+    standardBoundarySevenFaceNeighborhoodIntersection_one_sub_sum_pos hsne hs w
+  let z : Fin 8 → ℝ := fun k ↦ if k ∈ s then 0 else w.1.1 k / d
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    dsimp [z]
+    split_ifs
+    · exact le_rfl
+    · exact div_nonneg (w.1.1.2.1 k) hd.le
+  have hpartition :
+      (∑ k ∈ s, w.1.1 k) + (∑ k ∈ Finset.univ.filter (· ∉ s), w.1.1 k) = 1 := by
+    have hsplit := Finset.sum_filter_add_sum_filter_not Finset.univ
+      (fun k : Fin 8 ↦ k ∈ s) (fun k ↦ w.1.1 k)
+    rw [show Finset.univ.filter (fun k ↦ k ∈ s) = s by ext; simp] at hsplit
+    exact hsplit.trans w.1.1.2.2
+  have hother : (∑ k ∈ Finset.univ.filter (· ∉ s), w.1.1 k) = d := by
+    dsimp [d]
+    linarith
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    rw [Finset.sum_ite]
+    simp only [Finset.sum_const_zero, zero_add, ← Finset.sum_div]
+    rw [hother, div_self hd.ne']
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  refine ⟨zs, ?_⟩
+  obtain ⟨i, hi⟩ := hsne
+  refine ⟨i, ?_⟩
+  change z i = 0
+  simp [z, hi]
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s)
+    {i : Fin 8} (hi : i ∈ s) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 i = 0 := by
+  change (if i ∈ s then 0 else
+    w.1.1 i / (1 - ∑ j ∈ s, w.1.1 j)) = 0
+  rw [if_pos hi]
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_not_mem
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s)
+    {i : Fin 8} (hi : i ∉ s) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 i =
+      w.1.1 i / (1 - ∑ j ∈ s, w.1.1 j) := by
+  change (if i ∈ s then 0 else
+    w.1.1 i / (1 - ∑ j ∈ s, w.1.1 j)) = _
+  rw [if_neg hi]
+
+/-- The simultaneous projection lands in the common affine face. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_mem_face
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w ∈
+      standardBoundarySevenAffineFace s := by
+  intro i hi
+  exact standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+    s hsne hs w hi
+
+/-- The simultaneous projection also remains in the open intersection. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_mem
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w ∈
+      standardBoundarySevenFaceNeighborhoodIntersection s := by
+  intro i hi
+  rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+    s hsne hs w hi]
+  norm_num
+
+/-- The simultaneous normalization varies continuously. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodIntersectionProjection
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  by_cases hk : k ∈ s
+  · simp only [if_pos hk]
+    exact continuous_const
+  · simp only [if_neg hk]
+    have ck : Continuous (fun w : standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        w.1.1 k) :=
+      (((continuous_apply k).comp continuous_subtype_val).comp
+        continuous_subtype_val).comp continuous_subtype_val
+    have csum : Continuous (fun w : standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        ∑ i ∈ s, w.1.1 i) := by
+      apply continuous_finsetSum
+      intro i _hi
+      exact (((continuous_apply i).comp continuous_subtype_val).comp
+        continuous_subtype_val).comp continuous_subtype_val
+    exact ck.div (continuous_const.sub csum) fun w ↦
+      (standardBoundarySevenFaceNeighborhoodIntersection_one_sub_sum_pos
+        hsne hs w).ne'
+
+/-- Simultaneous normalization as a map to the common affine face. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionRetraction
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    C(standardBoundarySevenFaceNeighborhoodIntersection s,
+      standardBoundarySevenAffineFace s) :=
+  ⟨fun w ↦ ⟨standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w,
+      standardBoundarySevenFaceNeighborhoodIntersectionProjection_mem_face s hsne hs w⟩,
+    (continuous_standardBoundarySevenFaceNeighborhoodIntersectionProjection
+      s hsne hs).subtype_mk _⟩
+
+/-- Inclusion of the common affine face into the open intersection. -/
+public noncomputable def standardBoundarySevenAffineFaceInclusion
+    (s : Finset (Fin 8)) :
+    C(standardBoundarySevenAffineFace s,
+      standardBoundarySevenFaceNeighborhoodIntersection s) := by
+  refine ⟨fun w ↦ ⟨w.1, ?_⟩, continuous_subtype_val.subtype_mk _⟩
+  intro i hi
+  rw [w.2 i hi]
+  norm_num
+
+/-- Every zero coordinate remains zero under simultaneous normalization. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_eq_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) (k : Fin 8)
+    (hk : w.1.1 k = 0) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k = 0 := by
+  by_cases hks : k ∈ s
+  · exact standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+      s hsne hs w hks
+  · rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_not_mem
+      s hsne hs w hks, hk, zero_div]
+
+/-- The affine interpolation from a point to its simultaneous normalized projection. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (q : unitInterval × standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersection s := by
+  let t : ℝ := q.1
+  let w := q.2
+  let p := standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w
+  let z : Fin 8 → ℝ := fun k ↦ (1 - t) * w.1.1 k + t * p.1 k
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    exact add_nonneg
+      (mul_nonneg (sub_nonneg.mpr q.1.2.2) (w.1.1.2.1 k))
+      (mul_nonneg q.1.2.1 (p.1.2.1 k))
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    have hw_sum : (∑ k : Fin 8, w.1.1 k) = 1 := w.1.1.2.2
+    have hp_sum : (∑ k : Fin 8, p.1 k) = 1 := p.1.2.2
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      hw_sum, hp_sum]
+    ring
+  have hz_boundary : ∃ k, z k = 0 := by
+    obtain ⟨k, hk⟩ := w.1.2
+    refine ⟨k, ?_⟩
+    dsimp [z]
+    rw [hk, standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_eq_zero
+      s hsne hs w k hk]
+    ring
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  let zb : StandardSimplexBoundary 7 := ⟨zs, hz_boundary⟩
+  refine ⟨zb, ?_⟩
+  intro i hi
+  have hpi : p.1 i = 0 :=
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+      s hsne hs w hi
+  have hwi_nonneg : 0 ≤ w.1.1 i := w.1.1.2.1 i
+  have hwi_lt : w.1.1 i < (1 : ℝ) / 8 := w.2 i hi
+  have ht0 : 0 ≤ t := q.1.2.1
+  have ht1 : t ≤ 1 := q.1.2.2
+  change z i < (1 : ℝ) / 8
+  dsimp [z]
+  rw [hpi, mul_zero, add_zero]
+  nlinarith
+
+/-- The simultaneous affine deformation is continuous. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  change Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        (1 - (q.1 : ℝ)) * q.2.1.1 k +
+          (q.1 : ℝ) *
+            (standardBoundarySevenFaceNeighborhoodIntersectionProjection
+              s hsne hs q.2).1 k)
+  have ct : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦ (q.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have cw : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦ q.2.1.1 k) :=
+    ((((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp continuous_subtype_val).comp continuous_snd
+  have cp : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        (standardBoundarySevenFaceNeighborhoodIntersectionProjection
+          s hsne hs q.2).1 k) :=
+    (((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp
+        ((continuous_standardBoundarySevenFaceNeighborhoodIntersectionProjection
+          s hsne hs).comp continuous_snd)
+  exact (continuous_const.sub ct).mul cw |>.add (ct.mul cp)
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (0, w) = w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (0 : ℝ)) * w.1.1 k + 0 *
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k =
+    w.1.1 k
+  ring
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (1, w) =
+      standardBoundarySevenAffineFaceInclusion s
+        (standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs w) := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (1 : ℝ)) * w.1.1 k + 1 *
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k =
+        (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k
+  ring
+
+/-- The simultaneous affine deformation, from the identity to inclusion after retraction. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionHomotopy
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContinuousMap.Homotopy (ContinuousMap.id _)
+      ((standardBoundarySevenAffineFaceInclusion s).comp
+        (standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)) where
+  toFun := standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  continuous_toFun :=
+    continuous_standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  map_zero_left :=
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero s hsne hs
+  map_one_left :=
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one s hsne hs
+
+/-- Normalization is the identity on the common affine face. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_face
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs
+        (standardBoundarySevenAffineFaceInclusion s w) = w.1 := by
+  have hsum :
+      (∑ i ∈ s, (standardBoundarySevenAffineFaceInclusion s w).1.1 i) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    exact w.2 i hi
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  by_cases hk : k ∈ s
+  · rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+      s hsne hs _ hk, w.2 k hk]
+  · rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_not_mem
+      s hsne hs _ hk, hsum]
+    change w.1.1 k / (1 - 0) = w.1.1 k
+    ring
+
+/-- The normalization map is a strict retraction of the face inclusion. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs).comp
+        (standardBoundarySevenAffineFaceInclusion s) =
+      ContinuousMap.id _ := by
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  exact standardBoundarySevenFaceNeighborhoodIntersectionProjection_face s hsne hs w
+
+/-- The deformation fixes the affine face pointwise at every time. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_fixed
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (t : unitInterval) (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (t, standardBoundarySevenAffineFaceInclusion s w) =
+      standardBoundarySevenAffineFaceInclusion s w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  have hp := standardBoundarySevenFaceNeighborhoodIntersectionProjection_face
+    s hsne hs w
+  have hpk :
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs
+        (standardBoundarySevenAffineFaceInclusion s w)).1 k = w.1.1 k := by
+    rw [hp]
+  change (1 - (t : ℝ)) * w.1.1 k + (t : ℝ) *
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs
+        (standardBoundarySevenAffineFaceInclusion s w)).1 k = w.1.1 k
+  rw [hpk]
+  ring
+
+/-- A nonempty proper intersection is homotopy equivalent to its common affine face.  The
+forward map is the literal face inclusion and the inverse is simultaneous normalization. -/
+public noncomputable def standardBoundarySevenAffineFaceIntersectionHomotopyEquiv
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    standardBoundarySevenAffineFace s ≃ₕ
+      standardBoundarySevenFaceNeighborhoodIntersection s where
+  toFun := standardBoundarySevenAffineFaceInclusion s
+  invFun := standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs
+  left_inv := by
+    rw [standardBoundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion]
+  right_inv := ⟨(standardBoundarySevenFaceNeighborhoodIntersectionHomotopy
+    s hsne hs).symm⟩
+
+/-! ## Contractibility of the common affine face -/
+
+/-- A chosen coordinate outside a proper set of coordinates. -/
+public noncomputable def boundarySevenCoordinateOutside
+    (s : Finset (Fin 8)) (hs : s ≠ Finset.univ) : Fin 8 :=
+  Classical.choose (show ∃ i, i ∉ s by
+    by_contra h
+    apply hs
+    apply Finset.eq_univ_of_forall
+    intro i
+    by_contra hi
+    exact h ⟨i, hi⟩)
+
+@[simp]
+public theorem boundarySevenCoordinateOutside_not_mem
+    (s : Finset (Fin 8)) (hs : s ≠ Finset.univ) :
+    boundarySevenCoordinateOutside s hs ∉ s :=
+  Classical.choose_spec (show ∃ i, i ∉ s by
+    by_contra h
+    apply hs
+    apply Finset.eq_univ_of_forall
+    intro i
+    by_contra hi
+    exact h ⟨i, hi⟩)
+
+/-- The complementary vertex used as a contraction point for the common face. -/
+public noncomputable def standardBoundarySevenAffineFaceVertex
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    standardBoundarySevenAffineFace s := by
+  let j := boundarySevenCoordinateOutside s hs
+  let z : Fin 8 → ℝ := fun k ↦ if k = j then 1 else 0
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    dsimp [z]
+    split_ifs <;> norm_num
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    simp
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  have hj : j ∉ s := boundarySevenCoordinateOutside_not_mem s hs
+  have hz_face : ∀ i ∈ s, zs i = 0 := by
+    intro i hi
+    change (if i = j then 1 else 0) = 0
+    rw [if_neg]
+    intro hij
+    subst i
+    exact hj hi
+  have hz_boundary : ∃ i, zs i = 0 := by
+    obtain ⟨i, hi⟩ := hsne
+    exact ⟨i, hz_face i hi⟩
+  exact ⟨⟨zs, hz_boundary⟩, hz_face⟩
+
+/-- Linear contraction of the common affine face to a complementary vertex. -/
+public noncomputable def standardBoundarySevenAffineFaceContractionPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (q : unitInterval × standardBoundarySevenAffineFace s) :
+    standardBoundarySevenAffineFace s := by
+  let t : ℝ := q.1
+  let w := q.2
+  let v := standardBoundarySevenAffineFaceVertex s hsne hs
+  let z : Fin 8 → ℝ := fun k ↦ (1 - t) * w.1.1 k + t * v.1.1 k
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    exact add_nonneg
+      (mul_nonneg (sub_nonneg.mpr q.1.2.2) (w.1.1.2.1 k))
+      (mul_nonneg q.1.2.1 (v.1.1.2.1 k))
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    have hw_sum : (∑ k : Fin 8, w.1.1 k) = 1 := w.1.1.2.2
+    have hv_sum : (∑ k : Fin 8, v.1.1 k) = 1 := v.1.1.2.2
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      hw_sum, hv_sum]
+    ring
+  have hz_face : ∀ i ∈ s, z i = 0 := by
+    intro i hi
+    dsimp [z]
+    rw [w.2 i hi, v.2 i hi]
+    ring
+  have hz_boundary : ∃ i, z i = 0 := by
+    obtain ⟨i, hi⟩ := hsne
+    exact ⟨i, hz_face i hi⟩
+  exact ⟨⟨⟨z, ⟨hz_nonneg, hz_sum⟩⟩, hz_boundary⟩, hz_face⟩
+
+/-- The explicit contraction of the common face is continuous. -/
+public theorem continuous_standardBoundarySevenAffineFaceContractionPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous (standardBoundarySevenAffineFaceContractionPoint s hsne hs) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  change Continuous (fun q : unitInterval × standardBoundarySevenAffineFace s ↦
+    (1 - (q.1 : ℝ)) * q.2.1.1 k + (q.1 : ℝ) *
+      (standardBoundarySevenAffineFaceVertex s hsne hs).1.1 k)
+  have ct : Continuous (fun q : unitInterval × standardBoundarySevenAffineFace s ↦
+      (q.1 : ℝ)) := continuous_subtype_val.comp continuous_fst
+  have cw : Continuous (fun q : unitInterval × standardBoundarySevenAffineFace s ↦
+      q.2.1.1 k) :=
+    ((((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp continuous_subtype_val).comp continuous_snd
+  exact (continuous_const.sub ct).mul cw |>.add (ct.mul continuous_const)
+
+@[simp]
+public theorem standardBoundarySevenAffineFaceContractionPoint_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenAffineFaceContractionPoint s hsne hs (0, w) = w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (0 : ℝ)) * w.1.1 k + 0 *
+      (standardBoundarySevenAffineFaceVertex s hsne hs).1.1 k = w.1.1 k
+  ring
+
+@[simp]
+public theorem standardBoundarySevenAffineFaceContractionPoint_one
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenAffineFaceContractionPoint s hsne hs (1, w) =
+      standardBoundarySevenAffineFaceVertex s hsne hs := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (1 : ℝ)) * w.1.1 k + 1 *
+      (standardBoundarySevenAffineFaceVertex s hsne hs).1.1 k = _
+  ring
+
+/-- The common affine face is contractible. -/
+public theorem standardBoundarySevenAffineFace_contractibleSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContractibleSpace (standardBoundarySevenAffineFace s) := by
+  rw [contractible_iff_id_nullhomotopic]
+  refine ⟨standardBoundarySevenAffineFaceVertex s hsne hs, ⟨?_⟩⟩
+  exact
+    { toFun := standardBoundarySevenAffineFaceContractionPoint s hsne hs
+      continuous_toFun := continuous_standardBoundarySevenAffineFaceContractionPoint s hsne hs
+      map_zero_left := standardBoundarySevenAffineFaceContractionPoint_zero s hsne hs
+      map_one_left := standardBoundarySevenAffineFaceContractionPoint_one s hsne hs }
+
+/-- Every nonempty proper standard affine neighbourhood intersection is contractible. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersection_contractibleSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContractibleSpace (standardBoundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace (standardBoundarySevenAffineFace s) :=
+    standardBoundarySevenAffineFace_contractibleSpace s hsne hs
+  exact (standardBoundarySevenAffineFaceIntersectionHomotopyEquiv
+    s hsne hs).symm.contractibleSpace
+
+/-- Hence every nonempty proper standard intersection is path connected. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersection_pathConnectedSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    PathConnectedSpace (standardBoundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace
+      (standardBoundarySevenFaceNeighborhoodIntersection s) :=
+    standardBoundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hs
+  infer_instance
+
+/-! ## Transport to the geometric realization -/
+
+/-- The common affine face inside the geometric realization. -/
+public def boundarySevenAffineFaceIntersection (s : Finset (Fin 8)) :
+    Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
+  {x | ∀ i ∈ s, boundarySevenComparisonToStdSimplex x i = 0}
+
+/-- The canonical barycentric homeomorphism restricted to an intersection of face
+neighbourhoods. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard
+    (s : Finset (Fin 8)) :
+    boundarySevenFaceNeighborhoodIntersection s ≃ₜ
+      standardBoundarySevenFaceNeighborhoodIntersection s :=
+  boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
+    rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+    change (∀ i ∈ s, boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8) ↔
+      ∀ i ∈ s,
+        (boundarySevenRealizationHomeomorphStandardBoundary x :
+          stdSimplex ℝ (Fin 8)) i < (1 : ℝ) / 8
+    rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+
+/-- The canonical barycentric homeomorphism restricted to the common affine face. -/
+public noncomputable def boundarySevenAffineFaceIntersectionHomeomorphStandard
+    (s : Finset (Fin 8)) :
+    boundarySevenAffineFaceIntersection s ≃ₜ standardBoundarySevenAffineFace s :=
+  boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
+    change (∀ i ∈ s, boundarySevenComparisonToStdSimplex x i = 0) ↔
+      ∀ i ∈ s,
+        (boundarySevenRealizationHomeomorphStandardBoundary x :
+          stdSimplex ℝ (Fin 8)) i = 0
+    rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+
+/-- Every nonempty proper realized intersection is homotopy equivalent to its literal common
+affine face. -/
+public noncomputable def boundarySevenAffineFaceIntersectionHomotopyEquiv
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    boundarySevenAffineFaceIntersection s ≃ₕ
+      boundarySevenFaceNeighborhoodIntersection s :=
+  (boundarySevenAffineFaceIntersectionHomeomorphStandard s).toHomotopyEquiv |>.trans
+    (standardBoundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs) |>.trans
+      (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm.toHomotopyEquiv
+
+/-- The forward map of the transported equivalence is the literal inclusion of the common face
+in the neighbourhood intersection. -/
+public theorem boundarySevenAffineFaceIntersectionHomotopyEquiv_apply
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (x : boundarySevenAffineFaceIntersection s) :
+    (boundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs x).1 = x.1 := by
+  change (boundarySevenRealizationHomeomorphStandardBoundary).symm
+      (boundarySevenRealizationHomeomorphStandardBoundary x.1) = x.1
+  exact Homeomorph.symm_apply_apply _ _
+
+/-- Literal inclusion of the realized common affine face into the neighbourhood intersection. -/
+public noncomputable def boundarySevenAffineFaceIntersectionInclusion
+    (s : Finset (Fin 8)) :
+    C(boundarySevenAffineFaceIntersection s,
+      boundarySevenFaceNeighborhoodIntersection s) := by
+  refine ⟨fun x ↦ ⟨x.1, ?_⟩, continuous_subtype_val.subtype_mk _⟩
+  rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+  intro i hi
+  rw [x.2 i hi]
+  norm_num
+
+/-- The inverse of the realized face/intersection homotopy equivalence is the simultaneous
+normalization retraction. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionRetraction
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    C(boundarySevenFaceNeighborhoodIntersection s,
+      boundarySevenAffineFaceIntersection s) :=
+  (boundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs).invFun
+
+/-- The forward map used in the realized equivalence is exactly the literal inclusion. -/
+public theorem boundarySevenAffineFaceIntersectionHomotopyEquiv_toFun
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    (boundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs).toFun =
+      boundarySevenAffineFaceIntersectionInclusion s := by
+  apply ContinuousMap.ext
+  intro x
+  apply Subtype.ext
+  exact boundarySevenAffineFaceIntersectionHomotopyEquiv_apply s hsne hs x
+
+/-- The realized simultaneous normalization is a strict left inverse to face inclusion. -/
+public theorem boundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs).comp
+        (boundarySevenAffineFaceIntersectionInclusion s) =
+      ContinuousMap.id _ := by
+  apply ContinuousMap.ext
+  intro x
+  change (boundarySevenAffineFaceIntersectionHomeomorphStandard s).symm
+      ((standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)
+        ((boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s)
+          (boundarySevenAffineFaceIntersectionInclusion s x))) = x
+  apply (boundarySevenAffineFaceIntersectionHomeomorphStandard s).injective
+  rw [Homeomorph.apply_symm_apply]
+  exact ContinuousMap.congr_fun
+    (standardBoundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion
+      s hsne hs) ((boundarySevenAffineFaceIntersectionHomeomorphStandard s) x)
+
+/-- The affine homotopy transported explicitly to the geometric realization. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (q : unitInterval × boundarySevenFaceNeighborhoodIntersection s) :
+    boundarySevenFaceNeighborhoodIntersection s :=
+  (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+    (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+      (q.1, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s q.2))
+
+/-- The transported affine homotopy is continuous. -/
+public theorem continuous_boundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous (boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs) := by
+  exact (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm.continuous.comp
+    ((continuous_standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+      s hsne hs).comp
+        (continuous_fst.prodMk
+          ((boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).continuous.comp
+            continuous_snd)))
+
+@[simp]
+public theorem boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (x : boundarySevenFaceNeighborhoodIntersection s) :
+    boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (0, x) = x := by
+  change (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (0, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s x)) = x
+  rw [standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero,
+    Homeomorph.symm_apply_apply]
+
+@[simp]
+public theorem boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (x : boundarySevenFaceNeighborhoodIntersection s) :
+    boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (1, x) =
+      boundarySevenAffineFaceIntersectionInclusion s
+        (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs x) := by
+  change (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (1, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s x)) =
+    boundarySevenAffineFaceIntersectionInclusion s
+      (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs x)
+  apply (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).injective
+  rw [Homeomorph.apply_symm_apply]
+  rw [standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one]
+  apply Subtype.ext
+  have hr := Homeomorph.apply_symm_apply
+    (boundarySevenAffineFaceIntersectionHomeomorphStandard s)
+    ((standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)
+      (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s x))
+  exact (congrArg Subtype.val hr).symm
+
+/-- The transported homotopy from the identity to inclusion after normalization. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomotopy
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContinuousMap.Homotopy (ContinuousMap.id _)
+      ((boundarySevenAffineFaceIntersectionInclusion s).comp
+        (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)) where
+  toFun := boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  continuous_toFun :=
+    continuous_boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  map_zero_left := boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero s hsne hs
+  map_one_left := boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one s hsne hs
+
+/-- The transported deformation fixes the common affine face pointwise. -/
+public theorem boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_fixed
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (t : unitInterval) (x : boundarySevenAffineFaceIntersection s) :
+    boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (t, boundarySevenAffineFaceIntersectionInclusion s x) =
+      boundarySevenAffineFaceIntersectionInclusion s x := by
+  change (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (t, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s
+          (boundarySevenAffineFaceIntersectionInclusion s x))) =
+    boundarySevenAffineFaceIntersectionInclusion s x
+  apply (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).injective
+  rw [Homeomorph.apply_symm_apply]
+  change standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+      (t, standardBoundarySevenAffineFaceInclusion s
+        (boundarySevenAffineFaceIntersectionHomeomorphStandard s x)) =
+    standardBoundarySevenAffineFaceInclusion s
+      (boundarySevenAffineFaceIntersectionHomeomorphStandard s x)
+  exact standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_fixed
+    s hsne hs t _
+
+/-- The reverse affine homotopy is the deformation from inclusion after simultaneous
+normalization to the identity on the realized intersection. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionDeformation
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContinuousMap.Homotopy
+      ((boundarySevenAffineFaceIntersectionInclusion s).comp
+        (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs))
+      (ContinuousMap.id _) :=
+  (boundarySevenFaceNeighborhoodIntersectionHomotopy s hsne hs).symm
+
+/-- Every nonempty proper intersection of the actual face-neighbourhood cover is contractible. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_contractibleSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace
+      (standardBoundarySevenFaceNeighborhoodIntersection s) :=
+    standardBoundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hs
+  exact (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).contractibleSpace
+
+/-- Every nonempty proper intersection of the actual cover is path connected. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_pathConnectedSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    PathConnectedSpace (boundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) :=
+    boundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hs
+  infer_instance
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodLocalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodLocalComparison.lean
@@ -1,0 +1,80 @@
+module
+
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparison
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodDeformation
+
+/-!
+# The local simplicial--singular comparison on a boundary face
+
+The canonical adjunction unit on the standard six-simplex, followed by the singular-set map of
+the inclusion into its affine face neighbourhood, induces a quasi-isomorphism on integral
+chains.  The proof factors this exact canonical map into the standard-simplex comparison and the
+singular-chain map of the explicit face-neighbourhood homotopy equivalence.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical simplicial map from the standard six-simplex to singular simplices in its
+`i`-th affine face neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodLocalComparisonSSetMap
+    (i : Fin 8) :
+    (Δ[6] : SSet.{0}) ⟶
+      TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i)) :=
+  sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+    TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i)
+
+/-- The exact canonical integral chain map on one standard face and its affine neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodLocalIntegralComparison
+    (i : Fin 8) :
+    (Δ[6] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      IntegralSingularChainComplexObj
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood i)) :=
+  SSet.chainComplexMap (boundarySevenFaceNeighborhoodLocalComparisonSSetMap i)
+    (AddCommGrpCat.of ℤ)
+
+/-- Functoriality identifies the canonical local comparison with the standard-simplex
+simplicial--singular comparison followed by the singular chain map of face inclusion. -/
+public theorem boundarySevenFaceNeighborhoodLocalIntegralComparison_eq
+    (i : Fin 8) :
+    boundarySevenFaceNeighborhoodLocalIntegralComparison i =
+      simplicialToRealizationSingularChainMap
+          (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ) ≫
+        boundarySevenFaceNeighborhoodIntegralSingularChainMap i := by
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+        (sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+          TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i)) =
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (sSetTopAdj.unit.app (Δ[6] : SSet.{0})) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i))
+  exact Functor.map_comp _ _ _
+
+/-- The canonical local integral comparison is a quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodLocalIntegralComparison_quasiIso
+    (i : Fin 8) :
+    QuasiIso (boundarySevenFaceNeighborhoodLocalIntegralComparison i) := by
+  rw [boundarySevenFaceNeighborhoodLocalIntegralComparison_eq]
+  let hstandard : QuasiIso
+      (simplicialToRealizationSingularChainMap
+        (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ)) :=
+    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso 6
+  let hneighborhood : QuasiIso
+      (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) :=
+    boundarySevenFaceNeighborhoodIntegralSingularChainMap_quasiIso i
+  rw [quasiIso_iff]
+  intro k
+  exact quasiIsoAt_comp
+    (simplicialToRealizationSingularChainMap
+      (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) k
+    (hφ := hstandard.quasiIsoAt k)
+    (hφ' := hneighborhood.quasiIsoAt k)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereLowIntegralHomology.lean
+++ b/SphereSixComplex/Topology/SixSphereLowIntegralHomology.lean
@@ -1,0 +1,232 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodLocalComparison
+public import SphereSixComplex.Topology.BoundarySevenRealizationInjective
+public import SphereSixComplex.Topology.DiskSevenCoverRangeGeometryChains
+
+/-!
+# Low integral homology of the standard six-sphere: the exact remaining comparison
+
+The simplicial boundary of the seven-simplex has already been proved to have zero integral
+homology in degrees two and three, and its realization has already been identified with the
+standard six-sphere.  Consequently the desired singular-homology calculation needs only the
+degree-two and degree-three pieces of the canonical simplicial-to-singular comparison; a full
+quasi-isomorphism in every degree is unnecessary.
+
+This file records that sharp equivalence and connects it to the completed local relative
+Mayer--Vietoris calculation for the seven-disk.  It also isolates a degreewise Čech-total input
+which is strictly weaker than the earlier all-degree Čech comparison structure.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical integral comparison for the boundary of the seven-simplex. -/
+public noncomputable abbrev boundarySevenIntegralComparisonMap :=
+  simplicialToRealizationSingularChainMap
+    (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)
+
+/-- Only the two degrees actually needed in the six-sphere argument. -/
+public def BoundarySevenLowIntegralComparison : Prop :=
+  QuasiIsoAt boundarySevenIntegralComparisonMap 2 ∧
+    QuasiIsoAt boundarySevenIntegralComparisonMap 3
+
+/-- A full canonical comparison immediately supplies its two low-degree components. -/
+public theorem boundarySevenLowIntegralComparison_of_quasiIso
+    (h : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) :
+    BoundarySevenLowIntegralComparison := by
+  change QuasiIso boundarySevenIntegralComparisonMap at h
+  exact ⟨(quasiIso_iff boundarySevenIntegralComparisonMap).mp h 2,
+    (quasiIso_iff boundarySevenIntegralComparisonMap).mp h 3⟩
+
+/-- The low comparison is exactly equivalent to low singular-homology vanishing on the
+realization.  The reverse implication uses the already computed vanishing of simplicial
+homology, so any map between the two zero homology objects is an isomorphism. -/
+public theorem boundarySevenLowIntegralComparison_iff_realization_low_isZero :
+    BoundarySevenLowIntegralComparison ↔
+      IsZero (((TopCat.toSSet.obj (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).chainComplex
+        (AddCommGrpCat.of ℤ)).homology 2) ∧
+      IsZero (((TopCat.toSSet.obj (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).chainComplex
+        (AddCommGrpCat.of ℤ)).homology 3) := by
+  constructor
+  · rintro ⟨h₂, h₃⟩
+    let _ : QuasiIsoAt boundarySevenIntegralComparisonMap 2 := h₂
+    let _ : QuasiIsoAt boundarySevenIntegralComparisonMap 3 := h₃
+    exact
+      ⟨(boundarySeven_simplicialHomology_two_isZero (AddCommGrpCat.of ℤ)).of_iso
+          (isoOfQuasiIsoAt boundarySevenIntegralComparisonMap 2).symm,
+        (boundarySeven_simplicialHomology_three_isZero (AddCommGrpCat.of ℤ)).of_iso
+          (isoOfQuasiIsoAt boundarySevenIntegralComparisonMap 3).symm⟩
+  · rintro ⟨h₂, h₃⟩
+    constructor
+    · rw [quasiIsoAt_iff_isIso_homologyMap]
+      exact (boundarySeven_simplicialHomology_two_isZero
+        (AddCommGrpCat.of ℤ)).isIso h₂ _
+    · rw [quasiIsoAt_iff_isIso_homologyMap]
+      exact (boundarySeven_simplicialHomology_three_isZero
+        (AddCommGrpCat.of ℤ)).isIso h₃ _
+
+/-- The completed realization homeomorphism, followed by the project's identification of its
+metric sphere with `TopCat.sphere 6`. -/
+public noncomputable def boundarySevenRealizationHomeomorphTopCatSphereSix :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ
+      (TopCat.sphere.{0} 6 : Type) :=
+  Classical.choice boundarySevenRealizationHomeomorphSixSphere |>.trans
+    sixSphereHomeomorphTopCatSphereSix
+
+/-- Degreewise integral singular homology is transported by the preceding homeomorphism. -/
+public noncomputable def boundarySevenRealizationHomologyIsoTopCatSphereSix (k : ℕ) :
+    ((IntegralSingularChainComplexObj
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).homology k) ≅
+      ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology k) :=
+  ((singularHomologyFunctor AddCommGrpCat k).obj
+    (AddCommGrpCat.of ℤ)).mapIso
+      (TopCat.isoOfHomeo boundarySevenRealizationHomeomorphTopCatSphereSix)
+
+/-- Thus the two desired standard-sphere vanishings are equivalent to the two degreewise
+components of the canonical boundary comparison. -/
+public theorem boundarySevenLowIntegralComparison_iff_standardSphereSix_low_isZero :
+    BoundarySevenLowIntegralComparison ↔
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3) := by
+  rw [boundarySevenLowIntegralComparison_iff_realization_low_isZero]
+  constructor
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨h₂.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 2).symm,
+        h₃.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 3).symm⟩
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨h₂.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 2),
+        h₃.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 3)⟩
+
+/-- The disk-cover local acyclicity obligation is neither stronger nor weaker than the missing
+low-degree boundary comparison: they are exactly equivalent. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_iff_boundarySevenLowIntegralComparison :
+    DiskSevenCoverLocalRelativeLowAcyclic ↔ BoundarySevenLowIntegralComparison := by
+  rw [diskSevenCoverLocalRelativeLowAcyclic_iff_sphereSix_low_isZero,
+    boundarySevenLowIntegralComparison_iff_standardSphereSix_low_isZero]
+
+/-- A direct endpoint producing both standard-sphere homology vanishings from the minimal
+degreewise comparison input. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_boundaryLowComparison
+    (h : BoundarySevenLowIntegralComparison) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3) :=
+  boundarySevenLowIntegralComparison_iff_standardSphereSix_low_isZero.mp h
+
+/-- The same minimal comparison input discharges all four fields of the local relative
+Mayer--Vietoris acyclicity package. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_of_boundaryLowComparison
+    (h : BoundarySevenLowIntegralComparison) :
+    DiskSevenCoverLocalRelativeLowAcyclic :=
+  diskSevenCoverLocalRelativeLowAcyclic_iff_boundarySevenLowIntegralComparison.mpr h
+
+/-! ## A degreewise Čech-total endpoint -/
+
+/-- The remaining global Čech construction can be restricted to degrees two and three.  Unlike
+`BoundarySevenFaceNeighborhoodCechTotalComparison`, this structure asks for no quasi-isomorphism
+outside those two degrees. -/
+public structure BoundarySevenFaceNeighborhoodCechLowComparison where
+  boundaryToCech :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenFaceNeighborhoodCechTotal
+  augmentation :
+    boundarySevenFaceNeighborhoodCechTotal ⟶
+      CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood
+  fac : boundaryToCech ≫ augmentation =
+    simplicialToCoverSmallSingularChainMap
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  boundaryToCech_quasiIsoAt_two : QuasiIsoAt boundaryToCech 2
+  boundaryToCech_quasiIsoAt_three : QuasiIsoAt boundaryToCech 3
+  augmentation_quasiIsoAt_two : QuasiIsoAt augmentation 2
+  augmentation_quasiIsoAt_three : QuasiIsoAt augmentation 3
+
+/-- A full Čech-total comparison restricts to the low-degree one. -/
+public noncomputable def BoundarySevenFaceNeighborhoodCechTotalComparison.toLow
+    (h : BoundarySevenFaceNeighborhoodCechTotalComparison) :
+    BoundarySevenFaceNeighborhoodCechLowComparison where
+  boundaryToCech := h.boundaryToCech
+  augmentation := h.augmentation
+  fac := h.fac
+  boundaryToCech_quasiIsoAt_two := h.boundaryToCech_quasiIso.quasiIsoAt 2
+  boundaryToCech_quasiIsoAt_three := h.boundaryToCech_quasiIso.quasiIsoAt 3
+  augmentation_quasiIsoAt_two := h.augmentation_quasiIso.quasiIsoAt 2
+  augmentation_quasiIsoAt_three := h.augmentation_quasiIso.quasiIsoAt 3
+
+/-- A low Čech-total comparison gives the two degreewise quasi-isomorphisms for the cover-small
+lift. -/
+public theorem boundarySevenFaceNeighborhoodLift_lowComparison_of_cechLow
+    (h : BoundarySevenFaceNeighborhoodCechLowComparison) :
+    QuasiIsoAt
+        (simplicialToCoverSmallSingularChainMap
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods) 2 ∧
+      QuasiIsoAt
+        (simplicialToCoverSmallSingularChainMap
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods) 3 := by
+  constructor
+  · rw [← h.fac]
+    exact quasiIsoAt_comp h.boundaryToCech h.augmentation 2
+      (hφ := h.boundaryToCech_quasiIsoAt_two)
+      (hφ' := h.augmentation_quasiIsoAt_two)
+  · rw [← h.fac]
+    exact quasiIsoAt_comp h.boundaryToCech h.augmentation 3
+      (hφ := h.boundaryToCech_quasiIsoAt_three)
+      (hφ' := h.augmentation_quasiIsoAt_three)
+
+/-- Since inclusion of cover-small chains is already a quasi-isomorphism by affine
+subdivision, the low Čech-total package suffices for the desired low canonical comparison. -/
+public theorem boundarySevenLowIntegralComparison_of_cechLow
+    (h : BoundarySevenFaceNeighborhoodCechLowComparison) :
+    BoundarySevenLowIntegralComparison := by
+  have hlift := boundarySevenFaceNeighborhoodLift_lowComparison_of_cechLow h
+  have hinclusion : QuasiIso
+      (coverSmallIntegralSingularChainInclusion
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood) :=
+    coverSmallChainQuasiIsomorphism_of_openCover
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonFaceNeighborhood_isOpen
+      boundarySevenComparisonFaceNeighborhood_iUnion_unconditional
+  constructor
+  · change QuasiIsoAt
+      (simplicialToRealizationSingularChainMap
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 2
+    rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods]
+    exact quasiIsoAt_comp _ _ 2
+      (hφ := hlift.1) (hφ' := hinclusion.quasiIsoAt 2)
+  · change QuasiIsoAt
+      (simplicialToRealizationSingularChainMap
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 3
+    rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods]
+    exact quasiIsoAt_comp _ _ 3
+      (hφ := hlift.2) (hφ' := hinclusion.quasiIsoAt 3)
+
+/-- Consequently a degreewise Čech-total comparison proves the local relative acyclicity and
+the two low standard-sphere homology vanishings simultaneously. -/
+public theorem sixSphere_lowHomology_and_diskLocalAcyclic_of_cechLow
+    (h : BoundarySevenFaceNeighborhoodCechLowComparison) :
+    (IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3)) ∧
+      DiskSevenCoverLocalRelativeLowAcyclic := by
+  have hc := boundarySevenLowIntegralComparison_of_cechLow h
+  exact ⟨standardSphereSix_integralSingularHomology_low_isZero_of_boundaryLowComparison hc,
+    diskSevenCoverLocalRelativeLowAcyclic_of_boundaryLowComparison hc⟩
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- construct and deform the boundary-seven face neighborhoods
- identify their ordered intersections with common simplicial faces
- prove local simplicial-to-singular quasi-isomorphisms
- package the low integral homology consequence for the six-sphere

## Dependency

This is the third continuation PR, stacked on #60.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersectionHomology SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodLocalComparison SphereSixComplex.Topology.SixSphereLowIntegralHomology
- Build completed successfully: 3190 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders in the 6 added files