### PR TITLE
Compare ordered boundary Cech summands

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedLocalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedLocalComparison.lean
@@ -1,0 +1,382 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTuples
+
+/-!
+# Local comparison for ordered boundary-seven Cech tuples
+
+For an ordered tuple with proper support, its common simplicial face is representable by the
+standard simplex on the complementary vertices.  The order on `Fin 8` makes this
+representability canonical.  We use it to compare that common face with singular simplices in
+the corresponding intersection of affine face neighbourhoods.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+set_option maxHeartbeats 800000
+
+/-- The dimension of the standard simplex whose vertices are the complement of a proper Cech
+tuple's support. -/
+public def boundarySevenProperCechTupleFaceDimension
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) : ℕ :=
+  a.1.supportᶜ.card - 1
+
+/-- The canonical increasing enumeration of the complementary vertices. -/
+public noncomputable def boundarySevenProperCechTupleFaceOrderIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    Fin (boundarySevenProperCechTupleFaceDimension a + 1) ≃o
+      ↑(a.1.supportᶜ) := by
+  apply Finset.orderIsoOfFin
+  have hpos : 0 < a.1.supportᶜ.card :=
+    Finset.card_pos.mpr a.support_compl_nonempty
+  dsimp [boundarySevenProperCechTupleFaceDimension]
+  omega
+
+/-- The common face is canonically representable by the standard simplex on the complementary
+vertices. -/
+public noncomputable def boundarySevenProperCechTupleFaceIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≅
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) :=
+  SSet.stdSimplex.isoOfRepresentableBy
+    (SSet.stdSimplex.faceRepresentableBy a.1.supportᶜ
+      (boundarySevenProperCechTupleFaceDimension a)
+      (boundarySevenProperCechTupleFaceOrderIso a))
+
+/-- The simplex-category arrow which inserts the increasing complementary vertices into the
+eight ambient vertices. -/
+public noncomputable def boundarySevenProperCechTupleComplementSimplexHom
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    SimplexCategory.mk (boundarySevenProperCechTupleFaceDimension a) ⟶
+      SimplexCategory.mk 7 :=
+  SimplexCategory.Hom.mk
+    { toFun := fun j ↦ (boundarySevenProperCechTupleFaceOrderIso a j).1
+      monotone' := fun _ _ h ↦
+        (boundarySevenProperCechTupleFaceOrderIso a).monotone h }
+
+/-- The common complementary face includes canonically in the simplicial boundary. -/
+public noncomputable def boundarySevenProperCechTupleFaceToBoundarySSetMap
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ⟶
+      (∂Δ[7] : SSet.{0}) := by
+  let i := Classical.choose a.support_nonempty
+  have hi : i ∈ a.1.support := Classical.choose_spec a.support_nonempty
+  apply SSet.Subcomplex.homOfLE
+  have hface : SSet.stdSimplex.face a.1.supportᶜ ≤
+      SSet.stdSimplex.face ({i} : Finset (Fin 8))ᶜ :=
+    (SSet.stdSimplex.face_le_face_iff _ _).mpr (by
+      intro j hj
+      simp only [Finset.mem_compl, Finset.mem_singleton]
+      intro hji
+      subst j
+      exact (Finset.mem_compl.mp hj) hi)
+  exact hface.trans (SSet.face_singleton_compl_le_boundary i)
+
+/-- Forgetting the boundary subtype recovers the ordinary inclusion of the common face in the
+ambient standard simplex. -/
+@[reassoc]
+public theorem boundarySevenProperCechTupleFaceToBoundarySSetMap_comp_inclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenProperCechTupleFaceToBoundarySSetMap a ≫
+        (SSet.boundary 7).ι =
+      (SSet.stdSimplex.face a.1.supportᶜ).ι := by
+  simp [boundarySevenProperCechTupleFaceToBoundarySSetMap]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The representability isomorphism uses exactly the increasing complementary-vertex
+inclusion. -/
+public theorem boundarySevenProperCechTupleFaceIso_hom_comp_faceInclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (boundarySevenProperCechTupleFaceIso a).hom ≫
+        (SSet.stdSimplex.face a.1.supportᶜ).ι =
+      SSet.stdSimplex.map
+        (boundarySevenProperCechTupleComplementSimplexHom a) := by
+  rfl
+
+/-- Insert the barycentric coordinates of the complementary standard simplex into the eight
+coordinates of the ambient seven-simplex. -/
+public noncomputable def boundarySevenProperCechTupleCoordinatePoint
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    stdSimplex ℝ (Fin 8) :=
+  stdSimplex.map
+    (fun j ↦ (boundarySevenProperCechTupleFaceOrderIso a j).1)
+    (SimplexCategory.toTopHomeo
+      (SimplexCategory.mk (boundarySevenProperCechTupleFaceDimension a)) x)
+
+/-- In barycentric coordinates, realizing the common-face inclusion is the literal insertion
+of the complementary coordinates. -/
+public theorem boundarySevenComparisonToStdSimplex_faceToBoundary_faceIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    boundarySevenComparisonToStdSimplex
+        (SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a)
+          (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).hom x)) =
+      boundarySevenProperCechTupleCoordinatePoint a x := by
+  unfold boundarySevenComparisonToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a)
+          (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).hom x))) = _
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    boundarySevenProperCechTupleFaceToBoundarySSetMap_comp_inclusion]
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    boundarySevenProperCechTupleFaceIso_hom_comp_faceInclusion]
+  exact SimplexCategory.toTopHomeo_naturality_apply
+    (boundarySevenProperCechTupleComplementSimplexHom a) x
+
+/-- Coordinates indexed by the tuple's support vanish in the complementary coordinate point. -/
+public theorem boundarySevenProperCechTupleCoordinatePoint_apply_of_mem_support
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}))
+    {i : Fin 8} (hi : i ∈ a.1.support) :
+    boundarySevenProperCechTupleCoordinatePoint a x i = 0 := by
+  apply stdSimplex_map_apply_eq_zero_of_not_mem_range
+  rintro ⟨j, rfl⟩
+  exact (Finset.mem_compl.mp
+    (boundarySevenProperCechTupleFaceOrderIso a j).2) hi
+
+/-- The complementary coordinate point lies in the ordinary simplex boundary. -/
+public theorem boundarySevenProperCechTupleCoordinatePoint_mem_boundary
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    ∃ i, boundarySevenProperCechTupleCoordinatePoint a x i = 0 := by
+  exact ⟨a.1 0,
+    boundarySevenProperCechTupleCoordinatePoint_apply_of_mem_support a x
+      (a.1.mem_support 0)⟩
+
+/-- The literal coordinate inclusion from the complementary standard simplex into the
+intersection belonging to the tuple support. -/
+public noncomputable def boundarySevenProperCechTupleStandardSimplexToIntersection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    C((SSet.toTop.obj
+        (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) : Type),
+      boundarySevenFaceNeighborhoodIntersection a.1.support) := by
+  let q : C((SSet.toTop.obj
+        (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) : Type),
+      StandardSimplexBoundary 7) :=
+    ⟨fun x ↦ ⟨boundarySevenProperCechTupleCoordinatePoint a x,
+        boundarySevenProperCechTupleCoordinatePoint_mem_boundary a x⟩,
+      (stdSimplex.continuous_map
+        (fun j ↦ (boundarySevenProperCechTupleFaceOrderIso a j).1)).comp
+          (SimplexCategory.toTopHomeo
+            (SimplexCategory.mk
+              (boundarySevenProperCechTupleFaceDimension a))).continuous |>.subtype_mk _⟩
+  have hmem (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+      boundarySevenRealizationHomeomorphStandardBoundary.symm (q x) ∈
+        boundarySevenFaceNeighborhoodIntersection a.1.support := by
+    rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+    intro i hi
+    have hcoord :
+        boundarySevenComparisonToStdSimplex
+            (boundarySevenRealizationHomeomorphStandardBoundary.symm (q x)) i = 0 := by
+      rw [← boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+      rw [Homeomorph.apply_symm_apply]
+      exact boundarySevenProperCechTupleCoordinatePoint_apply_of_mem_support a x hi
+    rw [hcoord]
+    norm_num
+  exact
+    ⟨fun x ↦
+        ⟨boundarySevenRealizationHomeomorphStandardBoundary.symm (q x), hmem x⟩,
+      (boundarySevenRealizationHomeomorphStandardBoundary.symm.continuous.comp
+        q.continuous).subtype_mk (fun x ↦ hmem x)⟩
+
+/-- The underlying boundary point of the literal coordinate map. -/
+@[simp]
+public theorem boundarySevenProperCechTupleStandardSimplexToIntersection_val
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    (boundarySevenProperCechTupleStandardSimplexToIntersection a x).1 =
+      boundarySevenRealizationHomeomorphStandardBoundary.symm
+        ⟨boundarySevenProperCechTupleCoordinatePoint a x,
+          boundarySevenProperCechTupleCoordinatePoint_mem_boundary a x⟩ := by
+  rfl
+
+/-- The literal coordinate inclusion with the common face itself as source.  The inverse of the
+canonical representability isomorphism merely changes from face coordinates to the ordered
+complementary standard-simplex coordinates. -/
+public noncomputable def boundarySevenProperCechTupleFaceToIntersection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    C((SSet.toTop.obj
+        (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) : Type),
+      boundarySevenFaceNeighborhoodIntersection a.1.support) :=
+  (boundarySevenProperCechTupleStandardSimplexToIntersection a).comp
+    (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).inv).hom
+
+/-- The underlying inclusion of a face-neighbourhood intersection into the realized simplicial
+boundary. -/
+public def boundarySevenFaceNeighborhoodIntersectionToBoundary
+    (s : Finset (Fin 8)) :
+    C(boundarySevenFaceNeighborhoodIntersection s,
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :=
+  ⟨Subtype.val, continuous_subtype_val⟩
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The literal local coordinate map, followed by the ambient inclusion, is exactly the
+realization of the canonical inclusion of the common face in the simplicial boundary. -/
+public theorem boundarySevenProperCechTupleFaceToIntersection_comp_ambientInclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (boundarySevenFaceNeighborhoodIntersectionToBoundary a.1.support).comp
+        (boundarySevenProperCechTupleFaceToIntersection a) =
+      (SSet.toTop.map
+        (boundarySevenProperCechTupleFaceToBoundarySSetMap a)).hom := by
+  apply ContinuousMap.ext
+  intro x
+  let J := boundarySevenProperCechTupleFaceIso a
+  change (boundarySevenProperCechTupleFaceToIntersection a x).1 =
+    SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a) x
+  change (boundarySevenProperCechTupleStandardSimplexToIntersection a
+    (SSet.toTop.map J.inv x)).1 = _
+  apply boundarySevenRealizationHomeomorphStandardBoundary.injective
+  rw [boundarySevenProperCechTupleStandardSimplexToIntersection_val]
+  rw [Homeomorph.apply_symm_apply]
+  apply Subtype.ext
+  change boundarySevenProperCechTupleCoordinatePoint a
+      (SSet.toTop.map J.inv x) =
+    (boundarySevenRealizationHomeomorphStandardBoundary
+      (SSet.toTop.map
+        (boundarySevenProperCechTupleFaceToBoundarySSetMap a) x) :
+          stdSimplex ℝ (Fin 8))
+  rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+  rw [← boundarySevenComparisonToStdSimplex_faceToBoundary_faceIso a
+    (SSet.toTop.map J.inv x)]
+  congr 2
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    Iso.inv_hom_id, SSet.toTop.map_id]
+  rfl
+
+/-- Categorical form of the ambient-inclusion compatibility, stated with the standard
+topological-subset inclusion used by the Cech comparison. -/
+@[reassoc]
+public theorem boundarySevenProperCechTupleFaceToIntersection_comp_subsetInclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    TopCat.ofHom (boundarySevenProperCechTupleFaceToIntersection a) ≫
+        topologicalSubsetInclusion
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          (boundarySevenFaceNeighborhoodIntersection a.1.support) =
+      SSet.toTop.map
+        (boundarySevenProperCechTupleFaceToBoundarySSetMap a) := by
+  apply ConcreteCategory.hom_ext
+  intro x
+  exact DFunLike.congr_fun
+    (boundarySevenProperCechTupleFaceToIntersection_comp_ambientInclusion a) x
+
+/-- The canonical simplicial map from the common face to singular simplices in the matching
+face-neighbourhood intersection. -/
+public noncomputable def boundarySevenProperCechTupleLocalComparisonSSetMap
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ⟶
+      TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) :=
+  sSetTopAdj.unit.app
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ≫
+    TopCat.toSSet.map
+      (TopCat.ofHom (boundarySevenProperCechTupleFaceToIntersection a))
+
+/-- The integral chain map induced by the ordered-tuple local comparison. -/
+public noncomputable def boundarySevenProperCechTupleLocalIntegralComparison
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}).chainComplex
+        (AddCommGrpCat.of ℤ) ⟶
+      (TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))).chainComplex
+          (AddCommGrpCat.of ℤ) :=
+  SSet.chainComplexMap
+    (boundarySevenProperCechTupleLocalComparisonSSetMap a)
+      (AddCommGrpCat.of ℤ)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Precomposing the face comparison by its canonical representability isomorphism gives the
+standard-simplex comparison associated to the literal coordinate inclusion. -/
+public theorem boundarySevenProperCechTupleFaceIso_hom_comp_localComparisonSSetMap
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (boundarySevenProperCechTupleFaceIso a).hom ≫
+        boundarySevenProperCechTupleLocalComparisonSSetMap a =
+      sSetTopAdj.unit.app
+          (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≫
+        TopCat.toSSet.map (TopCat.ofHom
+          (boundarySevenProperCechTupleStandardSimplexToIntersection a)) := by
+  let J := boundarySevenProperCechTupleFaceIso a
+  have hnat := sSetTopAdj.unit.naturality J.hom
+  rw [boundarySevenProperCechTupleLocalComparisonSSetMap]
+  change (((𝟭 SSet).map J.hom ≫ sSetTopAdj.unit.app
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0})) ≫
+    TopCat.toSSet.map (TopCat.ofHom
+      (boundarySevenProperCechTupleFaceToIntersection a))) = _
+  rw [hnat]
+  change (sSetTopAdj.unit.app
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≫
+    TopCat.toSSet.map (SSet.toTop.map J.hom)) ≫
+      TopCat.toSSet.map (TopCat.ofHom
+        (boundarySevenProperCechTupleFaceToIntersection a)) = _
+  simp only [Category.assoc]
+  rw [← Functor.map_comp]
+  apply congrArg (fun f ↦ sSetTopAdj.unit.app
+    (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≫
+      TopCat.toSSet.map f)
+  apply ConcreteCategory.hom_ext
+  intro x
+  change boundarySevenProperCechTupleStandardSimplexToIntersection a
+      (SSet.toTop.map J.inv (SSet.toTop.map J.hom x)) =
+    boundarySevenProperCechTupleStandardSimplexToIntersection a x
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    Iso.hom_inv_id, SSet.toTop.map_id]
+  rfl
+
+/-- Chain-level form of the preceding representability identity. -/
+public theorem boundarySevenProperCechTupleFaceIso_chainMap_comp_localIntegralComparison
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    SSet.chainComplexMap (boundarySevenProperCechTupleFaceIso a).hom
+        (AddCommGrpCat.of ℤ) ≫
+      boundarySevenProperCechTupleLocalIntegralComparison a =
+    standardSimplexToContractibleSingularChainMap (AddCommGrpCat.of ℤ)
+      (boundarySevenProperCechTupleFaceDimension a)
+      (boundarySevenProperCechTupleStandardSimplexToIntersection a) := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  have h := F.congr_map
+    (boundarySevenProperCechTupleFaceIso_hom_comp_localComparisonSSetMap a)
+  rw [Functor.map_comp, Functor.map_comp] at h
+  exact h
+
+/-- The canonical integral comparison on every proper ordered Cech tuple is a
+quasi-isomorphism. -/
+public theorem boundarySevenProperCechTupleLocalIntegralComparison_quasiIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    QuasiIso (boundarySevenProperCechTupleLocalIntegralComparison a) := by
+  let P := SSet.chainComplexMap (boundarySevenProperCechTupleFaceIso a).hom
+    (AddCommGrpCat.of ℤ)
+  let L := boundarySevenProperCechTupleLocalIntegralComparison a
+  letI : IsIso (boundarySevenProperCechTupleFaceIso a).hom := inferInstance
+  letI : IsIso P := by
+    dsimp only [P]
+    infer_instance
+  let hstandard : QuasiIso
+      (standardSimplexToContractibleSingularChainMap (AddCommGrpCat.of ℤ)
+        (boundarySevenProperCechTupleFaceDimension a)
+        (boundarySevenProperCechTupleStandardSimplexToIntersection a)) :=
+    standardSimplexToBoundarySevenFaceNeighborhoodIntersection_quasiIso
+      (AddCommGrpCat.of ℤ) (boundarySevenProperCechTupleFaceDimension a)
+      a.1.support a.support_nonempty a.2
+      (boundarySevenProperCechTupleStandardSimplexToIntersection a)
+  have hcomp : QuasiIso (P ≫ L) := by
+    rw [show P ≫ L =
+        standardSimplexToContractibleSingularChainMap (AddCommGrpCat.of ℤ)
+          (boundarySevenProperCechTupleFaceDimension a)
+          (boundarySevenProperCechTupleStandardSimplexToIntersection a) by
+      exact boundarySevenProperCechTupleFaceIso_chainMap_comp_localIntegralComparison a]
+    exact hstandard
+  exact quasiIso_of_comp_left P L
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedSource.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedSource.lean
@@ -1,0 +1,396 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTuples
+public import Mathlib.CategoryTheory.Limits.Types.Coproducts
+
+/-!
+# Ordered-intersection decomposition of the simplicial-face Cech nerve
+
+In a fixed outer Cech degree, a compatible ordered tuple of facets of the seven-simplex
+has common simplicial face indexed by the complement of the tuple's support.  Full-support
+tuples have empty common face and are omitted.  This file identifies the coproduct of all
+remaining common faces with the corresponding object of the canonical pullback Cech nerve.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The common simplicial face belonging to a proper ordered Cech tuple. -/
+public abbrev boundarySevenOrderedSourceCommonFace
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) : SSet.{0} :=
+  (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0})
+
+/-- The common face includes into the facet selected in slot `i`, expressed in the standard
+`Delta[6]` parametrization used by the face presentation. -/
+public noncomputable def boundarySevenOrderedSourceCommonFaceToFacet
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFace a ⟶ (Δ[6] : SSet.{0}) :=
+  SSet.Subcomplex.homOfLE (by
+      rw [SSet.stdSimplex.face_le_face_iff]
+      intro j hj
+      apply Finset.mem_compl.mpr
+      simp only [Finset.mem_singleton]
+      intro hja
+      subst j
+      exact (Finset.mem_compl.mp hj) (a.1.mem_support i)) ≫
+    (SSet.stdSimplex.faceSingletonComplIso (a.1 i)).inv
+
+/-- The common face includes into the simplicial boundary. -/
+public noncomputable def boundarySevenOrderedSourceCommonFaceToBoundary
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCommonFace a ⟶ (∂Δ[7] : SSet.{0}) :=
+  boundarySevenOrderedSourceCommonFaceToFacet a 0 ≫
+    SSet.boundary.ι (a.1 0)
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCommonFaceToBoundary a ≫
+        (SSet.boundary 7).ι =
+      (SSet.stdSimplex.face a.1.supportᶜ).ι := by
+  simp [boundarySevenOrderedSourceCommonFaceToBoundary,
+    boundarySevenOrderedSourceCommonFaceToFacet]
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFaceToFacet a i ≫
+        SSet.boundary.ι (a.1 i) =
+      boundarySevenOrderedSourceCommonFaceToBoundary a := by
+  apply (cancel_mono (SSet.boundary 7).ι).1
+  simp only [Category.assoc,
+    boundarySevenOrderedSourceCommonFaceToFacet,
+    SSet.boundary.faceSingletonComplIso_inv_ι,
+    SSet.boundary.faceι_ι,
+    SSet.Subcomplex.homOfLE_ι]
+  exact (boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion a).symm
+
+/-- The leg from a common face to the coproduct presentation object in slot `i`. -/
+public noncomputable def boundarySevenOrderedSourcePresentationLeg
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFace a ⟶
+      boundarySevenSimplicialFacePresentationSource :=
+  boundarySevenOrderedSourceCommonFaceToFacet a i ≫
+    Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) (a.1 i)
+
+@[reassoc]
+public theorem boundarySevenOrderedSourcePresentationLeg_comp_presentation
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourcePresentationLeg a i ≫
+        boundarySevenSimplicialFacePresentation =
+      boundarySevenOrderedSourceCommonFaceToBoundary a := by
+  simp [boundarySevenOrderedSourcePresentationLeg,
+    boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary]
+
+/-- A common face determines a point of the pullback Cech object. -/
+public noncomputable def boundarySevenOrderedSourceCechSummand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCommonFace a ⟶
+      boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n :=
+  WidePullback.lift (boundarySevenOrderedSourceCommonFaceToBoundary a)
+    (boundarySevenOrderedSourcePresentationLeg a)
+    (boundarySevenOrderedSourcePresentationLeg_comp_presentation a)
+
+/-- The canonical map from the coproduct of proper common faces to the source Cech object. -/
+public noncomputable def boundarySevenOrderedSourceToCech
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      boundarySevenOrderedSourceCommonFace a) ⟶
+      boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n :=
+  Sigma.desc boundarySevenOrderedSourceCechSummand
+
+/-- Projection from the source Cech object to one selected presentation leg. -/
+public noncomputable def boundarySevenSourceCechProjection
+    (n : SimplexCategoryᵒᵖ) (i : Fin (n.unop.len + 1)) :
+    boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n ⟶
+      boundarySevenSimplicialFacePresentationSource :=
+  WidePullback.π
+    (fun _ : Fin (n.unop.len + 1) ↦
+      boundarySevenSimplicialFacePresentation) i
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem boundarySevenOrderedSourceCechSummand_comp_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCechSummand a ≫
+        boundarySevenSourceCechProjection n i =
+      boundarySevenOrderedSourcePresentationLeg a i := by
+  simpa [boundarySevenOrderedSourceCechSummand,
+    boundarySevenSourceCechProjection,
+    boundarySevenSimplicialFaceAugmentedCechNerve,
+    boundarySevenSimplicialFacePresentationArrow] using
+      (WidePullback.lift_π
+        (fun _ : Fin (n.unop.len + 1) ↦
+          boundarySevenSimplicialFacePresentation)
+        (boundarySevenOrderedSourceCommonFaceToBoundary a)
+        (boundarySevenOrderedSourcePresentationLeg a)
+        (boundarySevenOrderedSourcePresentationLeg_comp_presentation a) i)
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceToCech_comp_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n ↦
+        boundarySevenOrderedSourceCommonFace b) a ≫
+        boundarySevenOrderedSourceToCech n ≫
+        boundarySevenSourceCechProjection n i =
+      boundarySevenOrderedSourcePresentationLeg a i := by
+  rw [← Category.assoc, boundarySevenOrderedSourceToCech, Sigma.ι_desc]
+  exact boundarySevenOrderedSourceCechSummand_comp_projection a i
+
+public noncomputable def boundarySevenSourceCoproductAppIsColimit
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) :
+    IsColimit (Cofan.mk ((∐ X).obj q) (fun i => (Sigma.ι X i).app q)) :=
+  isColimitCofanMkObjOfIsColimit ((evaluation _ _).obj q) X
+    (fun i ↦ Sigma.ι X i) (coproductIsCoproduct X)
+
+public theorem boundarySevenSourceCoproduct_app_jointly_surjective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ)
+    (x : (∐ X).obj q) : ∃ i y, (Sigma.ι X i).app q y = x :=
+  Cofan.inj_jointly_surjective_of_isColimit
+    (boundarySevenSourceCoproductAppIsColimit X q) x
+
+public theorem boundarySevenSourceCoproduct_app_index_eq
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ)
+    {i j : ι} (x : (X i).obj q) (y : (X j).obj q)
+    (h : (Sigma.ι X i).app q x = (Sigma.ι X j).app q y) : i = j :=
+  Cofan.eq_of_inj_apply_eq_of_isColimit
+    (boundarySevenSourceCoproductAppIsColimit X q) x y h
+
+public theorem boundarySevenSourceCoproduct_app_injective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) (i : ι) :
+    Function.Injective ((Sigma.ι X i).app q) :=
+  Cofan.inj_injective_of_isColimit
+    (boundarySevenSourceCoproductAppIsColimit X q) i
+
+public theorem boundarySevenSourceCech_app_ext
+    {n q : SimplexCategoryᵒᵖ}
+    (x y : (boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n).obj q)
+    (h : ∀ i, (boundarySevenSourceCechProjection n i).app q x =
+      (boundarySevenSourceCechProjection n i).app q y) : x = y := by
+  let arrows := fun _ : Fin (n.unop.len + 1) ↦
+    boundarySevenSimplicialFacePresentation
+  let D := WidePullbackShape.wideCospan
+    (boundarySevenSimplicialFacePresentationArrow.right)
+    (fun _ : Fin (n.unop.len + 1) ↦
+      boundarySevenSimplicialFacePresentationArrow.left) arrows
+  let ev := (evaluation SimplexCategoryᵒᵖ (Type _)).obj q
+  have hlim : IsLimit (Functor.mapCone ev (limit.cone D)) :=
+    isLimitOfPreserves ev (limit.isLimit D)
+  apply (Types.isLimitEquivSections hlim).injective
+  apply Subtype.ext
+  funext j
+  cases j with
+  | none =>
+      have hx := congrArg (fun k ↦ k.app q x) (WidePullback.π_arrow arrows 0)
+      have hy := congrArg (fun k ↦ k.app q y) (WidePullback.π_arrow arrows 0)
+      exact hx.symm.trans
+        ((congrArg (fun z ↦ boundarySevenSimplicialFacePresentation.app q z)
+          (h 0)).trans hy)
+  | some i => exact h i
+
+public theorem boundarySevenOrderedSourceCommonFaceToFacet_app_injective
+    {n q : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Function.Injective
+      ((boundarySevenOrderedSourceCommonFaceToFacet a i).app q) := by
+  let _ : Mono (boundarySevenOrderedSourceCommonFaceToFacet a i) := by
+    dsimp [boundarySevenOrderedSourceCommonFaceToFacet]
+    infer_instance
+  exact (CategoryTheory.mono_iff_injective _).mp inferInstance
+
+public theorem boundarySevenOrderedSourceToCech_app_injective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Injective ((boundarySevenOrderedSourceToCech n).app q) := by
+  let X := fun a : BoundarySevenProperCechTuple n ↦
+    boundarySevenOrderedSourceCommonFace a
+  let Y := fun _j : Fin 8 ↦ (Δ[6] : SSet.{0})
+  intro x y hxy
+  obtain ⟨a, xa, rfl⟩ :=
+    boundarySevenSourceCoproduct_app_jointly_surjective X q x
+  obtain ⟨b, xb, rfl⟩ :=
+    boundarySevenSourceCoproduct_app_jointly_surjective X q y
+  have hcoord (i : Fin (n.unop.len + 1)) :
+      (Sigma.ι Y (a.1 i)).app q
+          ((boundarySevenOrderedSourceCommonFaceToFacet a i).app q xa) =
+        (Sigma.ι Y (b.1 i)).app q
+          ((boundarySevenOrderedSourceCommonFaceToFacet b i).app q xb) := by
+    have hproj := congrArg
+      (fun z ↦ (boundarySevenSourceCechProjection n i).app q z) hxy
+    have ha := congrArg (fun k ↦ k.app q xa)
+      (boundarySevenOrderedSourceToCech_comp_projection a i)
+    have hb := congrArg (fun k ↦ k.app q xb)
+      (boundarySevenOrderedSourceToCech_comp_projection b i)
+    exact ha.symm.trans (hproj.trans hb)
+  have hab : a = b := by
+    apply Subtype.ext
+    funext i
+    exact boundarySevenSourceCoproduct_app_index_eq Y q _ _ (hcoord i)
+  subst b
+  have hfacet :
+      (boundarySevenOrderedSourceCommonFaceToFacet a 0).app q xa =
+        (boundarySevenOrderedSourceCommonFaceToFacet a 0).app q xb :=
+    boundarySevenSourceCoproduct_app_injective Y q (a.1 0) (hcoord 0)
+  have habSimplex : xa = xb :=
+    boundarySevenOrderedSourceCommonFaceToFacet_app_injective a 0 hfacet
+  exact congrArg ((Sigma.ι X a).app q) habSimplex
+
+public theorem boundarySevenSimplicialFacePresentation_iota_app_injective
+    (q : SimplexCategoryᵒᵖ) (i : Fin 8) :
+    Function.Injective ((SSet.boundary.ι i).app q) := by
+  exact (CategoryTheory.mono_iff_injective _).mp inferInstance
+
+public theorem boundarySevenOrderedSourceToCech_app_surjective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Surjective ((boundarySevenOrderedSourceToCech n).app q) := by
+  rcases q with ⟨⟨d⟩⟩
+  let q : SimplexCategoryᵒᵖ := Opposite.op (SimplexCategory.mk d)
+  let X := fun a : BoundarySevenProperCechTuple n ↦
+    boundarySevenOrderedSourceCommonFace a
+  let Y := fun _j : Fin 8 ↦ (Δ[6] : SSet.{0})
+  intro x
+  have hex (i : Fin (n.unop.len + 1)) :
+      ∃ j y, (Sigma.ι Y j).app q y =
+        (boundarySevenSourceCechProjection n i).app q x :=
+    boundarySevenSourceCoproduct_app_jointly_surjective Y q _
+  choose a y hy using hex
+  let arrows := fun _ : Fin (n.unop.len + 1) ↦
+    boundarySevenSimplicialFacePresentation
+  have hboundary (i : Fin (n.unop.len + 1)) :
+      (SSet.boundary.ι (a i)).app q (y i) =
+        (SSet.boundary.ι (a 0)).app q (y 0) := by
+    have hpresi := congrArg (fun k ↦ k.app q (y i))
+      (boundarySevenSimplicialFacePresentation_iota (a i))
+    have hpres0 := congrArg (fun k ↦ k.app q (y 0))
+      (boundarySevenSimplicialFacePresentation_iota (a 0))
+    have hyi := congrArg
+      (fun z ↦ boundarySevenSimplicialFacePresentation.app q z) (hy i)
+    have hy0 := congrArg
+      (fun z ↦ boundarySevenSimplicialFacePresentation.app q z) (hy 0)
+    have hpi := congrArg (fun k ↦ k.app q x)
+      (WidePullback.π_arrow arrows i)
+    have hp0 := congrArg (fun k ↦ k.app q x)
+      (WidePullback.π_arrow arrows 0)
+    exact hpresi.symm.trans
+      (hyi.trans (hpi.trans (hp0.symm.trans (hy0.symm.trans hpres0))))
+  let zBoundary := (SSet.boundary.ι (a 0)).app q (y 0)
+  let zOrder := (SSet.stdSimplex.objEquiv zBoundary.1).toOrderHom
+  have havoid (k : Fin (q.unop.len + 1)) : zOrder k ∉
+      BoundarySevenCechTuple.support a := by
+    intro hk
+    obtain ⟨i, -, hai⟩ := Finset.mem_image.mp hk
+    have hiFace :=
+      ((SSet.stdSimplex.faceSingletonComplIso (a i)).hom.app q (y i)).2
+    rw [SSet.stdSimplex.mem_face_iff] at hiFace
+    have hne :
+        (SSet.stdSimplex.objEquiv
+            ((SSet.stdSimplex.faceSingletonComplIso (a i)).hom.app q (y i)).1).toOrderHom k ≠
+          a i := by
+      dsimp [q] at hiFace ⊢
+      simpa using hiFace k
+    have hfacetBoundary :
+        (SSet.stdSimplex.faceSingletonComplIso (a i)).hom ≫
+            SSet.boundary.faceι (a i) =
+          SSet.boundary.ι (a i) := by
+      apply (cancel_mono (SSet.boundary 7).ι).1
+      simp
+    have himage := congrArg Subtype.val
+      (ConcreteCategory.congr_hom (congr_app hfacetBoundary q) (y i))
+    apply hne
+    have himagek := congrArg
+      (fun t : (Δ[7] : SSet.{0}).obj q ↦
+        (SSet.stdSimplex.objEquiv t).toOrderHom k) himage
+    have hboundaryk := congrArg
+      (fun t : (∂Δ[7] : SSet.{0}).obj q ↦
+        (SSet.stdSimplex.objEquiv t.1).toOrderHom k) (hboundary i)
+    exact himagek.trans (hboundaryk.trans hai.symm)
+  have hproper : BoundarySevenCechTuple.support a ≠ Finset.univ := by
+    intro ha
+    exact havoid 0 (by rw [ha]; simp)
+  let ap : BoundarySevenProperCechTuple n := ⟨a, hproper⟩
+  let z : (boundarySevenOrderedSourceCommonFace ap).obj q :=
+    ⟨zBoundary.1, by
+      rw [SSet.stdSimplex.mem_face_iff]
+      intro k
+      dsimp [q, zOrder] at havoid ⊢
+      simpa using havoid k⟩
+  have hz (i : Fin (n.unop.len + 1)) :
+      (boundarySevenOrderedSourceCommonFaceToFacet ap i).app q z = y i := by
+    apply boundarySevenSimplicialFacePresentation_iota_app_injective q (a i)
+    have hfac :
+        (SSet.boundary.ι (a i)).app q
+            ((boundarySevenOrderedSourceCommonFaceToFacet ap i).app q z) =
+          (boundarySevenOrderedSourceCommonFaceToBoundary ap).app q z := by
+      simpa using ConcreteCategory.congr_hom
+        (congr_app
+          (boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary ap i) q) z
+    rw [hfac]
+    have hcommon :
+        (boundarySevenOrderedSourceCommonFaceToBoundary ap).app q z = zBoundary := by
+      apply Subtype.ext
+      have hinc := ConcreteCategory.congr_hom
+        (congr_app
+          (boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion ap) q) z
+      change ((boundarySevenOrderedSourceCommonFaceToBoundary ap).app q z).1 = z.1 at hinc
+      simpa [z] using hinc
+    rw [hcommon]
+    exact (hboundary i).symm
+  refine ⟨(Sigma.ι X ap).app q z, ?_⟩
+  apply boundarySevenSourceCech_app_ext
+  intro i
+  calc
+    (boundarySevenSourceCechProjection n i).app q
+        ((boundarySevenOrderedSourceToCech n).app q ((Sigma.ι X ap).app q z)) =
+      (Sigma.ι Y (a i)).app q
+        ((boundarySevenOrderedSourceCommonFaceToFacet ap i).app q z) := by
+          simpa [X, Y, boundarySevenOrderedSourcePresentationLeg] using
+            congrArg (fun k ↦ k.app q z)
+            (boundarySevenOrderedSourceToCech_comp_projection ap i)
+    _ = (Sigma.ι Y (a i)).app q (y i) := congrArg _ (hz i)
+    _ = (boundarySevenSourceCechProjection n i).app q x := hy i
+
+/-- In every outer degree, the coproduct of proper common simplicial faces is canonically
+isomorphic to the corresponding object of the simplicial-face Cech nerve. -/
+public noncomputable def boundarySevenOrderedSourceCechIso
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      boundarySevenOrderedSourceCommonFace a) ≅
+      boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n := by
+  let _ : ∀ q, IsIso ((boundarySevenOrderedSourceToCech n).app q) := fun q ↦
+    (CategoryTheory.isIso_iff_bijective _).mpr
+      ⟨boundarySevenOrderedSourceToCech_app_injective n q,
+        boundarySevenOrderedSourceToCech_app_surjective n q⟩
+  let _ : IsIso (boundarySevenOrderedSourceToCech n) :=
+    NatIso.isIso_of_isIso_app (boundarySevenOrderedSourceToCech n)
+  exact asIso (boundarySevenOrderedSourceToCech n)
+
+@[simp]
+public theorem boundarySevenOrderedSourceCechIso_hom
+    (n : SimplexCategoryᵒᵖ) :
+    (boundarySevenOrderedSourceCechIso n).hom =
+      boundarySevenOrderedSourceToCech n :=
+  rfl
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceCechIso_hom_comp_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n ↦
+        boundarySevenOrderedSourceCommonFace b) a ≫
+        (boundarySevenOrderedSourceCechIso n).hom ≫
+        boundarySevenSourceCechProjection n i =
+      boundarySevenOrderedSourcePresentationLeg a i := by
+  rw [boundarySevenOrderedSourceCechIso_hom]
+  exact boundarySevenOrderedSourceToCech_comp_projection a i
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedTarget.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedTarget.lean
@@ -1,0 +1,435 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTuples
+public import Mathlib.CategoryTheory.Limits.Types.Coproducts
+
+/-!
+# Ordered-tuple decomposition of the boundary-seven target Cech nerve
+
+The iterated pullback in each outer Cech degree is the coproduct of the singular simplicial
+sets of the corresponding ordered intersections.  Since the intersection of all eight face
+neighbourhoods is empty, only tuples with proper support occur.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+public abbrev boundarySevenTargetAmbient : TopCat :=
+  SSet.toTop.obj (∂Δ[7] : SSet.{0})
+
+/-- Inclusion of an ordered proper intersection into one of its selected cover members. -/
+public def boundarySevenTargetIntersectionToMember
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support) ⟶
+      TopCat.of (boundarySevenComparisonFaceNeighborhood (a.1 i)) :=
+  TopCat.ofHom
+    { toFun := fun x => ⟨x.1, by
+        exact (mem_boundarySevenFaceNeighborhoodIntersection_iff a.1.support x).mp x.2
+          (a.1 i) (BoundarySevenCechTuple.mem_support a.1 i)⟩
+      continuous_toFun := by fun_prop }
+
+@[reassoc]
+public theorem boundarySevenTargetIntersectionToMember_comp_inclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenTargetIntersectionToMember a i ≫
+        topologicalSubsetInclusion boundarySevenTargetAmbient
+          (boundarySevenComparisonFaceNeighborhood (a.1 i)) =
+      topologicalSubsetInclusion boundarySevenTargetAmbient
+        (boundarySevenFaceNeighborhoodIntersection a.1.support) := by
+  ext x
+  rfl
+
+/-- The leg from an ordered intersection to the selected summand of the presentation source. -/
+public noncomputable def boundarySevenTargetIntersectionToPresentationLeg
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) ⟶
+      boundarySevenFaceNeighborhoodPresentationSource :=
+  TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) ≫
+    Sigma.ι (fun j : Fin 8 => TopCat.toSSet.obj
+      (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i)
+
+public noncomputable def boundarySevenTargetIntersectionToSmall
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) ⟶
+      coverSmallSingularSubcomplex boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood :=
+  TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a 0) ≫
+    coverMemberToSmallSingularSet boundarySevenTargetAmbient
+      boundarySevenComparisonFaceNeighborhood (a.1 0)
+
+public theorem boundarySevenTargetIntersectionToPresentationLeg_condition
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenTargetIntersectionToPresentationLeg a i ≫
+        boundarySevenFaceNeighborhoodPresentation =
+      boundarySevenTargetIntersectionToSmall a := by
+  rw [← cancel_mono
+    (coverSmallSingularSubcomplex boundarySevenTargetAmbient
+      boundarySevenComparisonFaceNeighborhood).ι]
+  simp only [boundarySevenTargetIntersectionToPresentationLeg,
+    boundarySevenFaceNeighborhoodPresentation, Category.assoc, Sigma.ι_desc_assoc,
+    coverMemberToSmallSingularSet_comp_inclusion,
+    boundarySevenTargetIntersectionToSmall]
+  rw [← Functor.map_comp, ← Functor.map_comp]
+  congr 1
+
+/-- The canonical map from one ordered-intersection summand to the corresponding Cech
+wide pullback. -/
+public noncomputable def boundarySevenTargetIntersectionToCechSummand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n :=
+  WidePullback.lift (boundarySevenTargetIntersectionToSmall a)
+    (boundarySevenTargetIntersectionToPresentationLeg a)
+    (boundarySevenTargetIntersectionToPresentationLeg_condition a)
+
+/-- The coproduct map from all proper ordered intersections to the target Cech object. -/
+public noncomputable def boundarySevenOrderedTargetCechMap
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))) ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n :=
+  Sigma.desc boundarySevenTargetIntersectionToCechSummand
+
+private noncomputable def boundarySevenSSetCoproductAppIsColimit
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) :
+    IsColimit (Cofan.mk ((∐ X).obj q) (fun i => (Sigma.ι X i).app q)) :=
+  isColimitCofanMkObjOfIsColimit ((evaluation _ _).obj q) X
+    (fun i => Sigma.ι X i) (coproductIsCoproduct X)
+
+private theorem boundarySevenSSetCoproduct_app_jointly_surjective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) (x : (∐ X).obj q) :
+    ∃ i y, (Sigma.ι X i).app q y = x :=
+  Cofan.inj_jointly_surjective_of_isColimit
+    (boundarySevenSSetCoproductAppIsColimit X q) x
+
+private theorem boundarySevenSSetCoproduct_app_index_eq
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ)
+    {i j : ι} (x : (X i).obj q) (y : (X j).obj q)
+    (h : (Sigma.ι X i).app q x = (Sigma.ι X j).app q y) : i = j :=
+  Cofan.eq_of_inj_apply_eq_of_isColimit
+    (boundarySevenSSetCoproductAppIsColimit X q) x y h
+
+private theorem boundarySevenSSetCoproduct_app_injective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) (i : ι) :
+    Function.Injective ((Sigma.ι X i).app q) :=
+  Cofan.inj_injective_of_isColimit
+    (boundarySevenSSetCoproductAppIsColimit X q) i
+
+/-- Projection from the target Cech wide pullback to a selected presentation leg. -/
+public noncomputable def boundarySevenTargetCechProjection
+    (n : SimplexCategoryᵒᵖ) (i : Fin (n.unop.len + 1)) :
+    boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n ⟶
+      boundarySevenFaceNeighborhoodPresentationSource :=
+  WidePullback.π (fun _ : Fin (n.unop.len + 1) =>
+    boundarySevenFaceNeighborhoodPresentation) i
+
+private theorem boundarySevenTargetCech_app_ext
+    {n q : SimplexCategoryᵒᵖ}
+    (x y : (boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n).obj q)
+    (h : ∀ i, (boundarySevenTargetCechProjection n i).app q x =
+      (boundarySevenTargetCechProjection n i).app q y) : x = y := by
+  let arrows := fun _ : Fin (n.unop.len + 1) =>
+    boundarySevenFaceNeighborhoodPresentation
+  let D := WidePullbackShape.wideCospan
+    (coverSmallSingularSubcomplex boundarySevenTargetAmbient
+      boundarySevenComparisonFaceNeighborhood : SSet)
+    (fun _ : Fin (n.unop.len + 1) =>
+      boundarySevenFaceNeighborhoodPresentationSource) arrows
+  let ev := (evaluation SimplexCategoryᵒᵖ (Type _)).obj q
+  have hlim : IsLimit (Functor.mapCone ev (limit.cone D)) :=
+    isLimitOfPreserves ev (limit.isLimit D)
+  apply (Types.isLimitEquivSections hlim).injective
+  apply Subtype.ext
+  funext j
+  cases j with
+  | none =>
+      have hx := congrArg (fun k => k.app q x) (WidePullback.π_arrow arrows 0)
+      have hy := congrArg (fun k => k.app q y) (WidePullback.π_arrow arrows 0)
+      exact hx.symm.trans ((congrArg
+        (fun z => (arrows 0).app q z) (h 0)).trans hy)
+  | some i => exact h i
+
+/-- On a summand, the ordered-target map followed by a Cech projection is the selected
+intersection inclusion into the corresponding presentation summand. -/
+@[reassoc]
+public theorem boundarySevenOrderedTargetCechMap_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n =>
+        TopCat.toSSet.obj
+          (TopCat.of (boundarySevenFaceNeighborhoodIntersection b.1.support))) a ≫
+        boundarySevenOrderedTargetCechMap n ≫
+        boundarySevenTargetCechProjection n i =
+      TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) ≫
+        Sigma.ι (fun j : Fin 8 => TopCat.toSSet.obj
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i) := by
+  rw [← Category.assoc, boundarySevenOrderedTargetCechMap, Sigma.ι_desc]
+  change WidePullback.lift (boundarySevenTargetIntersectionToSmall a)
+      (boundarySevenTargetIntersectionToPresentationLeg a)
+      (boundarySevenTargetIntersectionToPresentationLeg_condition a) ≫
+        WidePullback.π (fun _ : Fin (n.unop.len + 1) =>
+          boundarySevenFaceNeighborhoodPresentation) i = _
+  rw [WidePullback.lift_π]
+  rfl
+
+private theorem boundarySevenTargetIntersectionToMember_app_injective
+    {n q : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Function.Injective
+      ((TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i)).app q) := by
+  let _ : Mono (boundarySevenTargetIntersectionToMember a i) :=
+    (TopCat.mono_iff_injective _).mpr
+      (fun _ _ h => Subtype.ext
+        (congrArg (fun z : boundarySevenComparisonFaceNeighborhood (a.1 i) => z.1) h))
+  let _ : Mono (TopCat.toSSet.map
+      (boundarySevenTargetIntersectionToMember a i)) :=
+    Functor.map_mono TopCat.toSSet _
+  exact (CategoryTheory.mono_iff_injective _).mp inferInstance
+
+public theorem boundarySevenOrderedTargetCechMap_app_injective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Injective ((boundarySevenOrderedTargetCechMap n).app q) := by
+  let X := fun a : BoundarySevenProperCechTuple n =>
+    TopCat.toSSet.obj
+      (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))
+  let Y := fun j : Fin 8 => TopCat.toSSet.obj
+    (TopCat.of (boundarySevenComparisonFaceNeighborhood j))
+  intro x y hxy
+  obtain ⟨a, xa, rfl⟩ :=
+    boundarySevenSSetCoproduct_app_jointly_surjective X q x
+  obtain ⟨b, xb, rfl⟩ :=
+    boundarySevenSSetCoproduct_app_jointly_surjective X q y
+  have hcoord (i : Fin (n.unop.len + 1)) :
+      (Sigma.ι Y (a.1 i)).app q
+          ((TopCat.toSSet.map
+            (boundarySevenTargetIntersectionToMember a i)).app q xa) =
+        (Sigma.ι Y (b.1 i)).app q
+          ((TopCat.toSSet.map
+            (boundarySevenTargetIntersectionToMember b i)).app q xb) := by
+    have hproj := congrArg
+      (fun z => (boundarySevenTargetCechProjection n i).app q z) hxy
+    have ha := congrArg (fun k => k.app q xa)
+      (boundarySevenOrderedTargetCechMap_projection a i)
+    have hb := congrArg (fun k => k.app q xb)
+      (boundarySevenOrderedTargetCechMap_projection b i)
+    exact ha.symm.trans (hproj.trans hb)
+  have hab : a = b := by
+    apply Subtype.ext
+    funext i
+    exact boundarySevenSSetCoproduct_app_index_eq Y q _ _ (hcoord i)
+  subst b
+  have hmember :
+      (TopCat.toSSet.map
+        (boundarySevenTargetIntersectionToMember a 0)).app q xa =
+      (TopCat.toSSet.map
+        (boundarySevenTargetIntersectionToMember a 0)).app q xb :=
+    boundarySevenSSetCoproduct_app_injective Y q (a.1 0) (hcoord 0)
+  have habSimplex : xa = xb :=
+    boundarySevenTargetIntersectionToMember_app_injective a 0 hmember
+  exact congrArg ((Sigma.ι X a).app q) habSimplex
+
+private theorem boundarySevenTargetPresentation_ι (j : Fin 8) :
+    Sigma.ι (fun k : Fin 8 => TopCat.toSSet.obj
+      (TopCat.of (boundarySevenComparisonFaceNeighborhood k))) j ≫
+        boundarySevenFaceNeighborhoodPresentation =
+      coverMemberToSmallSingularSet boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood j := by
+  rw [boundarySevenFaceNeighborhoodPresentation, Sigma.ι_desc]
+
+private theorem boundarySevenToSSetObjEquiv_map_apply
+    {X Y : TopCat} (f : X ⟶ Y) (q : SimplexCategoryᵒᵖ)
+    (x : (TopCat.toSSet.obj X).obj q)
+    (z : stdSimplex ℝ (Fin (q.unop.len + 1))) :
+    (TopCat.toSSetObjEquiv Y q) ((TopCat.toSSet.map f).app q x) z =
+      f ((TopCat.toSSetObjEquiv X q x) z) := by
+  rfl
+
+public theorem boundarySevenOrderedTargetCechMap_app_surjective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Surjective ((boundarySevenOrderedTargetCechMap n).app q) := by
+  let X := fun a : BoundarySevenProperCechTuple n =>
+    TopCat.toSSet.obj
+      (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))
+  let Y := fun j : Fin 8 => TopCat.toSSet.obj
+    (TopCat.of (boundarySevenComparisonFaceNeighborhood j))
+  intro x
+  have hex (i : Fin (n.unop.len + 1)) :
+      ∃ j y, (Sigma.ι Y j).app q y =
+        (boundarySevenTargetCechProjection n i).app q x :=
+    boundarySevenSSetCoproduct_app_jointly_surjective Y q _
+  choose a y hy using hex
+  let arrows := fun _ : Fin (n.unop.len + 1) =>
+    boundarySevenFaceNeighborhoodPresentation
+  have hsmall (i : Fin (n.unop.len + 1)) :
+      (coverMemberToSmallSingularSet boundarySevenTargetAmbient
+          boundarySevenComparisonFaceNeighborhood (a i)).app q (y i) =
+        (coverMemberToSmallSingularSet boundarySevenTargetAmbient
+          boundarySevenComparisonFaceNeighborhood (a 0)).app q (y 0) := by
+    have hpresi := congrArg (fun k => k.app q (y i))
+      (boundarySevenTargetPresentation_ι (a i))
+    have hpres0 := congrArg (fun k => k.app q (y 0))
+      (boundarySevenTargetPresentation_ι (a 0))
+    have hyi := congrArg
+      (fun z => boundarySevenFaceNeighborhoodPresentation.app q z) (hy i)
+    have hy0 := congrArg
+      (fun z => boundarySevenFaceNeighborhoodPresentation.app q z) (hy 0)
+    have hpi := congrArg (fun k => k.app q x) (WidePullback.π_arrow arrows i)
+    have hp0 := congrArg (fun k => k.app q x) (WidePullback.π_arrow arrows 0)
+    exact hpresi.symm.trans
+      (hyi.trans (hpi.trans (hp0.symm.trans (hy0.symm.trans hpres0))))
+  have hfull (i : Fin (n.unop.len + 1)) :
+      (TopCat.toSSet.map
+        (topologicalSubsetInclusion boundarySevenTargetAmbient
+          (boundarySevenComparisonFaceNeighborhood (a i)))).app q (y i) =
+      (TopCat.toSSet.map
+        (topologicalSubsetInclusion boundarySevenTargetAmbient
+          (boundarySevenComparisonFaceNeighborhood (a 0)))).app q (y 0) := by
+    have hi := congrArg (fun k => k.app q (y i))
+      (coverMemberToSmallSingularSet_comp_inclusion boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood (a i))
+    have h0 := congrArg (fun k => k.app q (y 0))
+      (coverMemberToSmallSingularSet_comp_inclusion boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood (a 0))
+    exact hi.symm.trans
+      ((congrArg (fun z =>
+        (coverSmallSingularSubcomplex boundarySevenTargetAmbient
+          boundarySevenComparisonFaceNeighborhood).ι.app q z) (hsmall i)).trans h0)
+  let y0Map := TopCat.toSSetObjEquiv
+    (TopCat.of (boundarySevenComparisonFaceNeighborhood (a 0))) q (y 0)
+  have haProper : BoundarySevenCechTuple.support a ≠ Finset.univ := by
+    intro ha
+    let p : stdSimplex ℝ (Fin (q.unop.len + 1)) := stdSimplex.barycenter
+    have hp : (y0Map p).1 ∈
+        boundarySevenFaceNeighborhoodIntersection
+          (BoundarySevenCechTuple.support a) := by
+      rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+      intro j hj
+      obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hj
+      have heq := congrArg (fun s =>
+        (TopCat.toSSetObjEquiv boundarySevenTargetAmbient q s) p) (hfull i)
+      rw [boundarySevenToSSetObjEquiv_map_apply,
+        boundarySevenToSSetObjEquiv_map_apply] at heq
+      change ((TopCat.toSSetObjEquiv
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).1 =
+          (y0Map p).1 at heq
+      rw [← heq]
+      exact ((TopCat.toSSetObjEquiv
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).2
+    rw [ha, boundarySevenFaceNeighborhoodIntersection_univ_eq_empty] at hp
+    exact hp
+  let ap : BoundarySevenProperCechTuple n := ⟨a, haProper⟩
+  let zMap : C(stdSimplex ℝ (Fin (q.unop.len + 1)),
+      boundarySevenFaceNeighborhoodIntersection
+        (BoundarySevenCechTuple.support a)) :=
+    { toFun := fun p => ⟨(y0Map p).1, by
+        rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+        intro j hj
+        obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hj
+        have heq := congrArg (fun s =>
+          (TopCat.toSSetObjEquiv boundarySevenTargetAmbient q s) p) (hfull i)
+        rw [boundarySevenToSSetObjEquiv_map_apply,
+          boundarySevenToSSetObjEquiv_map_apply] at heq
+        change ((TopCat.toSSetObjEquiv
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).1 =
+            (y0Map p).1 at heq
+        rw [← heq]
+        exact ((TopCat.toSSetObjEquiv
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).2⟩
+      continuous_toFun := by fun_prop }
+  let z := (TopCat.toSSetObjEquiv
+    (TopCat.of (boundarySevenFaceNeighborhoodIntersection
+      (BoundarySevenCechTuple.support a))) q).symm zMap
+  have hz (i : Fin (n.unop.len + 1)) :
+      (TopCat.toSSet.map
+        (boundarySevenTargetIntersectionToMember ap i)).app q z = y i := by
+    apply (TopCat.toSSetObjEquiv
+      (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q).injective
+    ext p
+    have heq := congrArg (fun s =>
+      (TopCat.toSSetObjEquiv boundarySevenTargetAmbient q s) p) (hfull i)
+    rw [boundarySevenToSSetObjEquiv_map_apply,
+      boundarySevenToSSetObjEquiv_map_apply] at heq
+    rw [boundarySevenToSSetObjEquiv_map_apply]
+    simp only [z]
+    exact heq.symm
+  refine ⟨(Sigma.ι X ap).app q z, ?_⟩
+  apply boundarySevenTargetCech_app_ext
+  intro i
+  calc
+    (boundarySevenTargetCechProjection n i).app q
+        ((boundarySevenOrderedTargetCechMap n).app q
+          ((Sigma.ι X ap).app q z)) =
+      (Sigma.ι Y (a i)).app q
+        ((TopCat.toSSet.map
+          (boundarySevenTargetIntersectionToMember ap i)).app q z) := by
+            simpa using congrArg (fun k => k.app q z)
+              (boundarySevenOrderedTargetCechMap_projection ap i)
+    _ = (Sigma.ι Y (a i)).app q (y i) := congrArg _ (hz i)
+    _ = (boundarySevenTargetCechProjection n i).app q x := hy i
+
+/-- Objectwise, the target Cech nerve is the coproduct of the singular simplicial sets of
+proper ordered face-neighbourhood intersections. -/
+public noncomputable def boundarySevenOrderedTargetCechIso
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))) ≅
+      boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n := by
+  let _ : ∀ q, IsIso ((boundarySevenOrderedTargetCechMap n).app q) := fun q =>
+    (CategoryTheory.isIso_iff_bijective _).mpr
+      ⟨boundarySevenOrderedTargetCechMap_app_injective n q,
+        boundarySevenOrderedTargetCechMap_app_surjective n q⟩
+  let _ : IsIso (boundarySevenOrderedTargetCechMap n) :=
+    NatIso.isIso_of_isIso_app (boundarySevenOrderedTargetCechMap n)
+  exact asIso (boundarySevenOrderedTargetCechMap n)
+
+@[simp]
+public theorem boundarySevenOrderedTargetCechIso_hom
+    (n : SimplexCategoryᵒᵖ) :
+    (boundarySevenOrderedTargetCechIso n).hom =
+      boundarySevenOrderedTargetCechMap n :=
+  rfl
+
+/-- The public isomorphism restricts on each coproduct summand to the canonical wide-pullback
+lift from that ordered intersection. -/
+@[reassoc]
+public theorem boundarySevenOrderedTargetCechIso_hom_summand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n =>
+        TopCat.toSSet.obj
+          (TopCat.of (boundarySevenFaceNeighborhoodIntersection b.1.support))) a ≫
+        (boundarySevenOrderedTargetCechIso n).hom =
+      boundarySevenTargetIntersectionToCechSummand a := by
+  rw [boundarySevenOrderedTargetCechIso_hom,
+    boundarySevenOrderedTargetCechMap, Sigma.ι_desc]
+
+/-- Projection formula stated directly for the public objectwise isomorphism. -/
+@[reassoc]
+public theorem boundarySevenOrderedTargetCechIso_hom_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n =>
+        TopCat.toSSet.obj
+          (TopCat.of (boundarySevenFaceNeighborhoodIntersection b.1.support))) a ≫
+        (boundarySevenOrderedTargetCechIso n).hom ≫
+        boundarySevenTargetCechProjection n i =
+      TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) ≫
+        Sigma.ι (fun j : Fin 8 => TopCat.toSSet.obj
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i) := by
+  rw [boundarySevenOrderedTargetCechIso_hom]
+  exact boundarySevenOrderedTargetCechMap_projection a i
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedTuples.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedTuples.lean
@@ -1,0 +1,70 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechGlobalComparison
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersectionHomology
+
+/-!
+# Ordered tuples for the boundary-seven Cech nerves
+
+This file contains only the common finite indexing data used by the independent source- and
+target-side objectwise decompositions of the two Cech nerves.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- An ordered choice of one of the eight facets in every slot of an outer Cech degree. -/
+public abbrev BoundarySevenCechTuple (n : SimplexCategoryᵒᵖ) :=
+  Fin (n.unop.len + 1) → Fin 8
+
+namespace BoundarySevenCechTuple
+
+/-- The unordered support of an ordered Cech tuple. -/
+public def support {n : SimplexCategoryᵒᵖ} (a : BoundarySevenCechTuple n) :
+    Finset (Fin 8) :=
+  Finset.univ.image a
+
+@[simp]
+public theorem mem_support {n : SimplexCategoryᵒᵖ} (a : BoundarySevenCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    a i ∈ a.support :=
+  Finset.mem_image.mpr ⟨i, Finset.mem_univ i, rfl⟩
+
+public theorem support_nonempty {n : SimplexCategoryᵒᵖ} (a : BoundarySevenCechTuple n) :
+    a.support.Nonempty :=
+  ⟨a 0, a.mem_support 0⟩
+
+end BoundarySevenCechTuple
+
+/-- Tuples with proper support.  The omitted full-support tuples correspond on both sides to
+the empty eightfold intersection. -/
+public abbrev BoundarySevenProperCechTuple (n : SimplexCategoryᵒᵖ) :=
+  {a : BoundarySevenCechTuple n // a.support ≠ Finset.univ}
+
+namespace BoundarySevenProperCechTuple
+
+public theorem support_nonempty {n : SimplexCategoryᵒᵖ}
+    (a : BoundarySevenProperCechTuple n) :
+    a.1.support.Nonempty :=
+  a.1.support_nonempty
+
+public theorem support_ssubset_univ {n : SimplexCategoryᵒᵖ}
+    (a : BoundarySevenProperCechTuple n) :
+    a.1.support ⊂ Finset.univ :=
+  Finset.ssubset_iff_subset_ne.mpr ⟨Finset.subset_univ _, a.2⟩
+
+public theorem support_compl_nonempty {n : SimplexCategoryᵒᵖ}
+    (a : BoundarySevenProperCechTuple n) :
+    a.1.supportᶜ.Nonempty := by
+  apply Finset.nonempty_of_ne_empty
+  intro h
+  exact a.2 ((Finset.compl_eq_empty_iff _).mp h)
+
+end BoundarySevenProperCechTuple
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- index proper ordered Cech tuples by their common simplicial faces
- decompose source and target Cech objects as finite coproducts
- construct the tuplewise canonical comparison maps
- prove every local ordered-summand comparison is an integral quasi-isomorphism

## Dependency

This is the fifth continuation PR, stacked on #62.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenCechOrderedLocalComparison SphereSixComplex.Topology.BoundarySevenCechOrderedSource SphereSixComplex.Topology.BoundarySevenCechOrderedTarget
- Build completed successfully: 3197 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders in the 4 added files