### PR TITLE
Globalize boundary Cech comparison rowwise

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenCechGlobalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechGlobalComparison.lean
@@ -1,0 +1,475 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantSingleColumnTotal
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersections
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodLocalComparison
+public import SphereSixComplex.Topology.SixSphereLowIntegralHomology
+
+/-!
+# Global Cech comparison for the boundary of the seven-simplex
+
+This file assembles the two canonical augmented Cech nerves which occur in the comparison
+between the simplicial boundary and the singular complex small for the eight affine face
+neighbourhoods.  In particular, it constructs the actual totalized Cech augmentation (rather
+than leaving it as structure data), the map between the two Cech bicomplexes, and proves the
+strict compatibility of all three canonical augmentations.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+universe u v
+
+set_option linter.style.haveILetI false in
+/-- A finite coproduct of quasi-isomorphisms of chain complexes is a quasi-isomorphism. -/
+public theorem quasiIso_finite_coproduct
+    {I : Type} [Finite I]
+    (K L : I → FirstQuadrantChainComplex)
+    (f : ∀ i, K i ⟶ L i) (hf : ∀ i, QuasiIso (f i)) :
+    QuasiIso (CategoryTheory.Limits.Sigma.map f) := by
+  rw [quasiIso_iff]
+  intro n
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  let H := HomologicalComplex.homologyFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) n
+  let σK := sigmaComparison H K
+  let σL := sigmaComparison H L
+  haveI hfi (i : I) : IsIso (H.map (f i)) := by
+    exact (quasiIsoAt_iff_isIso_homologyMap (f i) n).mp
+      ((hf i).quasiIsoAt n)
+  haveI : IsIso (CategoryTheory.Limits.Sigma.map fun i ↦ H.map (f i)) := inferInstance
+  haveI : IsIso σK := by dsimp [σK]; infer_instance
+  haveI : IsIso σL := by dsimp [σL]; infer_instance
+  have hnat : σK ≫ H.map (CategoryTheory.Limits.Sigma.map f) =
+      CategoryTheory.Limits.Sigma.map (fun i ↦ H.map (f i)) ≫ σL := by
+    apply Sigma.hom_ext
+    intro i
+    simp only [← Category.assoc, σK, σL,
+      CategoryTheory.Limits.ι_comp_sigmaComparison,
+      ← H.map_comp, CategoryTheory.Limits.Sigma.ι_map]
+    rw [Category.assoc,
+      CategoryTheory.Limits.ι_comp_sigmaComparison, ← H.map_comp]
+  haveI : IsIso (σK ≫ H.map (CategoryTheory.Limits.Sigma.map f)) := by
+    rw [hnat]
+    infer_instance
+  exact @IsIso.of_isIso_comp_left _ _ _ _ _ σK
+    (H.map (CategoryTheory.Limits.Sigma.map f)) inferInstance inferInstance
+
+set_option linter.style.haveILetI false in
+/-- A functor to chain complexes which preserves a finite coproduct carries a coproduct of
+maps sent to quasi-isomorphisms to a quasi-isomorphism. -/
+public theorem quasiIso_map_finite_coproduct
+    {C : Type u} [Category.{v} C] {I : Type} [Finite I]
+    (F : C ⥤ FirstQuadrantChainComplex.{0})
+    [HasColimitsOfShape (Discrete I) C]
+    [PreservesColimitsOfShape (Discrete I) F]
+    (K L : I → C) (f : ∀ i, K i ⟶ L i)
+    (hf : ∀ i, QuasiIso (F.map (f i))) :
+    QuasiIso (F.map (CategoryTheory.Limits.Sigma.map f)) := by
+  let σK := sigmaComparison F K
+  let σL := sigmaComparison F L
+  let sf := CategoryTheory.Limits.Sigma.map (fun i ↦ F.map (f i))
+  haveI : IsIso σK := by dsimp [σK]; infer_instance
+  haveI : IsIso σL := by dsimp [σL]; infer_instance
+  haveI : QuasiIso sf := quasiIso_finite_coproduct
+    (fun i ↦ F.obj (K i)) (fun i ↦ F.obj (L i))
+    (fun i ↦ F.map (f i)) hf
+  have hnat : σK ≫ F.map (CategoryTheory.Limits.Sigma.map f) = sf ≫ σL := by
+    apply Sigma.hom_ext
+    intro i
+    simp only [← Category.assoc, σK, σL, sf,
+      CategoryTheory.Limits.ι_comp_sigmaComparison,
+      ← F.map_comp, CategoryTheory.Limits.Sigma.ι_map]
+    rw [Category.assoc,
+      CategoryTheory.Limits.ι_comp_sigmaComparison, ← F.map_comp]
+  haveI : QuasiIso σK := inferInstance
+  haveI : QuasiIso σL := inferInstance
+  haveI : QuasiIso (σK ≫ F.map (CategoryTheory.Limits.Sigma.map f)) := by
+    rw [hnat]
+    infer_instance
+  exact quasiIso_of_comp_left σK
+    (F.map (CategoryTheory.Limits.Sigma.map f))
+
+/-- The simplicial face presentation, regarded as an arrow. -/
+public noncomputable def boundarySevenSimplicialFacePresentationArrow : Arrow SSet :=
+  Arrow.mk boundarySevenSimplicialFacePresentation
+
+/-- The simplicial face presentation evaluated in one inner simplicial degree. -/
+public noncomputable def boundarySevenSimplicialFacePresentationEvaluationArrow
+    (n : SimplexCategoryᵒᵖ) : Arrow (Type 0) :=
+  Arrow.mk (boundarySevenSimplicialFacePresentation.app n)
+
+/-- A chosen splitting of the evaluated simplicial face presentation. -/
+public noncomputable def boundarySevenSimplicialFacePresentationEvaluationSplitEpi
+    (n : SimplexCategoryᵒᵖ) :
+    SplitEpi (boundarySevenSimplicialFacePresentationEvaluationArrow n).hom := by
+  let h := boundarySevenSimplicialFacePresentation_app_surjective n
+  exact
+    { section_ := ↾ fun z ↦ Function.surjInv h z
+      id := by
+        ext z
+        exact Function.rightInverse_surjInv h z }
+
+/-- The evaluated simplicial face-presentation Cech nerve has an extra degeneracy. -/
+public noncomputable def boundarySevenSimplicialFaceEvaluationExtraDegeneracy
+    (n : SimplexCategoryᵒᵖ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenSimplicialFacePresentationEvaluationArrow n).augmentedCechNerve :=
+  Arrow.AugmentedCechNerve.extraDegeneracy
+    (boundarySevenSimplicialFacePresentationEvaluationArrow n)
+    (boundarySevenSimplicialFacePresentationEvaluationSplitEpi n)
+
+/-- Integral coefficients on the evaluated augmented Cech nerve of the simplicial face
+presentation. -/
+public noncomputable abbrev boundarySevenSimplicialFaceIntegralEvaluationCech
+    (k : ℕ) : SimplicialObject.Augmented AddCommGrpCat :=
+  ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (boundarySevenSimplicialFacePresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk k))).augmentedCechNerve
+
+/-- The integral evaluated face-presentation Cech nerve retains its extra degeneracy. -/
+public noncomputable def boundarySevenSimplicialFaceIntegralEvaluationExtraDegeneracy
+    (k : ℕ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenSimplicialFaceIntegralEvaluationCech k) :=
+  (boundarySevenSimplicialFaceEvaluationExtraDegeneracy
+    (Opposite.op (SimplexCategory.mk k))).map
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))
+
+/-- Each horizontal row of the augmented face-presentation Cech complex contracts onto the
+corresponding chain group of the simplicial boundary. -/
+public noncomputable def boundarySevenSimplicialFaceIntegralCechRowHomotopyEquiv
+    (k : ℕ) :
+    HomotopyEquiv
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenSimplicialFaceIntegralEvaluationCech k)))
+      ((ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenSimplicialFaceIntegralEvaluationCech k))) :=
+  (boundarySevenSimplicialFaceIntegralEvaluationExtraDegeneracy k).homotopyEquiv
+
+/-- Thus every horizontal row augmentation of the simplicial face resolution is a
+quasi-isomorphism. -/
+public theorem boundarySevenSimplicialFaceIntegralCechRowAugmentation_quasiIso
+    (k : ℕ) :
+    QuasiIso (AlternatingFaceMapComplex.ε.app
+      (boundarySevenSimplicialFaceIntegralEvaluationCech k)) :=
+  (boundarySevenSimplicialFaceIntegralCechRowHomotopyEquiv k).quasiIso_hom
+
+/-- The map of the two degree-zero Cech presentation objects is literally the finite coproduct
+of the eight canonical local face comparisons. -/
+public theorem boundarySevenFacePresentationSourceMap_eq_sigmaMap :
+    boundarySevenFacePresentationSourceMap =
+      CategoryTheory.Limits.Sigma.map
+        (fun i : Fin 8 ↦ boundarySevenFaceNeighborhoodLocalComparisonSSetMap i) := by
+  apply Sigma.hom_ext
+  intro i
+  rw [boundarySevenFacePresentationSourceMap_iota,
+    CategoryTheory.Limits.Sigma.ι_map]
+  rfl
+
+set_option linter.style.haveILetI false in
+/-- Consequently the canonical map on the degree-zero Cech presentation objects induces a
+quasi-isomorphism on integral chains.  This is the first graded piece of the vertical-column
+filtration of the Cech total map. -/
+public theorem boundarySevenFacePresentationSourceIntegralChainMap_quasiIso :
+    QuasiIso (SSet.chainComplexMap boundarySevenFacePresentationSourceMap
+      (AddCommGrpCat.of ℤ)) := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  let K : Fin 8 → SSet.{0} := fun _ ↦ (Δ[6] : SSet.{0})
+  let L : Fin 8 → SSet.{0} := fun i ↦
+    TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i))
+  let f : ∀ i, K i ⟶ L i :=
+    fun i ↦ boundarySevenFaceNeighborhoodLocalComparisonSSetMap i
+  letI : PreservesColimitsOfShape (Discrete (Fin 8)) F := by
+    apply HomologicalComplex.preservesColimitsOfShape_of_eval
+    intro n
+    change PreservesColimitsOfShape (Discrete (Fin 8))
+      ((evaluation SimplexCategoryᵒᵖ Type).obj
+        (Opposite.op (SimplexCategory.mk n)) ⋙
+          sigmaConst.obj (AddCommGrpCat.of ℤ))
+    infer_instance
+  have hf : ∀ i, QuasiIso (F.map (f i)) := by
+    intro i
+    exact boundarySevenFaceNeighborhoodLocalIntegralComparison_quasiIso i
+  have h := quasiIso_map_finite_coproduct F K L f hf
+  rw [boundarySevenFacePresentationSourceMap_eq_sigmaMap]
+  exact h
+
+/-- The augmented Cech nerve of the simplicial face presentation. -/
+public noncomputable def boundarySevenSimplicialFaceAugmentedCechNerve :
+    SimplicialObject.Augmented SSet :=
+  boundarySevenSimplicialFacePresentationArrow.augmentedCechNerve
+
+/-- Integral chains in the inner simplicial direction of the face-presentation Cech nerve. -/
+public noncomputable def boundarySevenSimplicialFaceAugmentedCechChains :
+    SimplicialObject.Augmented (ChainComplex AddCommGrpCat ℕ) :=
+  ((SimplicialObject.Augmented.whiskering SSet
+    (ChainComplex AddCommGrpCat ℕ)).obj
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ))).obj
+        boundarySevenSimplicialFaceAugmentedCechNerve
+
+/-- The Cech--simplicial bicomplex of the eight standard faces. -/
+public noncomputable def boundarySevenSimplicialFaceCechBicomplex :
+    FirstQuadrantBicomplex :=
+  AlternatingFaceMapComplex.obj
+    (SimplicialObject.Augmented.drop.obj
+      boundarySevenSimplicialFaceAugmentedCechChains)
+
+/-- The direct-sum total of the Cech--simplicial bicomplex. -/
+public noncomputable def boundarySevenSimplicialFaceCechTotal :
+    FirstQuadrantChainComplex :=
+  boundarySevenSimplicialFaceCechBicomplex.total (ComplexShape.down ℕ)
+
+/-- The outer augmentation of the Cech--simplicial bicomplex. -/
+public noncomputable def boundarySevenSimplicialFaceCechOuterAugmentation :
+    boundarySevenSimplicialFaceCechBicomplex ⟶
+      firstQuadrantSingleZeroBicomplex
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)) :=
+  AlternatingFaceMapComplex.ε.app boundarySevenSimplicialFaceAugmentedCechChains
+
+/-- The map of augmented Cech nerves induced by the facewise local comparison square. -/
+public noncomputable def boundarySevenFaceAugmentedCechNerveMap :
+    boundarySevenSimplicialFaceAugmentedCechNerve ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechNerve :=
+  Arrow.mapAugmentedCechNerve boundarySevenFacePresentationArrowMap
+
+/-- Apply integral chains to the map of augmented Cech nerves. -/
+public noncomputable def boundarySevenFaceAugmentedCechChainMap :
+    boundarySevenSimplicialFaceAugmentedCechChains ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechChains :=
+  ((SimplicialObject.Augmented.whiskering SSet
+    (ChainComplex AddCommGrpCat ℕ)).obj
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ))).map
+        boundarySevenFaceAugmentedCechNerveMap
+
+/-- The induced morphism of the two first-quadrant Cech bicomplexes. -/
+public noncomputable def boundarySevenFaceCechBicomplexMap :
+    boundarySevenSimplicialFaceCechBicomplex ⟶
+      boundarySevenFaceNeighborhoodCechBicomplex :=
+  AlternatingFaceMapComplex.map
+    (SimplicialObject.Augmented.drop.map boundarySevenFaceAugmentedCechChainMap)
+
+/-- The induced map of direct-sum total complexes. -/
+public noncomputable def boundarySevenFaceCechTotalMap :
+    boundarySevenSimplicialFaceCechTotal ⟶
+      boundarySevenFaceNeighborhoodCechTotal :=
+  HomologicalComplex₂.total.map boundarySevenFaceCechBicomplexMap
+    (ComplexShape.down ℕ)
+
+/-- Totalize the Cech--simplicial augmentation and identify the total of its unique target
+column with the ordinary simplicial chain complex. -/
+public noncomputable def boundarySevenSimplicialFaceCechTotalAugmentation :
+    boundarySevenSimplicialFaceCechTotal ⟶
+      (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) :=
+  HomologicalComplex₂.total.map boundarySevenSimplicialFaceCechOuterAugmentation
+      (ComplexShape.down ℕ) ≫
+    firstQuadrantTotalToSingleZero
+      ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))
+
+/-- The canonical totalized augmentation from the face-neighbourhood Cech total to cover-small
+integral singular chains. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechTotalAugmentation :
+    boundarySevenFaceNeighborhoodCechTotal ⟶
+      CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood :=
+  HomologicalComplex₂.total.map boundarySevenFaceNeighborhoodCechOuterAugmentation
+      (ComplexShape.down ℕ) ≫
+    firstQuadrantTotalToSingleZero
+      (CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood)
+
+/-- The evaluated horizontal row of the outer neighbourhood-Cech augmentation, in the precise
+coefficient presentation furnished by the evaluated augmented Cech nerve. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechOuterAugmentationRow (k : ℕ) :
+    AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)) ⟶
+      (ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)) :=
+  AlternatingFaceMapComplex.ε.app
+    (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)
+
+/-- The previously constructed extra degeneracy proves that every actual horizontal row of the
+outer augmentation is a quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodCechOuterAugmentationRow_quasiIso (k : ℕ) :
+    QuasiIso (boundarySevenFaceNeighborhoodCechOuterAugmentationRow k) := by
+  exact boundarySevenFaceNeighborhoodIntegralCechRowAugmentation_quasiIso k
+
+/-- Naturality of the alternating-complex augmentation, before totalization. -/
+public theorem boundarySevenFaceCechBicomplexMap_comp_outerAugmentation :
+    boundarySevenFaceCechBicomplexMap ≫
+        boundarySevenFaceNeighborhoodCechOuterAugmentation =
+      boundarySevenSimplicialFaceCechOuterAugmentation ≫
+        (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map
+          (SSet.chainComplexMap
+            (simplicialToCoverSmallSingularSet
+              (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+              boundarySevenComparisonUnitLandsInFaceNeighborhoods)
+            (AddCommGrpCat.of ℤ)) := by
+  exact AlternatingFaceMapComplex.ε.naturality
+    boundarySevenFaceAugmentedCechChainMap
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The inclusion into the total of a zero-column bicomplex is natural in the column. -/
+public theorem firstQuadrantSingleZeroToTotal_naturality
+    {K L : FirstQuadrantChainComplex} (f : K ⟶ L) :
+    f ≫ firstQuadrantSingleZeroToTotal L =
+      firstQuadrantSingleZeroToTotal K ≫
+        HomologicalComplex₂.total.map
+          ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map f)
+          (ComplexShape.down ℕ) := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  simp only [HomologicalComplex.comp_f]
+  dsimp only [firstQuadrantSingleZeroToTotal,
+    firstQuadrantZeroColumnToTotal]
+  simp only [HomologicalComplex.comp_f]
+  simp only [show firstQuadrantSingleZeroColumnIso K = Iso.refl K by
+      exact ChainComplex.single₀ObjXSelf K,
+    show firstQuadrantSingleZeroColumnIso L = Iso.refl L by
+      exact ChainComplex.single₀ObjXSelf L,
+    Iso.refl_inv, HomologicalComplex.id_f, Category.id_comp]
+  rw [HomologicalComplex₂.ιTotal_map]
+  simp
+
+set_option linter.style.haveILetI false in
+/-- The projection from the total of a zero-column bicomplex is natural in the column. -/
+public theorem firstQuadrantTotalToSingleZero_naturality
+    {K L : FirstQuadrantChainComplex} (f : K ⟶ L) :
+    HomologicalComplex₂.total.map
+          ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map f)
+          (ComplexShape.down ℕ) ≫
+        firstQuadrantTotalToSingleZero L =
+      firstQuadrantTotalToSingleZero K ≫ f := by
+  letI : IsIso (firstQuadrantSingleZeroToTotal K) :=
+    (firstQuadrantSingleZeroTotalIso K).isIso_inv
+  apply (cancel_epi (firstQuadrantSingleZeroToTotal K)).1
+  rw [← Category.assoc, ← firstQuadrantSingleZeroToTotal_naturality]
+  rw [Category.assoc, firstQuadrantSingleZeroToTotal_comp_projection]
+  rw [Category.comp_id, ← Category.assoc,
+    firstQuadrantSingleZeroToTotal_comp_projection, Category.id_comp]
+
+/-- The total Cech map commutes strictly with the canonical totalized augmentations. -/
+public theorem boundarySevenFaceCechTotalMap_comp_augmentation :
+    boundarySevenFaceCechTotalMap ≫
+        boundarySevenFaceNeighborhoodCechTotalAugmentation =
+      boundarySevenSimplicialFaceCechTotalAugmentation ≫
+        simplicialToCoverSmallSingularChainMap
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods := by
+  let φ := simplicialToCoverSmallSingularChainMap
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  let S := boundarySevenSimplicialFaceCechOuterAugmentation
+  let T := boundarySevenFaceNeighborhoodCechOuterAugmentation
+  let F := boundarySevenFaceCechBicomplexMap
+  change HomologicalComplex₂.total.map F (ComplexShape.down ℕ) ≫
+      (HomologicalComplex₂.total.map T (ComplexShape.down ℕ) ≫
+        firstQuadrantTotalToSingleZero _) =
+    (HomologicalComplex₂.total.map S (ComplexShape.down ℕ) ≫
+      firstQuadrantTotalToSingleZero _) ≫ φ
+  calc
+    _ = (HomologicalComplex₂.total.map F (ComplexShape.down ℕ) ≫
+          HomologicalComplex₂.total.map T (ComplexShape.down ℕ)) ≫
+          firstQuadrantTotalToSingleZero _ :=
+      (Category.assoc _ _ _).symm
+    _ = HomologicalComplex₂.total.map (F ≫ T) (ComplexShape.down ℕ) ≫
+          firstQuadrantTotalToSingleZero _ := by
+      rw [HomologicalComplex₂.total.map_comp]
+    _ = HomologicalComplex₂.total.map
+          (S ≫ (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map φ)
+          (ComplexShape.down ℕ) ≫ firstQuadrantTotalToSingleZero _ := by
+      rw [show F ≫ T =
+          S ≫ (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map φ by
+        exact boundarySevenFaceCechBicomplexMap_comp_outerAugmentation]
+    _ = (HomologicalComplex₂.total.map S (ComplexShape.down ℕ) ≫
+          HomologicalComplex₂.total.map
+            ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map φ)
+            (ComplexShape.down ℕ)) ≫ firstQuadrantTotalToSingleZero _ := by
+      rw [HomologicalComplex₂.total.map_comp]
+    _ = HomologicalComplex₂.total.map S (ComplexShape.down ℕ) ≫
+          (firstQuadrantTotalToSingleZero _ ≫ φ) := by
+      rw [Category.assoc, firstQuadrantTotalToSingleZero_naturality]
+    _ = _ := by rw [Category.assoc]
+
+/-! ## Exact low-degree assembly endpoint -/
+
+/-- The remaining input for the low-degree global comparison, after the canonical Cech maps
+and their strict augmentation square have been constructed above.  The lift is the output of
+totalizing a contraction of the simplicial face-presentation resolution; the other four fields
+are precisely the degree-two and degree-three conclusions of the rowwise-to-total argument. -/
+public structure BoundarySevenCechLowAssemblyInput where
+  sourceLift :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenSimplicialFaceCechTotal
+  sourceLift_fac :
+    sourceLift ≫ boundarySevenSimplicialFaceCechTotalAugmentation = 𝟙 _
+  sourceLift_quasiIsoAt_two : QuasiIsoAt sourceLift 2
+  sourceLift_quasiIsoAt_three : QuasiIsoAt sourceLift 3
+  cechMap_quasiIsoAt_two : QuasiIsoAt boundarySevenFaceCechTotalMap 2
+  cechMap_quasiIsoAt_three : QuasiIsoAt boundarySevenFaceCechTotalMap 3
+  augmentation_quasiIsoAt_two :
+    QuasiIsoAt boundarySevenFaceNeighborhoodCechTotalAugmentation 2
+  augmentation_quasiIsoAt_three :
+    QuasiIsoAt boundarySevenFaceNeighborhoodCechTotalAugmentation 3
+
+/-- The canonical map from boundary chains to the neighbourhood Cech total obtained from a
+contracting lift of the simplicial face resolution. -/
+public noncomputable def boundarySevenBoundaryToFaceNeighborhoodCechTotal
+    (h : BoundarySevenCechLowAssemblyInput) :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenFaceNeighborhoodCechTotal :=
+  h.sourceLift ≫ boundarySevenFaceCechTotalMap
+
+/-- The constructed boundary-to-Cech map has exactly the required canonical composite. -/
+public theorem boundarySevenBoundaryToFaceNeighborhoodCechTotal_fac
+    (h : BoundarySevenCechLowAssemblyInput) :
+    boundarySevenBoundaryToFaceNeighborhoodCechTotal h ≫
+        boundarySevenFaceNeighborhoodCechTotalAugmentation =
+      simplicialToCoverSmallSingularChainMap
+        (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+        boundarySevenComparisonUnitLandsInFaceNeighborhoods := by
+  unfold boundarySevenBoundaryToFaceNeighborhoodCechTotal
+  rw [Category.assoc, boundarySevenFaceCechTotalMap_comp_augmentation]
+  rw [← Category.assoc, h.sourceLift_fac, Category.id_comp]
+
+/-- The exact low-degree Cech package consumed by the six-sphere homology reduction. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechLowComparison_of_assembly
+    (h : BoundarySevenCechLowAssemblyInput) :
+    BoundarySevenFaceNeighborhoodCechLowComparison where
+  boundaryToCech := boundarySevenBoundaryToFaceNeighborhoodCechTotal h
+  augmentation := boundarySevenFaceNeighborhoodCechTotalAugmentation
+  fac := boundarySevenBoundaryToFaceNeighborhoodCechTotal_fac h
+  boundaryToCech_quasiIsoAt_two :=
+    quasiIsoAt_comp h.sourceLift boundarySevenFaceCechTotalMap 2
+      (hφ := h.sourceLift_quasiIsoAt_two)
+      (hφ' := h.cechMap_quasiIsoAt_two)
+  boundaryToCech_quasiIsoAt_three :=
+    quasiIsoAt_comp h.sourceLift boundarySevenFaceCechTotalMap 3
+      (hφ := h.sourceLift_quasiIsoAt_three)
+      (hφ' := h.cechMap_quasiIsoAt_three)
+  augmentation_quasiIsoAt_two := h.augmentation_quasiIsoAt_two
+  augmentation_quasiIsoAt_three := h.augmentation_quasiIsoAt_three
+
+/-- Consequently the remaining low-degree Cech assembly input is sufficient for both desired
+six-sphere homology vanishings and the disk-cover local acyclicity package. -/
+public theorem sixSphere_lowHomology_and_diskLocalAcyclic_of_cechAssembly
+    (h : BoundarySevenCechLowAssemblyInput) :
+    (IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3)) ∧
+      DiskSevenCoverLocalRelativeLowAcyclic :=
+  sixSphere_lowHomology_and_diskLocalAcyclic_of_cechLow
+    (boundarySevenFaceNeighborhoodCechLowComparison_of_assembly h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechLowAssemblyProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechLowAssemblyProof.lean
@@ -1,0 +1,209 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechGlobalComparison
+
+/-!
+# Low-degree assembly for the boundary-seven Cech comparison
+
+This file isolates the three genuinely global steps left in the Cech comparison: rowwise
+globalization (including the pointwise-limit coherence), a strict chain-level section of the
+simplicial-face Cech augmentation, and the low-degree comparison of the two Cech totals.
+
+The definitions below are deliberately expressed using the actual bicomplexes and maps from
+`BoundarySevenCechGlobalComparison`, rather than replacing either step by an informal
+"spectral sequence" hypothesis.  We also prove that the two quasi-isomorphism fields for the
+strict section in `BoundarySevenCechLowAssemblyInput` are redundant: they follow formally
+from the section equation and the corresponding assertion for the augmentation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The horizontal chain complex obtained from a first-quadrant bicomplex by evaluating its
+vertical chain-complex entries in degree `q`. -/
+public noncomputable def firstQuadrantHorizontalRow
+    (K : FirstQuadrantBicomplex) (q : ℕ) : FirstQuadrantChainComplex :=
+  ((HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q).mapHomologicalComplex
+    (ComplexShape.down ℕ)).obj K
+
+/-- Evaluation of a bicomplex map on a horizontal row. -/
+public noncomputable def firstQuadrantHorizontalRowMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (q : ℕ) :
+    firstQuadrantHorizontalRow K q ⟶ firstQuadrantHorizontalRow L q :=
+  ((HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q).mapHomologicalComplex
+    (ComplexShape.down ℕ)).map f
+
+/-- The exact generic homological-algebra statement needed to totalize the existing row
+contractions.  It is kept as a proposition, not an axiom or typeclass, so downstream results
+must display this missing proof as an explicit argument.
+
+For first-quadrant direct-sum totals this follows from the finite brutal-column filtration:
+each total degree sees only finitely many columns. -/
+public def FirstQuadrantRowwiseTotalization : Prop :=
+  ∀ {K L : FirstQuadrantBicomplex} (f : K ⟶ L),
+    (∀ q : ℕ, QuasiIso (firstQuadrantHorizontalRowMap f q)) →
+      QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ))
+
+/-- A strict right inverse to the simplicial-face total augmentation.  This is the exact
+chain-level datum which cannot be recovered merely by choosing inverses on homology. -/
+public structure BoundarySevenCechStrictSourceSplit where
+  sourceLift :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenSimplicialFaceCechTotal
+  sourceLift_fac :
+    sourceLift ≫ boundarySevenSimplicialFaceCechTotalAugmentation = 𝟙 _
+
+/-- The remaining comparison for the map between the two Cech totals.  Its proof is the
+finite-coproduct decomposition of the ordered intersections, followed by the local comparison
+theorems and rowwise totalization. -/
+public structure BoundarySevenFaceCechTotalLowComparison where
+  quasiIsoAt_two : QuasiIsoAt boundarySevenFaceCechTotalMap 2
+  quasiIsoAt_three : QuasiIsoAt boundarySevenFaceCechTotalMap 3
+
+/-- The coherence isomorphisms identifying evaluation of the two constructed Cech
+bicomplexes with the separately constructed evaluated Cech nerves.  These isomorphisms are
+canonical pointwise-limit comparisons, but they are not definitional equalities: the Cech
+nerve contains wide pullbacks in a functor category. -/
+public structure BoundarySevenCechAugmentationRowIdentifications where
+  sourceRowArrowIso (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenSimplicialFaceCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q))
+  targetRowArrowIso (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenFaceNeighborhoodCechOuterAugmentation q) ≅
+      Arrow.mk (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q)
+
+/-- The single homological-algebra/coherence package needed to globalize the already-proved
+row contractions.  Its first field is the brutal-prefix theorem, and its second field records
+the pointwise wide-pullback comparisons needed to apply that theorem to the actual Cech
+bicomplexes. -/
+public structure BoundarySevenCechRowwiseGlobalization where
+  totalization : FirstQuadrantRowwiseTotalization
+  rowIdentifications : BoundarySevenCechAugmentationRowIdentifications
+
+/-- A section of a quasi-isomorphism in one degree is automatically a quasi-isomorphism in
+that degree. -/
+public theorem quasiIsoAt_of_strict_section
+    {K L : FirstQuadrantChainComplex} (s : K ⟶ L) (p : L ⟶ K)
+    (fac : s ≫ p = 𝟙 K) (n : ℕ) [QuasiIsoAt p n] : QuasiIsoAt s n := by
+  haveI : QuasiIsoAt (s ≫ p) n := by
+    rw [fac]
+    infer_instance
+  exact quasiIsoAt_of_comp_right s p n
+
+/-- Rowwise totalization turns the already-proved source row augmentations into a global
+quasi-isomorphism of total complexes. -/
+public theorem boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+    (hrow : FirstQuadrantRowwiseTotalization)
+    (hident : BoundarySevenCechAugmentationRowIdentifications) :
+    QuasiIso boundarySevenSimplicialFaceCechTotalAugmentation := by
+  let T := HomologicalComplex₂.total.map
+    boundarySevenSimplicialFaceCechOuterAugmentation (ComplexShape.down ℕ)
+  have hT : QuasiIso T := by
+    apply hrow boundarySevenSimplicialFaceCechOuterAugmentation
+    intro q
+    letI : QuasiIso (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q)) :=
+      boundarySevenSimplicialFaceIntegralCechRowAugmentation_quasiIso q
+    exact quasiIso_of_arrow_mk_iso
+      (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q))
+      (firstQuadrantHorizontalRowMap
+        boundarySevenSimplicialFaceCechOuterAugmentation q)
+      (hident.sourceRowArrowIso q).symm
+  have hP : QuasiIso (firstQuadrantTotalToSingleZero
+      ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))) := by
+    letI : IsIso (firstQuadrantTotalToSingleZero
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))) :=
+      (firstQuadrantSingleZeroTotalIso
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))).isIso_hom
+    infer_instance
+  exact quasiIso_comp T _
+
+/-- Rowwise totalization likewise promotes the existing neighbourhood-row contractions to
+the actual totalized neighbourhood Cech augmentation. -/
+public theorem boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+    (hrow : FirstQuadrantRowwiseTotalization)
+    (hident : BoundarySevenCechAugmentationRowIdentifications) :
+    QuasiIso boundarySevenFaceNeighborhoodCechTotalAugmentation := by
+  let T := HomologicalComplex₂.total.map
+    boundarySevenFaceNeighborhoodCechOuterAugmentation (ComplexShape.down ℕ)
+  have hT : QuasiIso T := by
+    apply hrow boundarySevenFaceNeighborhoodCechOuterAugmentation
+    intro q
+    letI : QuasiIso (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q) :=
+      boundarySevenFaceNeighborhoodCechOuterAugmentationRow_quasiIso q
+    exact quasiIso_of_arrow_mk_iso
+      (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q)
+      (firstQuadrantHorizontalRowMap
+        boundarySevenFaceNeighborhoodCechOuterAugmentation q)
+      (hident.targetRowArrowIso q).symm
+  have hP : QuasiIso (firstQuadrantTotalToSingleZero
+      (CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood)) := by
+    letI : IsIso (firstQuadrantTotalToSingleZero
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)) :=
+      (firstQuadrantSingleZeroTotalIso
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)).isIso_hom
+    infer_instance
+  exact quasiIso_comp T _
+
+/-- Once the generic first-quadrant theorem, the strict source split, and the geometric
+comparison of the two Cech totals are supplied, all eight fields of the original low-assembly
+package are canonical.  In particular, no separate proof about the source lift on homology is
+needed. -/
+public noncomputable def boundarySevenCechLowAssemblyInput_of_global_steps
+    (hglobal : BoundarySevenCechRowwiseGlobalization)
+    (hsplit : BoundarySevenCechStrictSourceSplit)
+    (hcech : BoundarySevenFaceCechTotalLowComparison) :
+    BoundarySevenCechLowAssemblyInput where
+  sourceLift := hsplit.sourceLift
+  sourceLift_fac := hsplit.sourceLift_fac
+  sourceLift_quasiIsoAt_two := by
+    letI : QuasiIso boundarySevenSimplicialFaceCechTotalAugmentation :=
+      boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    exact quasiIsoAt_of_strict_section hsplit.sourceLift
+      boundarySevenSimplicialFaceCechTotalAugmentation hsplit.sourceLift_fac 2
+  sourceLift_quasiIsoAt_three := by
+    letI : QuasiIso boundarySevenSimplicialFaceCechTotalAugmentation :=
+      boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    exact quasiIsoAt_of_strict_section hsplit.sourceLift
+      boundarySevenSimplicialFaceCechTotalAugmentation hsplit.sourceLift_fac 3
+  cechMap_quasiIsoAt_two := hcech.quasiIsoAt_two
+  cechMap_quasiIsoAt_three := hcech.quasiIsoAt_three
+  augmentation_quasiIsoAt_two := by
+    letI : QuasiIso boundarySevenFaceNeighborhoodCechTotalAugmentation :=
+      boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    infer_instance
+  augmentation_quasiIsoAt_three := by
+    letI : QuasiIso boundarySevenFaceNeighborhoodCechTotalAugmentation :=
+      boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    infer_instance
+
+/-- Exact final residual for the current Cech route.  It records, without disguising any
+obligation, that rowwise globalization, the strict face-resolution split, and
+the ordered-intersection comparison together construct the requested assembly input. -/
+public theorem boundarySevenCechLowAssemblyInput_of_exact_residual
+    (hglobal : BoundarySevenCechRowwiseGlobalization)
+    (hsplit : BoundarySevenCechStrictSourceSplit)
+    (hcech : BoundarySevenFaceCechTotalLowComparison) :
+    Nonempty BoundarySevenCechLowAssemblyInput :=
+  ⟨boundarySevenCechLowAssemblyInput_of_global_steps hglobal hsplit hcech⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechRowIdentificationsProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechRowIdentificationsProof.lean
@@ -1,0 +1,681 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechLowAssemblyProof
+
+/-!
+# Row identifications for the boundary-seven Cech bicomplexes
+
+This file identifies evaluation of the two actual Cech bicomplex augmentations with the
+separately constructed evaluated augmented-Cech rows.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+noncomputable def cechPresentationEvaluationArrow
+    (A : Arrow SSet) (q : ℕ) : Arrow (Type 0) :=
+  Arrow.mk (A.hom.app (Opposite.op (SimplexCategory.mk q)))
+
+noncomputable def cechPresentationWideCospanEvaluationIso
+    (A : Arrow SSet) (p q : ℕ) :
+    WidePullbackShape.wideCospan A.right
+        (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom) ⋙
+          (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)) ≅
+      WidePullbackShape.wideCospan
+        ((cechPresentationEvaluationArrow A q).right)
+        (fun _ : Fin (p + 1) ↦ (cechPresentationEvaluationArrow A q).left)
+        (fun _ ↦ (cechPresentationEvaluationArrow A q).hom) :=
+  NatIso.ofComponents
+    (fun x ↦ by cases x <;> exact Iso.refl _)
+    (by
+      intro X Y f
+      cases f <;> rfl)
+
+noncomputable def cechPresentationEvaluationIso
+    (A : Arrow SSet) (p q : ℕ) :
+    (A.augmentedCechNerve.left.obj
+        (Opposite.op (SimplexCategory.mk p))).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (cechPresentationEvaluationArrow A q).augmentedCechNerve.left.obj
+        (Opposite.op (SimplexCategory.mk p)) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  change E.obj (widePullback A.right (fun _ : Fin (p + 1) ↦ A.left)
+      (fun _ ↦ A.hom)) ≅
+    widePullback (E.obj A.right) (fun _ : Fin (p + 1) ↦ E.obj A.left)
+      (fun _ ↦ E.map A.hom)
+  exact preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+    (cechPresentationWideCospanEvaluationIso A p q)
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+theorem cechPresentationEvaluationIso_hom_π
+    (A : Arrow SSet) (p q : ℕ) (i : Fin (p + 1)) :
+    (cechPresentationEvaluationIso A p q).hom ≫
+        WidePullback.π
+          (fun _ : Fin (p + 1) ↦
+            (cechPresentationEvaluationArrow A q).hom) i =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π (fun _ : Fin (p + 1) ↦ A.hom) i) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app (some i) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let B := cechPresentationEvaluationArrow A q
+  let D' := WidePullbackShape.wideCospan B.right
+    (fun _ : Fin (p + 1) ↦ B.left) (fun _ ↦ B.hom)
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (cechPresentationWideCospanEvaluationIso A p q)).hom) ≫
+      limit.π D' (some i) = E.map (limit.π D (some i)) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app (some i)
+  dsimp only [D']
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (cechPresentationWideCospanEvaluationIso A p q) (some i)]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+theorem cechPresentationEvaluationIso_hom_base
+    (A : Arrow SSet) (p q : ℕ) :
+    (cechPresentationEvaluationIso A p q).hom ≫
+        WidePullback.base
+          (fun _ : Fin (p + 1) ↦ (cechPresentationEvaluationArrow A q).hom) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (p + 1) ↦ A.hom)) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app none := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let B := cechPresentationEvaluationArrow A q
+  let D' := WidePullbackShape.wideCospan B.right
+    (fun _ : Fin (p + 1) ↦ B.left) (fun _ ↦ B.hom)
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (cechPresentationWideCospanEvaluationIso A p q)).hom) ≫
+      limit.π D' none = E.map (limit.π D none) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app none
+  dsimp only [D']
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (cechPresentationWideCospanEvaluationIso A p q) none]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cechPresentationEvaluation_map_π_comp_diagramIso
+    (A : Arrow SSet) (p q : ℕ) (i : Fin (p + 1)) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π (fun _ : Fin (p + 1) ↦ A.hom) i) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app (some i) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π (fun _ : Fin (p + 1) ↦ A.hom) i) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cechPresentationEvaluation_map_base_comp_diagramIso
+    (A : Arrow SSet) (p q : ℕ) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (p + 1) ↦ A.hom)) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app none =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (p + 1) ↦ A.hom)) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cechPresentationEvaluationIso_naturality
+    (A : Arrow SSet) (q : ℕ) {a b : SimplexCategoryᵒᵖ} (f : a ⟶ b) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (A.augmentedCechNerve.left.map f) ≫
+        (cechPresentationEvaluationIso A b.unop.len q).hom =
+      (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+        (cechPresentationEvaluationArrow A q).augmentedCechNerve.left.map f := by
+  let B := cechPresentationEvaluationArrow A q
+  let D := WidePullbackShape.wideCospan B.right
+    (fun _ : Fin (b.unop.len + 1) ↦ B.left) (fun _ ↦ B.hom)
+  apply limit.hom_ext (F := D)
+  intro j
+  cases j with
+  | some i =>
+    rw [Category.assoc, cechPresentationEvaluationIso_hom_π]
+    rw [cechPresentationEvaluation_map_π_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (A.cechNerve.map f ≫
+            WidePullback.π (fun _ : Fin (b.unop.len + 1) ↦ A.hom) i) =
+      (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+        ((cechPresentationEvaluationArrow A q).cechNerve.map f ≫
+          WidePullback.π
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (cechPresentationEvaluationArrow A q).hom) i)
+    simp only [Arrow.cechNerve_map, WidePullback.lift_π]
+    rw [cechPresentationEvaluationIso_hom_π,
+      cechPresentationEvaluation_map_π_comp_diagramIso]
+  | none =>
+    rw [Category.assoc, cechPresentationEvaluationIso_hom_base]
+    rw [cechPresentationEvaluation_map_base_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (A.cechNerve.map f ≫
+            WidePullback.base (fun _ : Fin (b.unop.len + 1) ↦ A.hom)) =
+      (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+        ((cechPresentationEvaluationArrow A q).cechNerve.map f ≫
+          WidePullback.base
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (cechPresentationEvaluationArrow A q).hom))
+    simp only [Arrow.cechNerve_map, WidePullback.lift_base]
+    rw [cechPresentationEvaluationIso_hom_base,
+      cechPresentationEvaluation_map_base_comp_diagramIso]
+
+noncomputable def cechPresentationSimplicialEvaluationIso
+    (A : Arrow SSet) (q : ℕ) :
+    A.augmentedCechNerve.left ⋙
+        (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (cechPresentationEvaluationArrow A q).augmentedCechNerve.left :=
+  NatIso.ofComponents
+    (fun a ↦ cechPresentationEvaluationIso A a.unop.len q)
+    (by
+      intro a b f
+      exact cechPresentationEvaluationIso_naturality A q f)
+
+noncomputable def cechPresentationAugmentedEvaluationIso
+    (A : Arrow SSet) (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj A.augmentedCechNerve ≅
+      (cechPresentationEvaluationArrow A q).augmentedCechNerve :=
+  Comma.isoMk
+    (cechPresentationSimplicialEvaluationIso A q)
+    (Iso.refl _)
+    (by
+      apply NatTrans.ext
+      funext a
+      simp only [NatTrans.comp_app, Functor.id_map]
+      dsimp only [cechPresentationSimplicialEvaluationIso,
+        SimplicialObject.Augmented.whiskering,
+        SimplicialObject.Augmented.whiskeringObj]
+      change (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+          WidePullback.base
+            (fun _ : Fin (a.unop.len + 1) ↦
+              (cechPresentationEvaluationArrow A q).hom) =
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (a.unop.len + 1) ↦ A.hom))
+      rw [cechPresentationEvaluationIso_hom_base,
+        cechPresentationEvaluation_map_base_comp_diagramIso])
+
+noncomputable def boundarySevenFaceNeighborhoodWideCospanEvaluationIso
+    (p q : ℕ) :
+    WidePullbackShape.wideCospan
+        boundarySevenFaceNeighborhoodPresentationArrow.right
+        (fun _ : Fin (p + 1) ↦ boundarySevenFaceNeighborhoodPresentationArrow.left)
+        (fun _ ↦ boundarySevenFaceNeighborhoodPresentationArrow.hom) ⋙
+          (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)) ≅
+      WidePullbackShape.wideCospan
+        (boundarySevenFaceNeighborhoodPresentationArrow.right.obj
+          (Opposite.op (SimplexCategory.mk q)))
+        (fun _ : Fin (p + 1) ↦
+          boundarySevenFaceNeighborhoodPresentationArrow.left.obj
+            (Opposite.op (SimplexCategory.mk q)))
+        (fun _ ↦ boundarySevenFaceNeighborhoodPresentationArrow.hom.app
+          (Opposite.op (SimplexCategory.mk q))) :=
+  NatIso.ofComponents
+    (fun x ↦ by cases x <;> exact Iso.refl _)
+    (by
+      intro X Y f
+      cases f <;> rfl)
+
+@[simp]
+private theorem boundarySevenFaceNeighborhoodWideCospanEvaluationIso_hom_app
+    (p q : ℕ) (x : WidePullbackShape (Fin (p + 1))) :
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app x =
+      eqToHom (by cases x <;> rfl) := by
+  cases x <;> rfl
+
+@[simp]
+private theorem boundarySevenFaceNeighborhoodWideCospanEvaluationIso_hom_app_some
+    (p q : ℕ) (i : Fin (p + 1)) :
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app (some i) =
+      𝟙 _ := by
+  rfl
+
+@[simp]
+private theorem boundarySevenFaceNeighborhoodWideCospanEvaluationIso_hom_app_none
+    (p q : ℕ) :
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none = 𝟙 _ := by
+  rfl
+
+noncomputable def boundarySevenFaceNeighborhoodCechEvaluationIso
+    (p q : ℕ) :
+    (boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj
+        (Opposite.op (SimplexCategory.mk p))).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve.left.obj
+          (Opposite.op (SimplexCategory.mk p)) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let A := boundarySevenFaceNeighborhoodPresentationArrow
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  change E.obj (widePullback A.right (fun _ : Fin (p + 1) ↦ A.left)
+      (fun _ ↦ A.hom)) ≅
+    widePullback (E.obj A.right) (fun _ : Fin (p + 1) ↦ E.obj A.left)
+      (fun _ ↦ E.map A.hom)
+  exact preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q)
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+private theorem boundarySevenFaceNeighborhoodCechEvaluationIso_hom_π
+    (p q : ℕ) (i : Fin (p + 1)) :
+    (boundarySevenFaceNeighborhoodCechEvaluationIso p q).hom ≫
+        WidePullback.π
+          (fun _ : Fin (p + 1) ↦
+            (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+              (Opposite.op (SimplexCategory.mk q))).hom) i =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom) i) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app
+          (some i) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let A := boundarySevenFaceNeighborhoodPresentationArrow
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let D' := WidePullbackShape.wideCospan
+    (A.right.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ : Fin (p + 1) ↦
+      A.left.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ ↦ A.hom.app (Opposite.op (SimplexCategory.mk q)))
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q)).hom) ≫
+      limit.π D' (some i) = E.map (limit.π D (some i)) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app
+          (some i)
+  dsimp only [D', E, A]
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q) (some i)]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+private theorem boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base
+    (p q : ℕ) :
+    (boundarySevenFaceNeighborhoodCechEvaluationIso p q).hom ≫
+        WidePullback.base
+          (fun _ : Fin (p + 1) ↦
+            (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+              (Opposite.op (SimplexCategory.mk q))).hom) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom)) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let A := boundarySevenFaceNeighborhoodPresentationArrow
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let D' := WidePullbackShape.wideCospan
+    (A.right.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ : Fin (p + 1) ↦
+      A.left.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ ↦ A.hom.app (Opposite.op (SimplexCategory.mk q)))
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q)).hom) ≫
+      limit.π D' none = E.map (limit.π D none) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none
+  dsimp only [D', E, A]
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q) none]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+private theorem boundarySevenFaceNeighborhoodEvaluation_map_π_comp_diagramIso
+    (p q : ℕ) (i : Fin (p + 1)) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom) i) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app
+          (some i) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom) i) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+private theorem boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso
+    (p q : ℕ) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom)) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom)) := by
+  rfl
+
+private noncomputable def boundarySevenFaceNeighborhoodCechRowXIso
+    (q p : ℕ) :
+    (firstQuadrantHorizontalRow
+        boundarySevenFaceNeighborhoodCechBicomplex q).X p ≅
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech q))).X p :=
+  (sigmaConst.obj (AddCommGrpCat.of ℤ)).mapIso
+    (boundarySevenFaceNeighborhoodCechEvaluationIso p q)
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem boundarySevenFaceNeighborhoodCechEvaluationIso_naturality
+    (q : ℕ) {a b : SimplexCategoryᵒᵖ} (f : a ⟶ b) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (boundarySevenFaceNeighborhoodAugmentedCechNerve.left.map f) ≫
+        (boundarySevenFaceNeighborhoodCechEvaluationIso b.unop.len q).hom =
+      (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+        (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+          (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve.left.map f := by
+  let A := boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (b.unop.len + 1) ↦ A.left) (fun _ ↦ A.hom)
+  apply limit.hom_ext (F := D)
+  intro j
+  cases j with
+  | some i =>
+    rw [Category.assoc,
+      boundarySevenFaceNeighborhoodCechEvaluationIso_hom_π]
+    rw [boundarySevenFaceNeighborhoodEvaluation_map_π_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (boundarySevenFaceNeighborhoodPresentationArrow.cechNerve.map f ≫
+            WidePullback.π
+              (fun _ : Fin (b.unop.len + 1) ↦
+                boundarySevenFaceNeighborhoodPresentationArrow.hom) i) =
+      (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+        ((boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+            (Opposite.op (SimplexCategory.mk q))).cechNerve.map f ≫
+          WidePullback.π
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+                (Opposite.op (SimplexCategory.mk q))).hom) i)
+    simp only [Arrow.cechNerve_map, WidePullback.lift_π]
+    rw [boundarySevenFaceNeighborhoodCechEvaluationIso_hom_π,
+      boundarySevenFaceNeighborhoodEvaluation_map_π_comp_diagramIso]
+  | none =>
+    rw [Category.assoc,
+      boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base]
+    rw [boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (boundarySevenFaceNeighborhoodPresentationArrow.cechNerve.map f ≫
+            WidePullback.base
+              (fun _ : Fin (b.unop.len + 1) ↦
+                boundarySevenFaceNeighborhoodPresentationArrow.hom)) =
+      (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+        ((boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+            (Opposite.op (SimplexCategory.mk q))).cechNerve.map f ≫
+          WidePullback.base
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+                (Opposite.op (SimplexCategory.mk q))).hom))
+    simp only [Arrow.cechNerve_map, WidePullback.lift_base]
+    rw [boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base,
+      boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso]
+
+noncomputable def boundarySevenFaceNeighborhoodCechSimplicialEvaluationIso
+    (q : ℕ) :
+    boundarySevenFaceNeighborhoodAugmentedCechNerve.left ⋙
+        (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve.left :=
+  NatIso.ofComponents
+    (fun a ↦ boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q)
+    (by
+      intro a b f
+      exact boundarySevenFaceNeighborhoodCechEvaluationIso_naturality q f)
+
+noncomputable def boundarySevenFaceNeighborhoodCechAugmentedEvaluationIso
+    (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj
+          boundarySevenFaceNeighborhoodAugmentedCechNerve ≅
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve :=
+  Comma.isoMk
+    (boundarySevenFaceNeighborhoodCechSimplicialEvaluationIso q)
+    (Iso.refl _)
+    (by
+      apply NatTrans.ext
+      funext a
+      simp only [NatTrans.comp_app, Functor.id_map]
+      dsimp only [boundarySevenFaceNeighborhoodCechSimplicialEvaluationIso,
+        SimplicialObject.Augmented.whiskering,
+        SimplicialObject.Augmented.whiskeringObj]
+      change (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+          WidePullback.base
+            (fun _ : Fin (a.unop.len + 1) ↦
+              (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+                (Opposite.op (SimplexCategory.mk q))).hom) =
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (a.unop.len + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom))
+      rw [boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base,
+        boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso])
+
+noncomputable def boundarySevenFaceNeighborhoodIntegralCechAugmentedRowIso
+    (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+        (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+          ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)))).obj
+              boundarySevenFaceNeighborhoodAugmentedCechNerve) ≅
+      boundarySevenFaceNeighborhoodIntegralEvaluationCech q :=
+  Functor.mapIso _ (boundarySevenFaceNeighborhoodCechAugmentedEvaluationIso q)
+
+set_option backward.isDefEq.respectTransparency false in
+noncomputable def boundarySevenFaceNeighborhoodCechRowArrowIso
+    (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+        boundarySevenFaceNeighborhoodCechOuterAugmentation q) ≅
+      Arrow.mk (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q) := by
+  let e := boundarySevenFaceNeighborhoodIntegralCechAugmentedRowIso q
+  let X := ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj
+            boundarySevenFaceNeighborhoodAugmentedCechNerve)
+  let F := HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q
+  let Y := SimplicialObject.Augmented.drop.obj
+    boundarySevenFaceNeighborhoodAugmentedCechChains
+  let l₀ : firstQuadrantHorizontalRow
+      boundarySevenFaceNeighborhoodCechBicomplex q ≅
+      AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj X) :=
+    eqToIso (Functor.congr_obj (map_alternatingFaceMapComplex F) Y)
+  let r₀ : firstQuadrantHorizontalRow
+      ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).obj
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)) q ≅
+      (ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj X) :=
+    (HomologicalComplex.singleMapHomologicalComplex F
+      (ComplexShape.down ℕ) 0).app
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)
+  let e₀ : Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenFaceNeighborhoodCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app X) :=
+    Arrow.isoMk' _ _ l₀ r₀ (by
+      ext n x
+      rcases n with _ | n
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenFaceNeighborhoodCechOuterAugmentation,
+          boundarySevenFaceNeighborhoodCechBicomplex,
+          boundarySevenFaceNeighborhoodAugmentedCechChains,
+          SSet.chainComplexFunctor,
+          AlternatingFaceMapComplex.ε_app_f_zero]
+        change (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenFaceNeighborhoodAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x =
+          (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenFaceNeighborhoodAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x
+        rfl
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenFaceNeighborhoodCechOuterAugmentation,
+          AlternatingFaceMapComplex.ε_app_f_succ])
+  let e₁ := Arrow.isoMk'
+    (AlternatingFaceMapComplex.ε.app X)
+    (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q)
+    ((alternatingFaceMapComplex AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.drop.mapIso e))
+    ((ChainComplex.single₀ AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.point.mapIso e))
+    (by
+      exact AlternatingFaceMapComplex.ε.naturality e.hom)
+  exact e₀ ≪≫ e₁
+
+noncomputable def boundarySevenSimplicialFaceIntegralCechAugmentedRowIso
+    (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+        (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+          ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)))).obj
+              boundarySevenSimplicialFaceAugmentedCechNerve) ≅
+      boundarySevenSimplicialFaceIntegralEvaluationCech q :=
+  Functor.mapIso _
+    (cechPresentationAugmentedEvaluationIso
+      boundarySevenSimplicialFacePresentationArrow q)
+
+set_option backward.isDefEq.respectTransparency false in
+noncomputable def boundarySevenSimplicialFaceCechRowArrowIso
+    (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+        boundarySevenSimplicialFaceCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q)) := by
+  let e := boundarySevenSimplicialFaceIntegralCechAugmentedRowIso q
+  let X := ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj
+            boundarySevenSimplicialFaceAugmentedCechNerve)
+  let F := HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q
+  let Y := SimplicialObject.Augmented.drop.obj
+    boundarySevenSimplicialFaceAugmentedCechChains
+  let l₀ : firstQuadrantHorizontalRow
+      boundarySevenSimplicialFaceCechBicomplex q ≅
+      AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj X) :=
+    eqToIso (Functor.congr_obj (map_alternatingFaceMapComplex F) Y)
+  let r₀ : firstQuadrantHorizontalRow
+      (firstQuadrantSingleZeroBicomplex
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))) q ≅
+      (ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj X) :=
+    (HomologicalComplex.singleMapHomologicalComplex F
+      (ComplexShape.down ℕ) 0).app
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))
+  let e₀ : Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenSimplicialFaceCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app X) :=
+    Arrow.isoMk' _ _ l₀ r₀ (by
+      ext n x
+      rcases n with _ | n
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenSimplicialFaceCechOuterAugmentation,
+          boundarySevenSimplicialFaceCechBicomplex,
+          boundarySevenSimplicialFaceAugmentedCechChains,
+          SSet.chainComplexFunctor,
+          AlternatingFaceMapComplex.ε_app_f_zero]
+        change (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenSimplicialFaceAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x =
+          (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenSimplicialFaceAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x
+        rfl
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenSimplicialFaceCechOuterAugmentation,
+          AlternatingFaceMapComplex.ε_app_f_succ])
+  let e₁ := Arrow.isoMk'
+    (AlternatingFaceMapComplex.ε.app X)
+    (AlternatingFaceMapComplex.ε.app
+      (boundarySevenSimplicialFaceIntegralEvaluationCech q))
+    ((alternatingFaceMapComplex AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.drop.mapIso e))
+    ((ChainComplex.single₀ AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.point.mapIso e))
+    (by
+      exact AlternatingFaceMapComplex.ε.naturality e.hom)
+  exact e₀ ≪≫ e₁
+
+/-- The actual horizontal rows of both boundary-seven Cech augmentations are canonically the
+evaluated rows used by the extra-degeneracy contractions. -/
+public noncomputable def boundarySevenCechAugmentationRowIdentifications :
+    BoundarySevenCechAugmentationRowIdentifications where
+  sourceRowArrowIso q := boundarySevenSimplicialFaceCechRowArrowIso q
+  targetRowArrowIso q := boundarySevenFaceNeighborhoodCechRowArrowIso q
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechRowwiseGlobalizationProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechRowwiseGlobalizationProof.lean
@@ -1,0 +1,31 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantRowwiseTotalizationProof
+public import SphereSixComplex.Topology.BoundarySevenCechRowIdentificationsProof
+
+/-!
+# Concrete rowwise globalization for the boundary-seven Cech bicomplexes
+
+This file combines the first-quadrant rowwise totalization theorem with the canonical
+identifications of the actual Cech rows.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace SphereSixComplex
+
+/-- The rowwise globalization package used by the boundary-seven low-assembly argument. -/
+public noncomputable def boundarySevenCechRowwiseGlobalization :
+    BoundarySevenCechRowwiseGlobalization where
+  totalization := firstQuadrantRowwiseTotalization
+  rowIdentifications := boundarySevenCechAugmentationRowIdentifications
+
+/-- The boundary-seven rowwise globalization package exists without any additional
+homological-algebra or coherence hypotheses. -/
+public theorem boundarySevenCechRowwiseGlobalization_nonempty :
+    Nonempty BoundarySevenCechRowwiseGlobalization :=
+  ⟨boundarySevenCechRowwiseGlobalization⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantColumnFiltration.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantColumnFiltration.lean
@@ -1,0 +1,77 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantSingleColumnTotal
+public import Mathlib.Algebra.Homology.Embedding.StupidTrunc
+public import Mathlib.Algebra.Homology.TotalComplexSymmetry
+
+/-!
+# Finite column filtrations of first-quadrant bicomplexes
+
+This file constructs the brutal finite-prefix filtration in the outer direction of a
+first-quadrant bicomplex.  It is the elementary filtration used to promote componentwise
+quasi-isomorphisms to quasi-isomorphisms after direct-sum totalization.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+/-- The finite interval of outer degrees retained by the `n`th brutal prefix. -/
+public abbrev FirstQuadrantColumnPrefixIndex (n : ℕ) := {p : ℕ // p ≤ n}
+
+/-- The chain-complex shape obtained by restricting the usual downward shape on `ℕ` to
+`0, ..., n`.  Defining the shape by restriction avoids all dependent casts at the cutoff. -/
+public def firstQuadrantColumnPrefixShape (n : ℕ) :
+    ComplexShape (FirstQuadrantColumnPrefixIndex n) where
+  Rel p q := (ComplexShape.down ℕ).Rel p.1 q.1
+  next_eq hp hq := Subtype.ext ((ComplexShape.down ℕ).next_eq hp hq)
+  prev_eq hp hq := Subtype.ext ((ComplexShape.down ℕ).prev_eq hp hq)
+
+/-- Inclusion of the finite prefix shape in the first-quadrant outer shape. -/
+public def firstQuadrantColumnPrefixEmbedding (n : ℕ) :
+    (firstQuadrantColumnPrefixShape n).Embedding (ComplexShape.down ℕ) :=
+  ComplexShape.Embedding.mk'
+    (firstQuadrantColumnPrefixShape n) (ComplexShape.down ℕ)
+    Subtype.val Subtype.val_injective (fun _ _ => Iff.rfl)
+
+noncomputable instance (n : ℕ) :
+    (firstQuadrantColumnPrefixEmbedding n).IsRelIff where
+  rel' _ _ h := h
+
+/-- The brutal prefix consisting of outer columns `0, ..., n`.
+
+This is Mathlib's restriction followed by extension by zero.  Consequently the shape and
+`d² = 0` proofs, including the differential crossing the cutoff, come from the generic
+zero-extension construction rather than from hand-written dependent `if` expressions. -/
+public noncomputable def firstQuadrantColumnPrefix
+    (K : FirstQuadrantBicomplex) (n : ℕ) : FirstQuadrantBicomplex :=
+  K.stupidTrunc (firstQuadrantColumnPrefixEmbedding n)
+
+/-- A bicomplex map restricts to every brutal finite column prefix. -/
+public noncomputable def firstQuadrantColumnPrefixMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (n : ℕ) :
+    firstQuadrantColumnPrefix K n ⟶ firstQuadrantColumnPrefix L n :=
+  HomologicalComplex.stupidTruncMap f (firstQuadrantColumnPrefixEmbedding n)
+
+/-- Inside the retained range, the brutal prefix has the original column. -/
+public noncomputable def firstQuadrantColumnPrefixXIso
+    (K : FirstQuadrantBicomplex) (n p : ℕ) (hp : p ≤ n) :
+    (firstQuadrantColumnPrefix K n).X p ≅ K.X p :=
+  K.stupidTruncXIso (firstQuadrantColumnPrefixEmbedding n)
+    (i := ⟨p, hp⟩) rfl
+
+/-- Outside the retained range, the brutal prefix column is zero. -/
+public theorem firstQuadrantColumnPrefix_isZero_X
+    (K : FirstQuadrantBicomplex) (n p : ℕ) (hp : n < p) :
+    IsZero ((firstQuadrantColumnPrefix K n).X p) := by
+  unfold firstQuadrantColumnPrefix
+  apply HomologicalComplex.isZero_stupidTrunc_X
+  intro i hi
+  change i.1 = p at hi
+  omega
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationQuotient.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationQuotient.lean
@@ -1,0 +1,100 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantColumnFiltration
+
+/-!
+# Successive column quotients of finite first-quadrant prefixes
+
+The `(n + 1)`st prefix has a canonical projection to its last column, regarded as a bicomplex
+concentrated in outer degree `n + 1`.  This is the quotient map in the finite column filtration.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+/-- A single outer column of a first-quadrant bicomplex. -/
+public noncomputable abbrev firstQuadrantSingleColumn
+    (K : FirstQuadrantBicomplex) (p : ℕ) : FirstQuadrantBicomplex :=
+  (HomologicalComplex.single (ChainComplex AddCommGrpCat ℕ)
+    (ComplexShape.down ℕ) p).obj (K.X p)
+
+/-- The unique nonzero outer column is canonically the original column. -/
+public noncomputable def firstQuadrantSingleColumnXIso
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    (firstQuadrantSingleColumn K p).X p ≅ K.X p :=
+  HomologicalComplex.singleObjXSelf (ComplexShape.down ℕ) p (K.X p)
+
+/-- Component of the projection from the prefix ending at `p` to its last column. -/
+public noncomputable def firstQuadrantColumnPrefixToLastComponent
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    (firstQuadrantColumnPrefix K p).X q ⟶
+      (firstQuadrantSingleColumn K p).X q := by
+  by_cases hq : q = p
+  · subst q
+    exact (firstQuadrantColumnPrefixXIso K p p le_rfl).hom ≫
+      (firstQuadrantSingleColumnXIso K p).inv
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantColumnPrefixToLastComponent_self
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefixToLastComponent K p p =
+      (firstQuadrantColumnPrefixXIso K p p le_rfl).hom ≫
+        (firstQuadrantSingleColumnXIso K p).inv := by
+  simp [firstQuadrantColumnPrefixToLastComponent]
+
+public theorem firstQuadrantColumnPrefixToLastComponent_eq_zero
+    (K : FirstQuadrantBicomplex) (p q : ℕ) (hq : q ≠ p) :
+    firstQuadrantColumnPrefixToLastComponent K p q = 0 := by
+  simp [firstQuadrantColumnPrefixToLastComponent, hq]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Projection of the finite prefix to its final outer column. -/
+public noncomputable def firstQuadrantColumnPrefixToLast
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefix K p ⟶ firstQuadrantSingleColumn K p where
+  f := firstQuadrantColumnPrefixToLastComponent K p
+  comm' i j hij := by
+    change j + 1 = i at hij
+    by_cases hi : i = p
+    · subst i
+      have hj : j ≠ p := by
+        omega
+      rw [hi, firstQuadrantColumnPrefixToLastComponent_self,
+        firstQuadrantColumnPrefixToLastComponent_eq_zero K p j hj,
+        comp_zero]
+      have hz : (firstQuadrantSingleColumn K p).d p j = 0 := by simp
+      rw [hz, comp_zero]
+    · rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K p i hi,
+        zero_comp]
+      by_cases hj : j = p
+      · subst j
+        have hip : p < i := by
+          omega
+        have hz : IsZero ((firstQuadrantColumnPrefix K p).X i) :=
+          firstQuadrantColumnPrefix_isZero_X K p i hip
+        exact hz.eq_of_src _ _
+      · rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K p j hj,
+          comp_zero]
+
+noncomputable instance firstQuadrantColumnPrefixToLast_epi
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    Epi (firstQuadrantColumnPrefixToLast K p) := by
+  apply HomologicalComplex.epi_of_epi_f
+  intro q
+  by_cases hq : q = p
+  · subst q
+    dsimp [firstQuadrantColumnPrefixToLast]
+    rw [firstQuadrantColumnPrefixToLastComponent_self]
+    infer_instance
+  · have hz : IsZero ((firstQuadrantSingleColumn K p).X q) :=
+      HomologicalComplex.isZero_single_obj_X
+        (ComplexShape.down ℕ) p (K.X p) q hq
+    exact hz.epi _
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationShortExact.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationShortExact.lean
@@ -1,0 +1,171 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantColumnFiltrationQuotient
+public import Mathlib.Algebra.Homology.HomologicalComplexAbelian
+public import Mathlib.Algebra.Homology.ShortComplex.Abelian
+
+/-!
+# Short exact sequences for the finite column filtration
+
+The inclusion from the prefix ending in column `p` to the prefix ending in column `p + 1`
+is the kernel of projection to the new final column.  Consequently the successive quotients
+of the finite column filtration are single-column bicomplexes.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The differential of a finite prefix, transported to the original bicomplex in two
+retained degrees. -/
+public theorem firstQuadrantColumnPrefix_d_eq
+    (K : FirstQuadrantBicomplex) (n i j : ℕ) (hi : i ≤ n) (hj : j ≤ n) :
+    (firstQuadrantColumnPrefix K n).d i j =
+      (firstQuadrantColumnPrefixXIso K n i hi).hom ≫ K.d i j ≫
+        (firstQuadrantColumnPrefixXIso K n j hj).inv := by
+  let e := firstQuadrantColumnPrefixEmbedding n
+  have h := HomologicalComplex.extend_d_eq
+    (K := K.restriction e) (e := e)
+    (i' := i) (j' := j) (i := ⟨i, hi⟩) (j := ⟨j, hj⟩) (hi := rfl) (hj := rfl)
+  simpa [e, firstQuadrantColumnPrefix, firstQuadrantColumnPrefixXIso,
+    firstQuadrantColumnPrefixEmbedding, ComplexShape.Embedding.mk',
+    HomologicalComplex.stupidTrunc, HomologicalComplex.stupidTruncXIso,
+    HomologicalComplex.restriction] using h
+
+/-- Component of the canonical inclusion of two consecutive finite column prefixes. -/
+public noncomputable def firstQuadrantColumnPrefixSuccInclusionComponent
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    (firstQuadrantColumnPrefix K p).X q ⟶
+      (firstQuadrantColumnPrefix K (p + 1)).X q := by
+  by_cases hq : q ≤ p
+  · exact (firstQuadrantColumnPrefixXIso K p q hq).hom ≫
+      (firstQuadrantColumnPrefixXIso K (p + 1) q (by omega)).inv
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantColumnPrefixSuccInclusionComponent_of_le
+    (K : FirstQuadrantBicomplex) (p q : ℕ) (hq : q ≤ p) :
+    firstQuadrantColumnPrefixSuccInclusionComponent K p q =
+      (firstQuadrantColumnPrefixXIso K p q hq).hom ≫
+        (firstQuadrantColumnPrefixXIso K (p + 1) q (by omega)).inv := by
+  simp [firstQuadrantColumnPrefixSuccInclusionComponent, hq]
+
+public theorem firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero
+    (K : FirstQuadrantBicomplex) (p q : ℕ) (hq : p < q) :
+    firstQuadrantColumnPrefixSuccInclusionComponent K p q = 0 := by
+  simp [firstQuadrantColumnPrefixSuccInclusionComponent, show ¬ q ≤ p by omega]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Canonical inclusion from the prefix through `p` into the prefix through `p + 1`. -/
+public noncomputable def firstQuadrantColumnPrefixSuccInclusion
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefix K p ⟶ firstQuadrantColumnPrefix K (p + 1) where
+  f := firstQuadrantColumnPrefixSuccInclusionComponent K p
+  comm' i j hij := by
+    change j + 1 = i at hij
+    by_cases hi : i ≤ p
+    · have hj : j ≤ p := by omega
+      rw [firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p i hi,
+        firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p j hj,
+        firstQuadrantColumnPrefix_d_eq K (p + 1) i j (by omega) (by omega),
+        firstQuadrantColumnPrefix_d_eq K p i j hi hj]
+      simp
+    · rw [firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero K p i (by omega),
+        zero_comp]
+      have hz : IsZero ((firstQuadrantColumnPrefix K p).X i) :=
+        firstQuadrantColumnPrefix_isZero_X K p i (by omega)
+      exact hz.eq_of_src _ _
+
+@[reassoc (attr := simp)]
+public theorem firstQuadrantColumnPrefixSuccInclusion_comp_toLast
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefixSuccInclusion K p ≫
+      firstQuadrantColumnPrefixToLast K (p + 1) = 0 := by
+  apply HomologicalComplex.hom_ext
+  intro q
+  by_cases hq : q ≤ p
+  · have hne : q ≠ p + 1 := by omega
+    change firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+      firstQuadrantColumnPrefixToLastComponent K (p + 1) q = 0
+    rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K (p + 1) q hne,
+      comp_zero]
+  · change firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+      firstQuadrantColumnPrefixToLastComponent K (p + 1) q = 0
+    rw [firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero K p q (by omega),
+      zero_comp]
+
+/-- The inclusion of one finite prefix into the next is the kernel of projection onto the
+new final column. -/
+public noncomputable def firstQuadrantColumnPrefixSuccInclusionIsKernel
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    IsLimit (KernelFork.ofι
+      (firstQuadrantColumnPrefixSuccInclusion K p)
+      (firstQuadrantColumnPrefixSuccInclusion_comp_toLast K p)) := by
+  apply HomologicalComplex.isLimitOfEval
+  intro q
+  refine (Limits.isLimitMapConeForkEquiv'
+    (HomologicalComplex.eval (ChainComplex AddCommGrpCat ℕ) (ComplexShape.down ℕ) q)
+    (firstQuadrantColumnPrefixSuccInclusion_comp_toLast K p)).symm ?_
+  change IsLimit (KernelFork.ofι
+    (HomologicalComplex.Hom.f (firstQuadrantColumnPrefixSuccInclusion K p) q)
+    _)
+  by_cases hq : q ≤ p
+  · let e : (firstQuadrantColumnPrefix K p).X q ≅
+        (firstQuadrantColumnPrefix K (p + 1)).X q :=
+      firstQuadrantColumnPrefixXIso K p q hq ≪≫
+        (firstQuadrantColumnPrefixXIso K (p + 1) q (by omega)).symm
+    have he : (firstQuadrantColumnPrefixSuccInclusion K p).f q = e.hom := by
+      change firstQuadrantColumnPrefixSuccInclusionComponent K p q = e.hom
+      simp [e, firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p q hq]
+    refine KernelFork.IsLimit.ofι _ _
+      (fun {_} k _ => k ≫ e.inv) ?_ ?_
+    · intro W k hk
+      rw [he, Category.assoc, e.inv_hom_id, Category.comp_id]
+    · intro W k hk m hm
+      rw [he] at hm
+      rw [← hm, Category.assoc, e.hom_inv_id, Category.comp_id]
+  · have hpq : p < q := by omega
+    have hz : IsZero ((firstQuadrantColumnPrefix K p).X q) :=
+      firstQuadrantColumnPrefix_isZero_X K p q hpq
+    apply KernelFork.IsLimit.ofMonoOfIsZero _ _ hz
+    by_cases hself : q = p + 1
+    · subst q
+      change Mono (firstQuadrantColumnPrefixToLastComponent K (p + 1) (p + 1))
+      rw [firstQuadrantColumnPrefixToLastComponent_self]
+      infer_instance
+    · have hgt : p + 1 < q := by omega
+      exact (firstQuadrantColumnPrefix_isZero_X K (p + 1) q hgt).mono _
+
+/-- The canonical short complex associated to one step of the finite column filtration. -/
+local instance : Preadditive FirstQuadrantBicomplex :=
+  (inferInstance : Abelian FirstQuadrantBicomplex).toPreadditive
+
+local instance : HasZeroMorphisms FirstQuadrantBicomplex :=
+  Preadditive.preadditiveHasZeroMorphisms
+
+public noncomputable def firstQuadrantColumnPrefixSuccShortComplex
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    ShortComplex FirstQuadrantBicomplex :=
+  ShortComplex.mk
+    (firstQuadrantColumnPrefixSuccInclusion K p)
+    (firstQuadrantColumnPrefixToLast K (p + 1))
+    (firstQuadrantColumnPrefixSuccInclusion_comp_toLast K p)
+
+/-- Each step of the finite column filtration is a short exact sequence whose quotient is
+the newly added single column. -/
+public theorem firstQuadrantColumnPrefixSuccShortComplex_shortExact
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    (firstQuadrantColumnPrefixSuccShortComplex K p).ShortExact := by
+  exact
+    { exact := (firstQuadrantColumnPrefixSuccShortComplex K p).exact_of_f_is_kernel
+        (firstQuadrantColumnPrefixSuccInclusionIsKernel K p)
+      mono_f := mono_of_isLimit_fork
+        (firstQuadrantColumnPrefixSuccInclusionIsKernel K p)
+      epi_g := firstQuadrantColumnPrefixToLast_epi K (p + 1) }
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantRowwiseTotalizationProof.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantRowwiseTotalizationProof.lean
@@ -1,0 +1,977 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantColumnFiltrationShortExact
+public import SphereSixComplex.Topology.BoundarySevenCechLowAssemblyProof
+
+/-!
+# Rowwise quasi-isomorphisms and first-quadrant totalization
+
+This file supplies the degree-local stabilization part of the brutal-filtration proof of
+rowwise totalization.  A total degree `n` only contains outer columns at most `n`; consequently
+the total of the prefix through `N` agrees with the full total in every degree at most `N`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+/-- Component of the canonical map from a finite outer-column prefix to the original
+bicomplex. -/
+public noncomputable def firstQuadrantColumnPrefixToOriginalComponent
+    (K : FirstQuadrantBicomplex) (N p : ℕ) :
+    (firstQuadrantColumnPrefix K N).X p ⟶ K.X p := by
+  by_cases hp : p ≤ N
+  · exact (firstQuadrantColumnPrefixXIso K N p hp).hom
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantColumnPrefixToOriginalComponent_of_le
+    (K : FirstQuadrantBicomplex) (N p : ℕ) (hp : p ≤ N) :
+    firstQuadrantColumnPrefixToOriginalComponent K N p =
+      (firstQuadrantColumnPrefixXIso K N p hp).hom := by
+  simp [firstQuadrantColumnPrefixToOriginalComponent, hp]
+
+public theorem firstQuadrantColumnPrefixToOriginalComponent_eq_zero
+    (K : FirstQuadrantBicomplex) (N p : ℕ) (hp : N < p) :
+    firstQuadrantColumnPrefixToOriginalComponent K N p = 0 := by
+  simp [firstQuadrantColumnPrefixToOriginalComponent, show ¬ p ≤ N by omega]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Canonical map from a finite outer-column prefix to the original bicomplex. -/
+public noncomputable def firstQuadrantColumnPrefixToOriginal
+    (K : FirstQuadrantBicomplex) (N : ℕ) :
+    firstQuadrantColumnPrefix K N ⟶ K where
+  f := firstQuadrantColumnPrefixToOriginalComponent K N
+  comm' i j hij := by
+    change j + 1 = i at hij
+    by_cases hi : i ≤ N
+    · have hj : j ≤ N := by omega
+      rw [firstQuadrantColumnPrefixToOriginalComponent_of_le K N i hi,
+        firstQuadrantColumnPrefixToOriginalComponent_of_le K N j hj,
+        firstQuadrantColumnPrefix_d_eq K N i j hi hj]
+      simp
+    · rw [firstQuadrantColumnPrefixToOriginalComponent_eq_zero K N i (by omega),
+        zero_comp]
+      exact (firstQuadrantColumnPrefix_isZero_X K N i (by omega)).eq_of_src _ _
+
+/-- Totalization of the canonical map from a finite prefix to the full bicomplex. -/
+public noncomputable def firstQuadrantColumnPrefixTotalToOriginal
+    (K : FirstQuadrantBicomplex) (N : ℕ) :
+    (firstQuadrantColumnPrefix K N).total (ComplexShape.down ℕ) ⟶
+      K.total (ComplexShape.down ℕ) :=
+  HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToOriginal K N)
+    (ComplexShape.down ℕ)
+
+/-- In total degree `n ≤ N`, project the full total back to the prefix total by using the
+inverse prefix isomorphism on every antidiagonal summand. -/
+public noncomputable def firstQuadrantColumnPrefixTotalToOriginalInverseComponent
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    (K.total (ComplexShape.down ℕ)).X n ⟶
+      ((firstQuadrantColumnPrefix K N).total (ComplexShape.down ℕ)).X n :=
+  K.totalDesc (fun p q hpq =>
+    (firstQuadrantColumnPrefixXIso K N p (by
+      change p + q = n at hpq
+      omega)).inv.f q ≫
+      (firstQuadrantColumnPrefix K N).ιTotal
+        (ComplexShape.down ℕ) p q n hpq)
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantColumnPrefixTotalToOriginal_hom_inv
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    (firstQuadrantColumnPrefixTotalToOriginal K N).f n ≫
+      firstQuadrantColumnPrefixTotalToOriginalInverseComponent K N n hn =
+        𝟙 _ := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  have hp : p ≤ N := by
+    change p + q = n at hpq
+    omega
+  dsimp [firstQuadrantColumnPrefixTotalToOriginal,
+    firstQuadrantColumnPrefixTotalToOriginalInverseComponent]
+  rw [HomologicalComplex₂.ιTotal_map_assoc]
+  change (firstQuadrantColumnPrefixToOriginalComponent K N p).f q ≫ _ = _
+  rw [
+    firstQuadrantColumnPrefixToOriginalComponent_of_le K N p hp,
+    HomologicalComplex₂.ι_totalDesc]
+  simp
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantColumnPrefixTotalToOriginal_inv_hom
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    firstQuadrantColumnPrefixTotalToOriginalInverseComponent K N n hn ≫
+      (firstQuadrantColumnPrefixTotalToOriginal K N).f n = 𝟙 _ := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  have hp : p ≤ N := by
+    change p + q = n at hpq
+    omega
+  dsimp [firstQuadrantColumnPrefixTotalToOriginal,
+    firstQuadrantColumnPrefixTotalToOriginalInverseComponent]
+  rw [HomologicalComplex₂.ι_totalDesc_assoc]
+  rw [Category.assoc, HomologicalComplex₂.ιTotal_map]
+  change (firstQuadrantColumnPrefixXIso K N p _).inv.f q ≫
+    (firstQuadrantColumnPrefixToOriginalComponent K N p).f q ≫ _ = _
+  rw [firstQuadrantColumnPrefixToOriginalComponent_of_le K N p hp]
+  simp
+
+/-- The finite-prefix total and full total are isomorphic componentwise through the cutoff. -/
+public noncomputable def firstQuadrantColumnPrefixTotalToOriginalComponentIso
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    ((firstQuadrantColumnPrefix K N).total (ComplexShape.down ℕ)).X n ≅
+      (K.total (ComplexShape.down ℕ)).X n where
+  hom := (firstQuadrantColumnPrefixTotalToOriginal K N).f n
+  inv := firstQuadrantColumnPrefixTotalToOriginalInverseComponent K N n hn
+  hom_inv_id := firstQuadrantColumnPrefixTotalToOriginal_hom_inv K N n hn
+  inv_hom_id := firstQuadrantColumnPrefixTotalToOriginal_inv_hom K N n hn
+
+public theorem firstQuadrantColumnPrefixTotalToOriginal_component_isIso
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    IsIso ((firstQuadrantColumnPrefixTotalToOriginal K N).f n) :=
+  (firstQuadrantColumnPrefixTotalToOriginalComponentIso K N n hn).isIso_hom
+
+set_option linter.style.haveILetI false in
+/-- Once the cutoff contains degree `n + 1`, the prefix-to-full total map is a
+quasi-isomorphism in degree `n`.  The extra degree is exactly the incoming differential needed
+to compute homology in degree `n`. -/
+public theorem firstQuadrantColumnPrefixTotalToOriginal_quasiIsoAt
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n + 1 ≤ N) :
+    QuasiIsoAt (firstQuadrantColumnPrefixTotalToOriginal K N) n := by
+  rw [quasiIsoAt_iff'
+    (firstQuadrantColumnPrefixTotalToOriginal K N)
+    (n + 1) n ((ComplexShape.down ℕ).next n) (by simp) rfl]
+  let φ := (HomologicalComplex.shortComplexFunctor'
+    AddCommGrpCat (ComplexShape.down ℕ)
+    (n + 1) n ((ComplexShape.down ℕ).next n)).map
+      (firstQuadrantColumnPrefixTotalToOriginal K N)
+  have hnext : (ComplexShape.down ℕ).next n ≤ N := by
+    rcases n with _ | n
+    · simp
+    · simp
+      omega
+  letI : IsIso φ.τ₁ :=
+    firstQuadrantColumnPrefixTotalToOriginal_component_isIso K N (n + 1) hn
+  letI : IsIso φ.τ₂ :=
+    firstQuadrantColumnPrefixTotalToOriginal_component_isIso K N n (by omega)
+  letI : IsIso φ.τ₃ :=
+    firstQuadrantColumnPrefixTotalToOriginal_component_isIso K N
+      ((ComplexShape.down ℕ).next n) hnext
+  letI : IsIso φ := ShortComplex.isIso_of_isIso φ
+  change ShortComplex.QuasiIso φ
+  infer_instance
+
+@[reassoc]
+public theorem firstQuadrantColumnPrefixMap_toOriginal_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N : ℕ) :
+    firstQuadrantColumnPrefixMap f N ≫
+      firstQuadrantColumnPrefixToOriginal L N =
+    firstQuadrantColumnPrefixToOriginal K N ≫ f := by
+  apply HomologicalComplex.hom_ext
+  intro p
+  by_cases hp : p ≤ N
+  · change (firstQuadrantColumnPrefixMap f N).f p ≫
+      firstQuadrantColumnPrefixToOriginalComponent L N p =
+        firstQuadrantColumnPrefixToOriginalComponent K N p ≫ f.f p
+    rw [firstQuadrantColumnPrefixToOriginalComponent_of_le L N p hp,
+      firstQuadrantColumnPrefixToOriginalComponent_of_le K N p hp]
+    exact HomologicalComplex.stupidTruncMap_stupidTruncXIso_hom
+      f (firstQuadrantColumnPrefixEmbedding N) (i := ⟨p, hp⟩) (i' := p) rfl
+  · have hNp : N < p := by omega
+    change (firstQuadrantColumnPrefixMap f N).f p ≫
+      firstQuadrantColumnPrefixToOriginalComponent L N p =
+        firstQuadrantColumnPrefixToOriginalComponent K N p ≫ f.f p
+    rw [firstQuadrantColumnPrefixToOriginalComponent_eq_zero L N p hNp,
+      firstQuadrantColumnPrefixToOriginalComponent_eq_zero K N p hNp,
+      comp_zero, zero_comp]
+
+@[reassoc]
+public theorem firstQuadrantColumnPrefixTotalToOriginal_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N : ℕ) :
+    HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ) ≫
+      firstQuadrantColumnPrefixTotalToOriginal L N =
+      firstQuadrantColumnPrefixTotalToOriginal K N ≫
+      HomologicalComplex₂.total.map f (ComplexShape.down ℕ) := by
+  dsimp only [firstQuadrantColumnPrefixTotalToOriginal]
+  rw [← HomologicalComplex₂.total.map_comp,
+    ← HomologicalComplex₂.total.map_comp]
+  exact congrArg
+    (fun g => HomologicalComplex₂.total.map g (ComplexShape.down ℕ))
+    (firstQuadrantColumnPrefixMap_toOriginal_naturality f N)
+
+set_option linter.style.haveILetI false in
+/-- A quasi-isomorphism on one sufficiently large finite prefix induces a
+quasi-isomorphism of full totals in the requested degree. -/
+public theorem firstQuadrantTotal_quasiIsoAt_of_prefix
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N n : ℕ)
+    (hn : n + 1 ≤ N)
+    (hprefix : QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ))) :
+    QuasiIsoAt (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) n := by
+  letI : QuasiIsoAt
+      (firstQuadrantColumnPrefixTotalToOriginal K N) n :=
+    firstQuadrantColumnPrefixTotalToOriginal_quasiIsoAt K N n hn
+  letI : QuasiIsoAt
+      (firstQuadrantColumnPrefixTotalToOriginal L N) n :=
+    firstQuadrantColumnPrefixTotalToOriginal_quasiIsoAt L N n hn
+  letI : QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ)) := hprefix
+  have hcomp : QuasiIsoAt
+      (firstQuadrantColumnPrefixTotalToOriginal K N ≫
+        HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) n := by
+    rw [← firstQuadrantColumnPrefixTotalToOriginal_naturality f N]
+    infer_instance
+  exact quasiIsoAt_of_comp_left
+    (firstQuadrantColumnPrefixTotalToOriginal K N)
+    (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) n
+
+/-- If a bicomplex map is a quasi-isomorphism after totalizing every finite column prefix,
+then it is a quasi-isomorphism after full first-quadrant totalization. -/
+public theorem firstQuadrantTotal_quasiIso_of_all_prefixes
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hprefix : ∀ N : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ))) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) := by
+  rw [quasiIso_iff]
+  intro n
+  exact firstQuadrantTotal_quasiIsoAt_of_prefix f (n + 1) n le_rfl (hprefix (n + 1))
+
+/-- The map between bicomplexes concentrated in one outer column induced by a bicomplex map. -/
+public noncomputable def firstQuadrantSingleColumnMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantSingleColumn K p ⟶ firstQuadrantSingleColumn L p :=
+  (HomologicalComplex.single (ChainComplex AddCommGrpCat ℕ)
+    (ComplexShape.down ℕ) p).map (f.f p)
+
+/-- Projection from a total supported in outer column `p` to its sole summand in
+total degree `p + q`. -/
+public noncomputable def firstQuadrantSingleColumnTotalXHom
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) ⟶
+      (K.X p).X q :=
+  (firstQuadrantSingleColumn K p).totalDesc (fun r s hrs => by
+    by_cases hr : r = p
+    · subst r
+      have hs : s = q := by
+        change p + s = p + q at hrs
+        omega
+      subst s
+      exact (firstQuadrantSingleColumnXIso K p).hom.f q
+    · exact 0)
+
+/-- Inclusion of the sole summand of a single-column total. -/
+public noncomputable def firstQuadrantSingleColumnTotalXInv
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    (K.X p).X q ⟶
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) :=
+  (firstQuadrantSingleColumnXIso K p).inv.f q ≫
+    (firstQuadrantSingleColumn K p).ιTotal
+      (ComplexShape.down ℕ) p q (p + q) rfl
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantSingleColumnTotalXHom_inv
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    firstQuadrantSingleColumnTotalXHom K p q ≫
+      firstQuadrantSingleColumnTotalXInv K p q = 𝟙 _ := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  by_cases hr : r = p
+  · subst r
+    have hs : s = q := by
+      change p + s = p + q at hrs
+      omega
+    subst s
+    dsimp [firstQuadrantSingleColumnTotalXHom,
+      firstQuadrantSingleColumnTotalXInv]
+    rw [HomologicalComplex₂.ι_totalDesc_assoc]
+    simp
+  · have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) s).map_isZero
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) p (K.X p) r hr)
+    exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantSingleColumnTotalXInv_hom
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    firstQuadrantSingleColumnTotalXInv K p q ≫
+      firstQuadrantSingleColumnTotalXHom K p q = 𝟙 _ := by
+  dsimp [firstQuadrantSingleColumnTotalXHom,
+    firstQuadrantSingleColumnTotalXInv]
+  rw [Category.assoc, HomologicalComplex₂.ι_totalDesc]
+  simp
+
+/-- In degree `p + q`, a total supported in outer column `p` is canonically its sole
+summand in inner degree `q`. -/
+public noncomputable def firstQuadrantSingleColumnTotalXIso
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) ≅
+      (K.X p).X q where
+  hom := firstQuadrantSingleColumnTotalXHom K p q
+  inv := firstQuadrantSingleColumnTotalXInv K p q
+  hom_inv_id := firstQuadrantSingleColumnTotalXHom_inv K p q
+  inv_hom_id := firstQuadrantSingleColumnTotalXInv_hom K p q
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Under the sole-summand identification, the differential on the total supported in
+outer column `p` is the vertical differential multiplied by the total-complex sign at `p`. -/
+public theorem firstQuadrantSingleColumnTotalXIso_d
+    (K : FirstQuadrantBicomplex) (p i j : ℕ)
+    (hij : (ComplexShape.down ℕ).Rel i j) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d
+        (p + i) (p + j) ≫
+      (firstQuadrantSingleColumnTotalXIso K p j).hom =
+    (ComplexShape.down ℕ).ε p •
+      ((firstQuadrantSingleColumnTotalXIso K p i).hom ≫ (K.X p).d i j) := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  by_cases hr : r = p
+  · subst r
+    have hs : s = i := by
+      change p + s = p + i at hrs
+      omega
+    subst s
+    rw [Linear.comp_units_smul]
+    dsimp only [HomologicalComplex₂.total_d]
+    rw [← Category.assoc, Preadditive.comp_add,
+      HomologicalComplex₂.ι_D₁, HomologicalComplex₂.ι_D₂]
+    have hd₁ : (firstQuadrantSingleColumn K p).d₁
+        (ComplexShape.down ℕ) p i (p + j) = 0 := by
+      dsimp [HomologicalComplex₂.d₁]
+      simp
+    rw [hd₁, zero_add]
+    rw [HomologicalComplex₂.d₂_eq
+      (firstQuadrantSingleColumn K p) (ComplexShape.down ℕ)
+      p hij (p + j) (by
+        change p + j = p + j
+        rfl)]
+    dsimp [firstQuadrantSingleColumnTotalXIso,
+      firstQuadrantSingleColumnTotalXHom]
+    rw [Linear.units_smul_comp, Category.assoc,
+      HomologicalComplex₂.ι_totalDesc]
+    simp
+  · have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) s).map_isZero
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) p (K.X p) r hr)
+    exact hz.eq_of_src _ _
+
+/-- The sign-twisted sole-summand identification which removes the constant vertical sign
+from a total supported in outer column `p`. -/
+public noncomputable def firstQuadrantSingleColumnTotalScaledXIso
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) ≅
+      (K.X p).X q :=
+  ((ComplexShape.down ℕ).ε p) ^ q •
+    firstQuadrantSingleColumnTotalXIso K p q
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The scaled sole-summand identifications commute with the differentials. -/
+public theorem firstQuadrantSingleColumnTotalScaledXIso_d
+    (K : FirstQuadrantBicomplex) (p i j : ℕ)
+    (hij : (ComplexShape.down ℕ).Rel i j) :
+    (firstQuadrantSingleColumnTotalScaledXIso K p i).hom ≫ (K.X p).d i j =
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d
+          (p + i) (p + j) ≫
+        (firstQuadrantSingleColumnTotalScaledXIso K p j).hom := by
+  change j + 1 = i at hij
+  subst i
+  change (((ComplexShape.down ℕ).ε p) ^ (j + 1) •
+      (firstQuadrantSingleColumnTotalXIso K p (j + 1)).hom) ≫ _ =
+    _ ≫ (((ComplexShape.down ℕ).ε p) ^ j •
+      (firstQuadrantSingleColumnTotalXIso K p j).hom)
+  rw [Linear.units_smul_comp, Linear.comp_units_smul,
+    firstQuadrantSingleColumnTotalXIso_d K p (j + 1) j (by simp), smul_smul,
+    pow_succ]
+
+/-- Embed inner degree `q` as total degree `p + q`. -/
+public abbrev firstQuadrantColumnDegreeEmbedding (p : ℕ) :
+    (ComplexShape.down ℕ).Embedding (ComplexShape.down ℕ) where
+  f q := p + q
+  injective_f := fun _ _ h => Nat.add_left_cancel h
+  rel := by
+    intro i j hij
+    change j + 1 = i at hij
+    change p + j + 1 = p + i
+    omega
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the unscaled sole-summand identification. -/
+public theorem firstQuadrantSingleColumnTotalXIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p q : ℕ) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f (p + q) ≫
+      (firstQuadrantSingleColumnTotalXIso L p q).hom =
+    (firstQuadrantSingleColumnTotalXIso K p q).hom ≫ (f.f p).f q := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  by_cases hr : r = p
+  · subst r
+    have hs : s = q := by
+      change p + s = p + q at hrs
+      omega
+    subst s
+    dsimp [firstQuadrantSingleColumnTotalXIso,
+      firstQuadrantSingleColumnTotalXHom]
+    rw [HomologicalComplex₂.ιTotal_map_assoc,
+      HomologicalComplex₂.ι_totalDesc,
+      HomologicalComplex₂.ι_totalDesc_assoc]
+    dsimp [firstQuadrantSingleColumnMap,
+      firstQuadrantSingleColumnXIso]
+    rw [HomologicalComplex.single_map_f_self]
+    simp
+  · have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) s).map_isZero
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) p (K.X p) r hr)
+    exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the sign-twisted sole-summand identification. -/
+public theorem firstQuadrantSingleColumnTotalScaledXIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p q : ℕ) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f (p + q) ≫
+      (firstQuadrantSingleColumnTotalScaledXIso L p q).hom =
+    (firstQuadrantSingleColumnTotalScaledXIso K p q).hom ≫ (f.f p).f q := by
+  change _ ≫ (((ComplexShape.down ℕ).ε p) ^ q •
+      (firstQuadrantSingleColumnTotalXIso L p q).hom) =
+    (((ComplexShape.down ℕ).ε p) ^ q •
+      (firstQuadrantSingleColumnTotalXIso K p q).hom) ≫ _
+  rw [Linear.comp_units_smul, Linear.units_smul_comp,
+    firstQuadrantSingleColumnTotalXIso_naturality]
+
+/-- Outside degrees `p + q`, the total supported in column `p` is zero. -/
+public theorem firstQuadrantSingleColumnTotalX_isZero_of_not_exists
+    (K : FirstQuadrantBicomplex) (p n : ℕ)
+    (hn : ∀ q : ℕ, p + q ≠ n) :
+    IsZero (((firstQuadrantSingleColumn K p).total
+      (ComplexShape.down ℕ)).X n) := by
+  rw [IsZero.iff_id_eq_zero]
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  rw [Category.comp_id, comp_zero]
+  have hr : r ≠ p := by
+    intro hr
+    subst r
+    exact hn s hrs
+  have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+    (HomologicalComplex.eval AddCommGrpCat
+      (ComplexShape.down ℕ) s).map_isZero
+      (HomologicalComplex.isZero_single_obj_X
+        (ComplexShape.down ℕ) p (K.X p) r hr)
+  exact hz.eq_of_src _ _
+
+/-- The component isomorphism from a single-column total to the extension-by-zero of its
+sole column, when the total degree is explicitly `p + q`. -/
+public noncomputable def firstQuadrantSingleColumnTotalExtendedXIsoOfEq
+    (K : FirstQuadrantBicomplex) (p q n : ℕ) (h : p + q = n) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X n ≅
+      ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).X n :=
+  (((firstQuadrantSingleColumn K p).total
+      (ComplexShape.down ℕ)).XIsoOfEq h).symm ≪≫
+    firstQuadrantSingleColumnTotalScaledXIso K p q ≪≫
+    ((K.X p).extendXIso (firstQuadrantColumnDegreeEmbedding p) h).symm
+
+/-- Componentwise comparison of a single-column total with the extension-by-zero of its
+sole column. -/
+public noncomputable def firstQuadrantSingleColumnTotalExtendedXIso
+    (K : FirstQuadrantBicomplex) (p n : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X n ≅
+      ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).X n := by
+  by_cases hn : p ≤ n
+  · exact firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p
+      (n - p) n (by omega)
+  · exact
+      (firstQuadrantSingleColumnTotalX_isZero_of_not_exists K p n
+        (by intro q h; omega)).isoZero ≪≫
+      ((K.X p).isZero_extend_X (firstQuadrantColumnDegreeEmbedding p) n
+        (by
+          intro q h
+          apply hn
+          change p + q = n at h
+          omega)).isoZero.symm
+
+public theorem firstQuadrantSingleColumnTotalExtendedXIso_eq
+    (K : FirstQuadrantBicomplex) (p q n : ℕ) (h : p + q = n) :
+    firstQuadrantSingleColumnTotalExtendedXIso K p n =
+      firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p q n h := by
+  subst n
+  simp [firstQuadrantSingleColumnTotalExtendedXIso]
+
+/-- The extended component comparisons commute with differentials between degrees in the
+image of the degree embedding. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIsoOfEq_d
+    (K : FirstQuadrantBicomplex) (p i j n m : ℕ)
+    (hi : p + i = n) (hj : p + j = m)
+    (hij : (ComplexShape.down ℕ).Rel i j) :
+    (firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p i n hi).hom ≫
+        ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).d n m =
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d n m ≫
+        (firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p j m hj).hom := by
+  subst n
+  subst m
+  dsimp [firstQuadrantSingleColumnTotalExtendedXIsoOfEq]
+  rw [(K.X p).extend_d_eq (firstQuadrantColumnDegreeEmbedding p) rfl rfl]
+  simp only [Category.assoc, Iso.inv_hom_id_assoc]
+  simp only [Category.id_comp]
+  rw [← Category.assoc,
+    firstQuadrantSingleColumnTotalScaledXIso_d K p i j hij]
+  rw [Category.assoc]
+
+/-- The componentwise comparisons commute with all differentials, including the lower
+boundary where extension by zero supplies the missing target degree. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIso_d
+    (K : FirstQuadrantBicomplex) (p n m : ℕ)
+    (hnm : (ComplexShape.down ℕ).Rel n m) :
+    (firstQuadrantSingleColumnTotalExtendedXIso K p n).hom ≫
+        ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).d n m =
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d n m ≫
+        (firstQuadrantSingleColumnTotalExtendedXIso K p m).hom := by
+  change m + 1 = n at hnm
+  by_cases hn : p ≤ n
+  · let q := n - p
+    have hnq : p + q = n := by
+      dsimp [q]
+      omega
+    by_cases hq : q = 0
+    · have hm : m < p := by omega
+      have hz : IsZero
+          (((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).X m) :=
+        (K.X p).isZero_extend_X (firstQuadrantColumnDegreeEmbedding p) m (by
+          intro r hr
+          change p + r = m at hr
+          omega)
+      exact hz.eq_of_tgt _ _
+    · let j := q - 1
+      have hjq : j + 1 = q := by
+        dsimp [j]
+        omega
+      have hmj : p + j = m := by omega
+      rw [firstQuadrantSingleColumnTotalExtendedXIso_eq K p q n hnq,
+        firstQuadrantSingleColumnTotalExtendedXIso_eq K p j m hmj]
+      exact firstQuadrantSingleColumnTotalExtendedXIsoOfEq_d
+        K p q j n m hnq hmj (by
+          change j + 1 = q
+          exact hjq)
+  · have hz : IsZero
+        (((firstQuadrantSingleColumn K p).total
+          (ComplexShape.down ℕ)).X n) :=
+      firstQuadrantSingleColumnTotalX_isZero_of_not_exists K p n (by
+        intro q h
+        apply hn
+        omega)
+    exact hz.eq_of_src _ _
+
+/-- A total supported in one outer column is the extension by zero of that column, with
+the canonical Koszul untwisting signs. -/
+public noncomputable def firstQuadrantSingleColumnTotalExtendedIso
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    (firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ) ≅
+      (K.X p).extend (firstQuadrantColumnDegreeEmbedding p) :=
+  HomologicalComplex.Hom.isoOfComponents
+    (firstQuadrantSingleColumnTotalExtendedXIso K p)
+    (firstQuadrantSingleColumnTotalExtendedXIso_d K p)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the extended comparison in a degree explicitly in the image. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIsoOfEq_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p q n : ℕ)
+    (h : p + q = n) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f n ≫
+      (firstQuadrantSingleColumnTotalExtendedXIsoOfEq L p q n h).hom =
+    (firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p q n h).hom ≫
+      (HomologicalComplex.extendMap (f.f p)
+        (firstQuadrantColumnDegreeEmbedding p)).f n := by
+  subst n
+  dsimp [firstQuadrantSingleColumnTotalExtendedXIsoOfEq]
+  rw [HomologicalComplex.extendMap_f (f.f p)
+    (firstQuadrantColumnDegreeEmbedding p) rfl]
+  simp only [Category.id_comp, Category.assoc, Iso.inv_hom_id_assoc]
+  rw [← Category.assoc,
+    firstQuadrantSingleColumnTotalScaledXIso_naturality,
+    Category.assoc]
+
+/-- Naturality of the componentwise extended comparison in every total degree. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p n : ℕ) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f n ≫
+      (firstQuadrantSingleColumnTotalExtendedXIso L p n).hom =
+    (firstQuadrantSingleColumnTotalExtendedXIso K p n).hom ≫
+      (HomologicalComplex.extendMap (f.f p)
+        (firstQuadrantColumnDegreeEmbedding p)).f n := by
+  by_cases hn : p ≤ n
+  · let q := n - p
+    have h : p + q = n := by
+      dsimp [q]
+      omega
+    rw [firstQuadrantSingleColumnTotalExtendedXIso_eq L p q n h,
+      firstQuadrantSingleColumnTotalExtendedXIso_eq K p q n h]
+    exact firstQuadrantSingleColumnTotalExtendedXIsoOfEq_naturality f p q n h
+  · have hz : IsZero
+        (((firstQuadrantSingleColumn K p).total
+          (ComplexShape.down ℕ)).X n) :=
+      firstQuadrantSingleColumnTotalX_isZero_of_not_exists K p n (by
+        intro q h
+        apply hn
+        omega)
+    exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the single-column total/extension chain isomorphism. -/
+@[reassoc]
+public theorem firstQuadrantSingleColumnTotalExtendedIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ) ≫
+      (firstQuadrantSingleColumnTotalExtendedIso L p).hom =
+    (firstQuadrantSingleColumnTotalExtendedIso K p).hom ≫
+      HomologicalComplex.extendMap (f.f p)
+        (firstQuadrantColumnDegreeEmbedding p) := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  exact firstQuadrantSingleColumnTotalExtendedXIso_naturality f p n
+
+set_option linter.style.haveILetI false in
+/-- A quasi-isomorphism on the sole column remains a quasi-isomorphism after placing that
+column in any outer degree and totalizing. -/
+public theorem firstQuadrantSingleColumnTotal_quasiIso
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ)
+    (hcolumn : QuasiIso (f.f p)) :
+    QuasiIso (HomologicalComplex₂.total.map
+      (firstQuadrantSingleColumnMap f p) (ComplexShape.down ℕ)) := by
+  let a := HomologicalComplex₂.total.map
+    (firstQuadrantSingleColumnMap f p) (ComplexShape.down ℕ)
+  let b := (firstQuadrantSingleColumnTotalExtendedIso L p).hom
+  let c := (firstQuadrantSingleColumnTotalExtendedIso K p).hom
+  let d := HomologicalComplex.extendMap (f.f p)
+    (firstQuadrantColumnDegreeEmbedding p)
+  letI : IsIso b := by dsimp [b]; infer_instance
+  letI : IsIso c := by dsimp [c]; infer_instance
+  letI : QuasiIso (f.f p) := hcolumn
+  letI : QuasiIso d := by
+    dsimp [d]
+    infer_instance
+  letI : QuasiIso (a ≫ b) := by
+    rw [show a ≫ b = c ≫ d from
+      firstQuadrantSingleColumnTotalExtendedIso_naturality f p]
+    infer_instance
+  exact quasiIso_of_comp_right a b
+
+set_option linter.unnecessarySimpa false in
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrantColumnPrefixMap_XIso_hom
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N p : ℕ) (hp : p ≤ N) :
+    (firstQuadrantColumnPrefixMap f N).f p ≫
+      (firstQuadrantColumnPrefixXIso L N p hp).hom =
+    (firstQuadrantColumnPrefixXIso K N p hp).hom ≫ f.f p := by
+  simpa [firstQuadrantColumnPrefixMap, firstQuadrantColumnPrefixXIso] using
+    (HomologicalComplex.stupidTruncMap_stupidTruncXIso_hom
+      f (firstQuadrantColumnPrefixEmbedding N)
+      (i := ⟨p, hp⟩) (i' := p) rfl)
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrantColumnPrefixSuccInclusion_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantColumnPrefixMap f p ≫
+      firstQuadrantColumnPrefixSuccInclusion L p =
+    firstQuadrantColumnPrefixSuccInclusion K p ≫
+      firstQuadrantColumnPrefixMap f (p + 1) := by
+  apply HomologicalComplex.hom_ext
+  intro q
+  by_cases hq : q ≤ p
+  · change (firstQuadrantColumnPrefixMap f p).f q ≫
+      firstQuadrantColumnPrefixSuccInclusionComponent L p q =
+        firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+          (firstQuadrantColumnPrefixMap f (p + 1)).f q
+    rw [firstQuadrantColumnPrefixSuccInclusionComponent_of_le L p q hq,
+      firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p q hq]
+    rw [← Category.assoc,
+      firstQuadrantColumnPrefixMap_XIso_hom f p q hq]
+    rw [Category.assoc, Category.assoc]
+    apply (cancel_mono
+      (firstQuadrantColumnPrefixXIso L (p + 1) q (by omega)).hom).1
+    simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id]
+    rw [firstQuadrantColumnPrefixMap_XIso_hom f (p + 1) q (by omega)]
+    simp
+  · have hpq : p < q := by omega
+    change (firstQuadrantColumnPrefixMap f p).f q ≫
+      firstQuadrantColumnPrefixSuccInclusionComponent L p q =
+        firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+          (firstQuadrantColumnPrefixMap f (p + 1)).f q
+    rw [firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero L p q hpq,
+      firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero K p q hpq,
+      comp_zero, zero_comp]
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrantColumnPrefixToLast_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantColumnPrefixMap f p ≫
+      firstQuadrantColumnPrefixToLast L p =
+    firstQuadrantColumnPrefixToLast K p ≫
+      firstQuadrantSingleColumnMap f p := by
+  apply HomologicalComplex.hom_ext
+  intro q
+  by_cases hq : q = p
+  · subst q
+    change (firstQuadrantColumnPrefixMap f p).f p ≫
+      firstQuadrantColumnPrefixToLastComponent L p p =
+        firstQuadrantColumnPrefixToLastComponent K p p ≫
+          (firstQuadrantSingleColumnMap f p).f p
+    rw [firstQuadrantColumnPrefixToLastComponent_self,
+      firstQuadrantColumnPrefixToLastComponent_self]
+    rw [← Category.assoc,
+      firstQuadrantColumnPrefixMap_XIso_hom f p p le_rfl]
+    dsimp only [firstQuadrantSingleColumnMap, firstQuadrantSingleColumnXIso]
+    rw [
+      HomologicalComplex.single_map_f_self]
+    simp
+  · change (firstQuadrantColumnPrefixMap f p).f q ≫
+      firstQuadrantColumnPrefixToLastComponent L p q =
+        firstQuadrantColumnPrefixToLastComponent K p q ≫
+          (firstQuadrantSingleColumnMap f p).f q
+    rw [firstQuadrantColumnPrefixToLastComponent_eq_zero L p q hq,
+      firstQuadrantColumnPrefixToLastComponent_eq_zero K p q hq,
+      comp_zero, zero_comp]
+
+/-- A bicomplex map induces a morphism between the successor short exact sequences of its
+finite column filtrations. -/
+public noncomputable def firstQuadrantColumnPrefixSuccShortComplexMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantColumnPrefixSuccShortComplex K p ⟶
+      firstQuadrantColumnPrefixSuccShortComplex L p where
+  τ₁ := firstQuadrantColumnPrefixMap f p
+  τ₂ := firstQuadrantColumnPrefixMap f (p + 1)
+  τ₃ := firstQuadrantSingleColumnMap f (p + 1)
+  comm₁₂ := firstQuadrantColumnPrefixSuccInclusion_naturality f p
+  comm₂₃ := firstQuadrantColumnPrefixToLast_naturality f (p + 1)
+
+set_option linter.style.haveILetI false in
+/-- The zeroth prefix is already its sole-column quotient. -/
+public theorem firstQuadrantColumnPrefixToLast_zero_isIso
+    (K : FirstQuadrantBicomplex) :
+    IsIso (firstQuadrantColumnPrefixToLast K 0) := by
+  letI : ∀ q : ℕ, IsIso ((firstQuadrantColumnPrefixToLast K 0).f q) := fun q => by
+    by_cases hq : q = 0
+    · subst q
+      change IsIso (firstQuadrantColumnPrefixToLastComponent K 0 0)
+      rw [firstQuadrantColumnPrefixToLastComponent_self]
+      infer_instance
+    · have hpos : 0 < q := by omega
+      change IsIso (firstQuadrantColumnPrefixToLastComponent K 0 q)
+      rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K 0 q hq]
+      exact (firstQuadrantColumnPrefix_isZero_X K 0 q hpos).isIso
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) 0 (K.X 0) q hq) _
+  exact HomologicalComplex.Hom.isIso_of_components _
+
+@[reassoc]
+public theorem firstQuadrantColumnPrefixToLast_total_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f p)
+        (ComplexShape.down ℕ) ≫
+      HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast L p)
+        (ComplexShape.down ℕ) =
+    HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast K p)
+        (ComplexShape.down ℕ) ≫
+      HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ) := by
+  rw [← HomologicalComplex₂.total.map_comp,
+    ← HomologicalComplex₂.total.map_comp]
+  exact congrArg
+    (fun g => HomologicalComplex₂.total.map g (ComplexShape.down ℕ))
+    (firstQuadrantColumnPrefixToLast_naturality f p)
+
+set_option linter.style.haveILetI false in
+/-- If every single-column layer map becomes a quasi-isomorphism on totalization, then every
+finite column-prefix map does as well. -/
+public theorem firstQuadrantFinitePrefixTotal_quasiIso_of_singleColumns
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hsingle : ∀ p : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ))) :
+    ∀ N : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ)) := by
+  intro N
+  induction N with
+  | zero =>
+      let a := HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f 0)
+        (ComplexShape.down ℕ)
+      let b := HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast L 0)
+        (ComplexShape.down ℕ)
+      let c := HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast K 0)
+        (ComplexShape.down ℕ)
+      let d := HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f 0)
+        (ComplexShape.down ℕ)
+      letI : IsIso (firstQuadrantColumnPrefixToLast K 0) :=
+        firstQuadrantColumnPrefixToLast_zero_isIso K
+      letI : IsIso (firstQuadrantColumnPrefixToLast L 0) :=
+        firstQuadrantColumnPrefixToLast_zero_isIso L
+      letI : IsIso b := by
+        dsimp [b]
+        exact (HomologicalComplex₂.total.mapIso
+          (asIso (firstQuadrantColumnPrefixToLast L 0))
+          (ComplexShape.down ℕ)).isIso_hom
+      letI : IsIso c := by
+        dsimp [c]
+        exact (HomologicalComplex₂.total.mapIso
+          (asIso (firstQuadrantColumnPrefixToLast K 0))
+          (ComplexShape.down ℕ)).isIso_hom
+      letI : QuasiIso d := hsingle 0
+      letI : QuasiIso (a ≫ b) := by
+        rw [show a ≫ b = c ≫ d from
+          firstQuadrantColumnPrefixToLast_total_naturality f 0]
+        infer_instance
+      exact quasiIso_of_comp_right a b
+  | succ N ih =>
+      let T := HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+      let S₁ := firstQuadrantColumnPrefixSuccShortComplex K N
+      let S₂ := firstQuadrantColumnPrefixSuccShortComplex L N
+      let φ := T.mapShortComplex.map
+        (firstQuadrantColumnPrefixSuccShortComplexMap f N)
+      have hS₁ : S₁.ShortExact :=
+        firstQuadrantColumnPrefixSuccShortComplex_shortExact K N
+      have hS₂ : S₂.ShortExact :=
+        firstQuadrantColumnPrefixSuccShortComplex_shortExact L N
+      have hTS₁ : (S₁.map T).ShortExact := firstQuadrantTotal_shortExact S₁ hS₁
+      have hTS₂ : (S₂.map T).ShortExact := firstQuadrantTotal_shortExact S₂ hS₂
+      have h₁ : QuasiIso φ.τ₁ := by
+        change QuasiIso
+          (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+            (ComplexShape.down ℕ))
+        exact ih
+      have h₃ : QuasiIso φ.τ₃ := by
+        change QuasiIso
+          (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f (N + 1))
+            (ComplexShape.down ℕ))
+        exact hsingle (N + 1)
+      have h₂ : QuasiIso φ.τ₂ :=
+        quasiIso_middle_of_shortExact φ hTS₁ hTS₂ h₁ h₃
+      exact h₂
+
+/-- Columnwise quasi-isomorphisms after totalizing the individual layers imply a
+quasi-isomorphism on the full first-quadrant total. -/
+public theorem firstQuadrantTotal_quasiIso_of_singleColumns
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hsingle : ∀ p : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ))) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) :=
+  firstQuadrantTotal_quasiIso_of_all_prefixes f
+    (firstQuadrantFinitePrefixTotal_quasiIso_of_singleColumns f hsingle)
+
+/-- Koszul symmetry for the standard first-quadrant total-complex signs. -/
+public instance firstQuadrantTotalComplexShapeSymmetry :
+    TotalComplexShapeSymmetry
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ) where
+  symm p q := add_comm q p
+  σ p q := (-1 : ℤˣ) ^ (p * q)
+  σ_ε₁ := by
+    rintro p p' hp q
+    change p' + 1 = p at hp
+    subst p
+    dsimp
+    rw [mul_one, add_mul, one_mul, pow_add, pow_mul]
+    exact mul_comm _ _
+  σ_ε₂ := by
+    rintro p q q' hq
+    change q' + 1 = q at hq
+    subst q
+    dsimp
+    rw [one_mul, mul_add, mul_one, pow_add, mul_assoc,
+      Int.units_mul_self, mul_one]
+
+/-- Flip a first-quadrant bicomplex map across the diagonal. -/
+public def firstQuadrantFlipMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) : K.flip ⟶ L.flip :=
+  (HomologicalComplex₂.flipFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map f
+
+/-- A column map of the flipped bicomplex is exactly the corresponding horizontal row map. -/
+public theorem firstQuadrantFlipMap_column_eq_horizontalRowMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (q : ℕ) :
+    (firstQuadrantFlipMap f).f q = firstQuadrantHorizontalRowMap f q := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrant_totalFlipIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) :
+    HomologicalComplex₂.total.map (firstQuadrantFlipMap f)
+        (ComplexShape.down ℕ) ≫
+      (L.totalFlipIso (ComplexShape.down ℕ)).hom =
+    (K.totalFlipIso (ComplexShape.down ℕ)).hom ≫
+      HomologicalComplex₂.total.map f (ComplexShape.down ℕ) := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  dsimp only [HomologicalComplex.comp_f]
+  rw [HomologicalComplex₂.ιTotal_map_assoc,
+    HomologicalComplex₂.ιTotal_totalFlipIso_f_hom,
+    HomologicalComplex₂.ιTotal_totalFlipIso_f_hom_assoc]
+  change (f.f q).f p ≫ (_ • _) = (_ • _) ≫ _
+  rw [Linear.comp_units_smul, Linear.units_smul_comp,
+    HomologicalComplex₂.ιTotal_map]
+
+set_option linter.style.haveILetI false in
+/-- It is enough to prove the single-column total statement after flipping: total symmetry then
+returns the desired quasi-isomorphism for the original bicomplex map. -/
+public theorem firstQuadrantTotal_quasiIso_of_flipped_singleColumns
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hsingle : ∀ p : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map
+        (firstQuadrantSingleColumnMap (firstQuadrantFlipMap f) p)
+        (ComplexShape.down ℕ))) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) := by
+  let g := HomologicalComplex₂.total.map (firstQuadrantFlipMap f)
+    (ComplexShape.down ℕ)
+  let eK := (K.totalFlipIso (ComplexShape.down ℕ)).hom
+  let eL := (L.totalFlipIso (ComplexShape.down ℕ)).hom
+  let h := HomologicalComplex₂.total.map f (ComplexShape.down ℕ)
+  letI : QuasiIso g := firstQuadrantTotal_quasiIso_of_singleColumns
+    (firstQuadrantFlipMap f) hsingle
+  letI : IsIso eK := by dsimp [eK]; infer_instance
+  letI : IsIso eL := by dsimp [eL]; infer_instance
+  letI : QuasiIso (eK ≫ h) := by
+    rw [← show g ≫ eL = eK ≫ h from firstQuadrant_totalFlipIso_naturality f]
+    infer_instance
+  exact quasiIso_of_comp_left eK h
+
+/-- Rowwise quasi-isomorphisms of first-quadrant bicomplexes induce a quasi-isomorphism on
+their direct-sum total complexes. -/
+public theorem firstQuadrantTotal_quasiIso_of_rows
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hrow : ∀ q : ℕ, QuasiIso (firstQuadrantHorizontalRowMap f q)) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) := by
+  apply firstQuadrantTotal_quasiIso_of_flipped_singleColumns f
+  intro q
+  apply firstQuadrantSingleColumnTotal_quasiIso
+    (firstQuadrantFlipMap f) q
+  rw [firstQuadrantFlipMap_column_eq_horizontalRowMap]
+  exact hrow q
+
+/-- The exact generic rowwise-totalization proposition used by the boundary-seven Cech
+assembly is therefore unconditional. -/
+public theorem firstQuadrantRowwiseTotalization :
+    FirstQuadrantRowwiseTotalization := by
+  intro K L f hrow
+  exact firstQuadrantTotal_quasiIso_of_rows f hrow
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantSingleColumnTotal.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantSingleColumnTotal.lean
@@ -1,0 +1,190 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantTotalComplex
+
+/-!
+# The total complex of the horizontal zero column
+
+This file supplies the missing unitor identifying the direct-sum total of a bicomplex supported
+only in horizontal degree zero with its unique nonzero column.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- Put a chain complex in horizontal degree zero of a first-quadrant bicomplex. -/
+public noncomputable abbrev firstQuadrantSingleZeroBicomplex
+    (K : FirstQuadrantChainComplex) : FirstQuadrantBicomplex :=
+  (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).obj K
+
+/-- The degree-zero horizontal column is canonically the original chain complex. -/
+public noncomputable def firstQuadrantSingleZeroColumnIso
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).X 0 ≅ K :=
+  HomologicalComplex.singleObjXSelf (ComplexShape.down ℕ) 0 K
+
+/-- The canonical inclusion of the actual horizontal zero column into the total complex. -/
+public noncomputable def firstQuadrantZeroColumnToTotal
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).X 0 ⟶
+      (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) where
+  f n := (firstQuadrantSingleZeroBicomplex K).ιTotal
+    (ComplexShape.down ℕ) 0 n n (by simp)
+  comm' := by
+    intro i j hij
+    change _ ≫
+      ((firstQuadrantSingleZeroBicomplex K).D₁
+        (ComplexShape.down ℕ) i j +
+       (firstQuadrantSingleZeroBicomplex K).D₂
+        (ComplexShape.down ℕ) i j) =
+      ((firstQuadrantSingleZeroBicomplex K).X 0).d i j ≫ _
+    rw [Preadditive.comp_add,
+      HomologicalComplex₂.ι_D₁,
+      HomologicalComplex₂.ι_D₂]
+    have hd₁ : (firstQuadrantSingleZeroBicomplex K).d₁
+        (ComplexShape.down ℕ) 0 i j = 0 := by
+      apply HomologicalComplex₂.d₁_eq_zero
+      simp
+    rw [hd₁, zero_add]
+    rw [HomologicalComplex₂.d₂_eq
+      (firstQuadrantSingleZeroBicomplex K)
+      (ComplexShape.down ℕ) 0 hij j (by simp)]
+    change (ComplexShape.down ℕ).ε 0 • _ = _
+    rw [ComplexShape.ε_zero, one_smul]
+
+/-- The canonical inclusion of the unique nonzero column into the total complex. -/
+public noncomputable def firstQuadrantSingleZeroToTotal
+    (K : FirstQuadrantChainComplex) :
+    K ⟶ (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) :=
+  (firstQuadrantSingleZeroColumnIso K).inv ≫ firstQuadrantZeroColumnToTotal K
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The componentwise projection used to descend from the total complex. -/
+public noncomputable def firstQuadrantSingleZeroTotalComponent
+    (K : FirstQuadrantChainComplex) (n p q : ℕ)
+    (hpq : (ComplexShape.down ℕ).π (ComplexShape.down ℕ)
+      (ComplexShape.down ℕ) (p, q) = n) :
+    ((firstQuadrantSingleZeroBicomplex K).X p).X q ⟶ K.X n := by
+  rcases p with _ | p
+  · change 0 + q = n at hpq
+    simp only [zero_add] at hpq
+    subst n
+    exact (firstQuadrantSingleZeroColumnIso K).hom.f q
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantSingleZeroTotalComponent_zero
+    (K : FirstQuadrantChainComplex) (q : ℕ) :
+    firstQuadrantSingleZeroTotalComponent K q 0 q (by simp) =
+      (firstQuadrantSingleZeroColumnIso K).hom.f q := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Project the total complex supported in horizontal degree zero back to its unique column. -/
+public noncomputable def firstQuadrantTotalToSingleZero
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) ⟶ K where
+  f n := (firstQuadrantSingleZeroBicomplex K).totalDesc
+    (firstQuadrantSingleZeroTotalComponent K n)
+  comm' := by
+    intro i j hij
+    apply HomologicalComplex₂.total.hom_ext
+    intro p q hpq
+    rcases p with _ | p
+    · have hqi : q = i := by simpa using hpq
+      subst q
+      rw [← Category.assoc,
+        HomologicalComplex₂.ι_totalDesc]
+      simp only [firstQuadrantSingleZeroTotalComponent_zero]
+      rw [(firstQuadrantSingleZeroColumnIso K).hom.comm i j]
+      change ((firstQuadrantSingleZeroBicomplex K).X 0).d i j ≫
+          (firstQuadrantSingleZeroColumnIso K).hom.f j =
+        (firstQuadrantSingleZeroBicomplex K).ιTotal
+            (ComplexShape.down ℕ) 0 i i (by simp) ≫
+            ((firstQuadrantSingleZeroBicomplex K).D₁
+                (ComplexShape.down ℕ) i j +
+              (firstQuadrantSingleZeroBicomplex K).D₂
+                (ComplexShape.down ℕ) i j) ≫ _
+      rw [← Category.assoc, Preadditive.comp_add,
+        HomologicalComplex₂.ι_D₁,
+        HomologicalComplex₂.ι_D₂]
+      have hd₁ : (firstQuadrantSingleZeroBicomplex K).d₁
+          (ComplexShape.down ℕ) 0 i j = 0 := by
+        apply HomologicalComplex₂.d₁_eq_zero
+        simp
+      rw [hd₁, zero_add]
+      rw [HomologicalComplex₂.d₂_eq
+        (firstQuadrantSingleZeroBicomplex K)
+        (ComplexShape.down ℕ) 0 hij j (by simp)]
+      simp
+    · have hzcol : IsZero
+          ((firstQuadrantSingleZeroBicomplex K).X (p + 1)) :=
+        HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) 0 K (p + 1) (by omega)
+      have hz : IsZero
+          (((firstQuadrantSingleZeroBicomplex K).X (p + 1)).X q) :=
+        (HomologicalComplex.eval AddCommGrpCat
+          (ComplexShape.down ℕ) q).map_isZero hzcol
+      exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Projection after inclusion is the identity of the unique column. -/
+public theorem firstQuadrantSingleZeroToTotal_comp_projection
+    (K : FirstQuadrantChainComplex) :
+    firstQuadrantSingleZeroToTotal K ≫ firstQuadrantTotalToSingleZero K =
+      𝟙 K := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  change (firstQuadrantSingleZeroBicomplex K).ιTotal
+      (ComplexShape.down ℕ) 0 n n (by simp) ≫
+      (firstQuadrantSingleZeroBicomplex K).totalDesc _ = 𝟙 _
+  rw [HomologicalComplex₂.ι_totalDesc]
+  simp [firstQuadrantSingleZeroTotalComponent,
+    firstQuadrantSingleZeroColumnIso]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Inclusion after projection is the identity of the total complex. -/
+public theorem firstQuadrantTotalToSingleZero_comp_inclusion
+    (K : FirstQuadrantChainComplex) :
+    firstQuadrantTotalToSingleZero K ≫ firstQuadrantSingleZeroToTotal K =
+      𝟙 _ := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  rcases p with _ | p
+  · have hqn : n = q := by simpa using hpq.symm
+    cases hqn
+    simp only [HomologicalComplex.comp_f, HomologicalComplex.id_f]
+    dsimp only [firstQuadrantTotalToSingleZero,
+      firstQuadrantSingleZeroToTotal]
+    rw [← Category.assoc, HomologicalComplex₂.ι_totalDesc]
+    simp [firstQuadrantSingleZeroTotalComponent,
+      firstQuadrantSingleZeroColumnIso]
+    rfl
+  · have hzcol : IsZero
+        ((firstQuadrantSingleZeroBicomplex K).X (p + 1)) :=
+      HomologicalComplex.isZero_single_obj_X
+        (ComplexShape.down ℕ) 0 K (p + 1) (by omega)
+    have hz : IsZero
+        (((firstQuadrantSingleZeroBicomplex K).X (p + 1)).X q) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) q).map_isZero hzcol
+    exact hz.eq_of_src _ _
+
+/-- The total of a first-quadrant bicomplex concentrated in horizontal degree zero is canonically
+isomorphic to its sole column. -/
+public noncomputable def firstQuadrantSingleZeroTotalIso
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) ≅ K where
+  hom := firstQuadrantTotalToSingleZero K
+  inv := firstQuadrantSingleZeroToTotal K
+  hom_inv_id := firstQuadrantTotalToSingleZero_comp_inclusion K
+  inv_hom_id := firstQuadrantSingleZeroToTotal_comp_projection K
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantTotalComplex.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantTotalComplex.lean
@@ -1,0 +1,277 @@
+module
+
+public import Mathlib.Algebra.Category.Grp.AB
+public import Mathlib.Algebra.Homology.HomologySequenceLemmas
+public import Mathlib.Algebra.Homology.TotalComplex
+
+/-!
+# First-quadrant total complexes
+
+This file isolates the homological-algebra input needed to pass from exact rows of a
+first-quadrant bicomplex to its direct-sum total complex.  Mathlib constructs total complexes,
+but currently has no spectral-sequence or filtered-complex theorem connecting row homology to
+total homology.  We first record the exact finite-filtration induction that such a construction
+must feed.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+public abbrev FirstQuadrantBicomplex :=
+  HomologicalComplex₂ AddCommGrpCat (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+
+public abbrev FirstQuadrantChainComplex :=
+  HomologicalComplex AddCommGrpCat (ComplexShape.down ℕ)
+
+/-- The finite antidiagonal indexing the summands of a first-quadrant total complex in degree
+`n`.  This is deliberately the same fiber used by `GradedObject.mapObj` inside
+`HomologicalComplex₂.total`. -/
+public abbrev FirstQuadrantTotalFiber (n : ℕ) :=
+  {pq : ℕ × ℕ // pq.1 + pq.2 = n}
+
+noncomputable instance (n : ℕ) : Finite (FirstQuadrantTotalFiber n) := by
+  apply Finite.of_injective
+    (fun pq : FirstQuadrantTotalFiber n =>
+      (⟨pq.1.1, by omega⟩ : Fin (n + 1)))
+  intro pq rs h
+  apply Subtype.ext
+  apply Prod.ext
+  · exact Fin.ext_iff.mp h
+  · have h₁ : pq.1.1 = rs.1.1 := Fin.ext_iff.mp h
+    omega
+
+/-- Before taking the coproduct in total degree `n`, a bicomplex gives the discrete diagram of
+its entries on the `n`th antidiagonal. -/
+@[simps]
+public def firstQuadrantTotalFiberDiagramFunctor (n : ℕ) :
+    FirstQuadrantBicomplex ⥤ (Discrete (FirstQuadrantTotalFiber n) ⥤ AddCommGrpCat) where
+  obj K := Discrete.functor fun pq => (K.X pq.1.1).X pq.1.2
+  map f := Discrete.natTrans fun pq => (f.f pq.as.1.1).f pq.as.1.2
+
+/-- Evaluation of the antidiagonal diagram is the corresponding pair of evaluations of the
+bicomplex. -/
+public def firstQuadrantTotalFiberEvaluationIso (n : ℕ)
+    (pq : Discrete (FirstQuadrantTotalFiber n)) :
+    firstQuadrantTotalFiberDiagramFunctor n ⋙
+        (evaluation (Discrete (FirstQuadrantTotalFiber n)) AddCommGrpCat).obj pq ≅
+      HomologicalComplex.eval FirstQuadrantChainComplex (ComplexShape.down ℕ) pq.as.1.1 ⋙
+        HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) pq.as.1.2 :=
+  NatIso.ofComponents (fun _ => Iso.refl _)
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteLimits (firstQuadrantTotalFiberDiagramFunctor n) := by
+  apply preservesFiniteLimits_of_evaluation
+  intro pq
+  exact preservesFiniteLimits_of_natIso
+    (firstQuadrantTotalFiberEvaluationIso n pq).symm
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteColimits (firstQuadrantTotalFiberDiagramFunctor n) := by
+  apply preservesFiniteColimits_of_evaluation
+  intro pq
+  exact preservesFiniteColimits_of_natIso
+    (firstQuadrantTotalFiberEvaluationIso n pq).symm
+
+/-- The exact functor which takes the finite coproduct of all entries in total degree `n`. -/
+public noncomputable def firstQuadrantTotalDegreeFunctor (n : ℕ) :
+    FirstQuadrantBicomplex ⥤ AddCommGrpCat :=
+  firstQuadrantTotalFiberDiagramFunctor n ⋙
+    colim (J := Discrete (FirstQuadrantTotalFiber n)) (C := AddCommGrpCat)
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteLimits (firstQuadrantTotalDegreeFunctor n) := by
+  dsimp only [firstQuadrantTotalDegreeFunctor]
+  infer_instance
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteColimits (firstQuadrantTotalDegreeFunctor n) := by
+  dsimp only [firstQuadrantTotalDegreeFunctor]
+  infer_instance
+
+@[simp]
+public theorem firstQuadrant_totalDegree_eq_add (pq : ℕ × ℕ) :
+    ComplexShape.π (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+      (ComplexShape.down ℕ) pq = pq.1 + pq.2 := rfl
+
+/-- Evaluation of Mathlib's direct-sum total complex agrees with the explicit finite
+antidiagonal coproduct functor above. -/
+public noncomputable def firstQuadrantTotalEvaluationIso (n : ℕ) :
+    HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ) ⋙
+      HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) n ≅
+    firstQuadrantTotalDegreeFunctor n :=
+  NatIso.ofComponents (fun _ => Iso.refl _)
+
+noncomputable instance : PreservesFiniteLimits
+    (HomologicalComplex₂.totalFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)) := by
+  refine ⟨by
+    intro J _ _
+    apply HomologicalComplex.preservesLimitsOfShape_of_eval
+    intro n
+    exact preservesLimitsOfShape_of_natIso
+      (J := J) (firstQuadrantTotalEvaluationIso n).symm⟩
+
+noncomputable instance : PreservesFiniteColimits
+    (HomologicalComplex₂.totalFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)) := by
+  refine ⟨by
+    intro J _ _
+    apply HomologicalComplex.preservesColimitsOfShape_of_eval
+    intro n
+    exact preservesColimitsOfShape_of_natIso
+      (J := J) (firstQuadrantTotalEvaluationIso n).symm⟩
+
+/-- Direct-sum totalization of first-quadrant bicomplexes preserves short exact sequences.
+The finiteness of each antidiagonal is the essential boundedness input. -/
+public theorem firstQuadrantTotal_shortExact
+    (S : ShortComplex FirstQuadrantBicomplex) (hS : S.ShortExact) :
+    (S.map (HomologicalComplex₂.totalFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ))).ShortExact :=
+  hS.map_of_exact _
+
+set_option linter.style.haveILetI false in
+/-- The middle-map version of two-out-of-three for a morphism of short exact sequences of
+complexes.  Mathlib currently only packages the corresponding result for `τ₃`; this form is
+the induction step needed for finite filtrations. -/
+public theorem quasiIso_middle_of_shortExact
+    {C ι : Type*} [Category* C] [Abelian C] {c : ComplexShape ι}
+    {S₁ S₂ : ShortComplex (HomologicalComplex C c)}
+    (f : S₁ ⟶ S₂) (hS₁ : S₁.ShortExact) (hS₂ : S₂.ShortExact)
+    (h₁ : QuasiIso f.τ₁) (h₃ : QuasiIso f.τ₃) : QuasiIso f.τ₂ := by
+  rw [quasiIso_iff]
+  intro i
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  have hi₁ : QuasiIsoAt f.τ₁ i := (quasiIso_iff f.τ₁).mp h₁ i
+  have hi₃ : QuasiIsoAt f.τ₃ i := (quasiIso_iff f.τ₃).mp h₃ i
+  let φ := (HomologicalComplex.homologyFunctor C c i).mapShortComplex.map f
+  letI : IsIso φ.τ₁ := by
+    dsimp [φ]
+    exact (quasiIsoAt_iff_isIso_homologyMap f.τ₁ i).mp hi₁
+  letI : IsIso φ.τ₃ := by
+    dsimp [φ]
+    exact (quasiIsoAt_iff_isIso_homologyMap f.τ₃ i).mp hi₃
+  letI : Mono φ.τ₂ := by
+    by_cases hi : ∃ k, c.Rel k i
+    · obtain ⟨k, hki⟩ := hi
+      have hk₃ : QuasiIsoAt f.τ₃ k := (quasiIso_iff f.τ₃).mp h₃ k
+      letI : IsIso (HomologicalComplex.homologyMap f.τ₃ k) :=
+        (quasiIsoAt_iff_isIso_homologyMap f.τ₃ k).mp hk₃
+      let Φ := ((CategoryTheory.ComposableArrows.δ₀Functor ⋙
+        CategoryTheory.ComposableArrows.δ₀Functor).map
+          (HomologicalComplex.HomologySequence.mapComposableArrows₅
+            f hS₁ hS₂ k i hki))
+      apply CategoryTheory.Abelian.mono_of_epi_of_mono_of_mono Φ
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₁ k i hki).δ₀.δ₀
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₂ k i hki).δ₀.δ₀
+      · change Epi (HomologicalComplex.homologyMap f.τ₃ k)
+        infer_instance
+      · change Mono (HomologicalComplex.homologyMap f.τ₁ i)
+        infer_instance
+      · change Mono (HomologicalComplex.homologyMap f.τ₃ i)
+        infer_instance
+    · letI : Mono (HomologicalComplex.homologyMap S₂.f i) := by
+        have := hS₂.mono_f
+        exact HomologicalComplex.mono_homologyMap_of_mono_of_not_rel S₂.f i
+          (by simpa using hi)
+      apply ShortComplex.mono_of_mono_of_mono_of_mono φ (hS₁.homology_exact₂ i)
+      · change Mono (HomologicalComplex.homologyMap S₂.f i)
+        infer_instance
+      all_goals infer_instance
+  letI : Epi φ.τ₂ := by
+    by_cases hi : ∃ j, c.Rel i j
+    · obtain ⟨j, hij⟩ := hi
+      have hj₁ : QuasiIsoAt f.τ₁ j := (quasiIso_iff f.τ₁).mp h₁ j
+      letI : IsIso (HomologicalComplex.homologyMap f.τ₁ j) :=
+        (quasiIsoAt_iff_isIso_homologyMap f.τ₁ j).mp hj₁
+      let Φ := ((CategoryTheory.ComposableArrows.δlastFunctor ⋙
+        CategoryTheory.ComposableArrows.δlastFunctor).map
+          (HomologicalComplex.HomologySequence.mapComposableArrows₅
+            f hS₁ hS₂ i j hij))
+      apply CategoryTheory.Abelian.epi_of_epi_of_epi_of_mono Φ
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₁ i j hij).δlast.δlast
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₂ i j hij).δlast.δlast
+      · change Epi (HomologicalComplex.homologyMap f.τ₁ i)
+        infer_instance
+      · change Epi (HomologicalComplex.homologyMap f.τ₃ i)
+        infer_instance
+      · change Mono (HomologicalComplex.homologyMap f.τ₁ j)
+        infer_instance
+    · letI : Epi (HomologicalComplex.homologyMap S₁.g i) := by
+        have := hS₁.epi_g
+        exact HomologicalComplex.epi_homologyMap_of_epi_of_not_rel S₁.g i
+          (by simpa using hi)
+      apply ShortComplex.epi_of_epi_of_epi_of_epi φ (hS₂.homology_exact₂ i)
+      · change Epi (HomologicalComplex.homologyMap S₁.g i)
+        infer_instance
+      all_goals infer_instance
+  change IsIso φ.τ₂
+  apply isIso_of_mono_of_epi
+
+set_option linter.style.haveILetI false in
+/-- A map between two filtrations is a quasi-isomorphism at every finite stage if it is one on
+the initial subobject and on every successive quotient.  The isomorphisms `glue` allow adjacent
+short exact sequences to use merely isomorphic (rather than definitionally equal) models for a
+filtration stage. -/
+public theorem quasiIso_of_successive_shortExact_extensions
+    {C ι : Type*} [Category* C] [Abelian C] {c : ComplexShape ι}
+    (A B : ℕ → ShortComplex (HomologicalComplex C c))
+    (f : ∀ n, A n ⟶ B n)
+    (hA : ∀ n, (A n).ShortExact) (hB : ∀ n, (B n).ShortExact)
+    (hbase : QuasiIso (f 0).τ₁) (hgraded : ∀ n, QuasiIso (f n).τ₃)
+    (glue : ∀ n, Arrow.mk (f n).τ₂ ≅ Arrow.mk (f (n + 1)).τ₁) :
+    ∀ n, QuasiIso (f n).τ₂ := by
+  intro n
+  induction n with
+  | zero =>
+      exact quasiIso_middle_of_shortExact (f 0) (hA 0) (hB 0) hbase (hgraded 0)
+  | succ n ih =>
+      letI : QuasiIso (f n).τ₂ := ih
+      have hleft : QuasiIso (f (n + 1)).τ₁ :=
+        quasiIso_of_arrow_mk_iso
+          (f n).τ₂ (f (n + 1)).τ₁ (glue n)
+      exact quasiIso_middle_of_shortExact (f (n + 1))
+        (hA (n + 1)) (hB (n + 1)) hleft (hgraded (n + 1))
+
+/-- The finite-filtration criterion specialized to first-quadrant direct-sum totals.  This is the
+formal endpoint consumed by a brutal-column filtration: one supplies short exact bicomplex
+layers, quasi-isomorphisms on the initial layer and the single-column quotients, and the canonical
+identifications between consecutive stages. -/
+public theorem firstQuadrantTotal_quasiIso_of_successive_extensions
+    (A B : ℕ → ShortComplex FirstQuadrantBicomplex)
+    (f : ∀ n, A n ⟶ B n)
+    (hA : ∀ n, (A n).ShortExact) (hB : ∀ n, (B n).ShortExact)
+    (hbase : QuasiIso
+      ((HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map
+          (f 0).τ₁))
+    (hgraded : ∀ n, QuasiIso
+      ((HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map
+          (f n).τ₃))
+    (glue : ∀ n, Arrow.mk (f n).τ₂ ≅ Arrow.mk (f (n + 1)).τ₁) :
+    ∀ n, QuasiIso
+      ((HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map
+          (f n).τ₂) := by
+  let T := HomologicalComplex₂.totalFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+  apply quasiIso_of_successive_shortExact_extensions
+    (fun n => (A n).map T) (fun n => (B n).map T)
+    (fun n => T.mapShortComplex.map (f n))
+  · exact fun n => firstQuadrantTotal_shortExact (A n) (hA n)
+  · exact fun n => firstQuadrantTotal_shortExact (B n) (hB n)
+  · exact hbase
+  · exact hgraded
+  · exact fun n => T.mapArrow.mapIso (glue n)
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- add first-quadrant direct-sum total complexes and column filtrations
- prove single-column and rowwise totalization quasi-isomorphism criteria
- construct the boundary-seven Cech global comparison
- identify its rows and globalize both augmentations

## Dependency

This is the fourth continuation PR, stacked on #61.

## Verification

- lake build SphereSixComplex.Topology.FirstQuadrantRowwiseTotalizationProof SphereSixComplex.Topology.BoundarySevenCechRowIdentificationsProof SphereSixComplex.Topology.BoundarySevenCechRowwiseGlobalizationProof
- Build completed successfully: 3199 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders in the 10 added files