### PR TITLE
Promote the mod-two H3 homotopy-sphere computation

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -239,6 +239,7 @@ public import SphereSixComplex.Topology.DiskBoundaryQuotient
 public import SphereSixComplex.Topology.RelativeSingularHomology
 public import SphereSixComplex.Topology.SingularExcision
 public import SphereSixComplex.Topology.SingularExcisionOpenCover
+public import SphereSixComplex.Topology.BoundarySevenCechTotalQuasiIsoProof
 public import SphereSixComplex.Topology.SingularBarycentricAllDegrees
 public import SphereSixComplex.Topology.SingularBarycentricOuterFaces
 public import SphereSixComplex.Topology.SingularBarycentricHomotopy

--- a/SphereSixComplex/Topology/BoundarySevenCechComparisonAssemblyProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechComparisonAssemblyProof.lean
@@ -1,0 +1,95 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechRowwiseGlobalizationProof
+
+/-!
+# Direct assembly of the boundary-seven Cech comparison
+
+The strict source split used by the earlier low-degree package is not needed for the canonical
+simplicial-to-singular comparison.  The canonical map of Cech totals commutes strictly with the
+two augmentations.  Since both augmentations are already quasi-isomorphisms, two-out-of-three
+reduces the whole comparison theorem to the single assertion that the map of Cech totals is a
+quasi-isomorphism.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+set_option linter.style.haveILetI false in
+/-- A map of simplicial sets which, after conjugating by coproduct isomorphisms, is a finite
+coproduct of integral chain quasi-isomorphisms is itself an integral chain quasi-isomorphism. -/
+public theorem quasiIso_sSetIntegralChains_of_finiteCoproduct_conjugation
+    {I : Type} [Finite I]
+    (K L : I → SSet.{0}) (f : ∀ i, K i ⟶ L i)
+    {X Y : SSet.{0}} (sourceIso : sigmaObj K ≅ X) (targetIso : sigmaObj L ≅ Y)
+    (g : X ⟶ Y)
+    (h : sourceIso.hom ≫ g = CategoryTheory.Limits.Sigma.map f ≫ targetIso.hom)
+    (hf : ∀ i, QuasiIso (SSet.chainComplexMap (f i) (AddCommGrpCat.of ℤ))) :
+    QuasiIso (SSet.chainComplexMap g (AddCommGrpCat.of ℤ)) := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  letI : PreservesColimitsOfShape (Discrete I) F := by
+    apply HomologicalComplex.preservesColimitsOfShape_of_eval
+    intro n
+    change PreservesColimitsOfShape (Discrete I)
+      ((evaluation SimplexCategoryᵒᵖ Type).obj
+        (Opposite.op (SimplexCategory.mk n)) ⋙
+          sigmaConst.obj (AddCommGrpCat.of ℤ))
+    infer_instance
+  haveI hsigma : QuasiIso (F.map (CategoryTheory.Limits.Sigma.map f)) :=
+    quasiIso_map_finite_coproduct F K L f hf
+  haveI hsource : QuasiIso (F.map sourceIso.hom) := by infer_instance
+  haveI htarget : QuasiIso (F.map targetIso.hom) := by infer_instance
+  have hmap : F.map sourceIso.hom ≫ F.map g =
+      F.map (CategoryTheory.Limits.Sigma.map f) ≫ F.map targetIso.hom := by
+    rw [← F.map_comp, h, F.map_comp]
+  haveI : QuasiIso (F.map sourceIso.hom ≫ F.map g) := by
+    rw [hmap]
+    infer_instance
+  exact quasiIso_of_comp_left (F.map sourceIso.hom) (F.map g)
+
+/-- Columnwise quasi-isomorphisms of the actual boundary-seven Cech bicomplex map imply the
+quasi-isomorphism of its direct-sum total. -/
+public theorem boundarySevenFaceCechTotalMap_quasiIso_of_columns
+    (hcolumn : ∀ p : ℕ, QuasiIso (boundarySevenFaceCechBicomplexMap.f p)) :
+    QuasiIso boundarySevenFaceCechTotalMap := by
+  apply firstQuadrantTotal_quasiIso_of_singleColumns
+    boundarySevenFaceCechBicomplexMap
+  intro p
+  exact firstQuadrantSingleColumnTotal_quasiIso
+    boundarySevenFaceCechBicomplexMap p (hcolumn p)
+
+set_option linter.style.haveILetI false in
+/-- The canonical integral comparison follows directly from the quasi-isomorphism of the two
+Cech totals.  No chain-level section of the source augmentation is required. -/
+public theorem boundarySeven_integralComparison_of_faceCechTotalMap_quasiIso
+    (hcech : QuasiIso boundarySevenFaceCechTotalMap) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) := by
+  let P := boundarySevenSimplicialFaceCechTotalAugmentation
+  let F := boundarySevenFaceCechTotalMap
+  let A := boundarySevenFaceNeighborhoodCechTotalAugmentation
+  let φ := simplicialToCoverSmallSingularChainMap
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  letI : QuasiIso P :=
+    boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+      boundarySevenCechRowwiseGlobalization.totalization
+      boundarySevenCechRowwiseGlobalization.rowIdentifications
+  letI : QuasiIso F := hcech
+  letI : QuasiIso A :=
+    boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+      boundarySevenCechRowwiseGlobalization.totalization
+      boundarySevenCechRowwiseGlobalization.rowIdentifications
+  haveI : QuasiIso (P ≫ φ) := by
+    rw [← boundarySevenFaceCechTotalMap_comp_augmentation]
+    infer_instance
+  have hφ : QuasiIso φ := quasiIso_of_comp_left P φ
+  exact boundarySeven_integralComparison_of_faceNeighborhoodLift
+    boundarySevenComparisonMapLandsInAffineBoundary hφ
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechGlobalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechGlobalComparison.lean
@@ -1,0 +1,475 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantSingleColumnTotal
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersections
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodLocalComparison
+public import SphereSixComplex.Topology.SixSphereLowIntegralHomology
+
+/-!
+# Global Cech comparison for the boundary of the seven-simplex
+
+This file assembles the two canonical augmented Cech nerves which occur in the comparison
+between the simplicial boundary and the singular complex small for the eight affine face
+neighbourhoods.  In particular, it constructs the actual totalized Cech augmentation (rather
+than leaving it as structure data), the map between the two Cech bicomplexes, and proves the
+strict compatibility of all three canonical augmentations.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+universe u v
+
+set_option linter.style.haveILetI false in
+/-- A finite coproduct of quasi-isomorphisms of chain complexes is a quasi-isomorphism. -/
+public theorem quasiIso_finite_coproduct
+    {I : Type} [Finite I]
+    (K L : I → FirstQuadrantChainComplex)
+    (f : ∀ i, K i ⟶ L i) (hf : ∀ i, QuasiIso (f i)) :
+    QuasiIso (CategoryTheory.Limits.Sigma.map f) := by
+  rw [quasiIso_iff]
+  intro n
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  let H := HomologicalComplex.homologyFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) n
+  let σK := sigmaComparison H K
+  let σL := sigmaComparison H L
+  haveI hfi (i : I) : IsIso (H.map (f i)) := by
+    exact (quasiIsoAt_iff_isIso_homologyMap (f i) n).mp
+      ((hf i).quasiIsoAt n)
+  haveI : IsIso (CategoryTheory.Limits.Sigma.map fun i ↦ H.map (f i)) := inferInstance
+  haveI : IsIso σK := by dsimp [σK]; infer_instance
+  haveI : IsIso σL := by dsimp [σL]; infer_instance
+  have hnat : σK ≫ H.map (CategoryTheory.Limits.Sigma.map f) =
+      CategoryTheory.Limits.Sigma.map (fun i ↦ H.map (f i)) ≫ σL := by
+    apply Sigma.hom_ext
+    intro i
+    simp only [← Category.assoc, σK, σL,
+      CategoryTheory.Limits.ι_comp_sigmaComparison,
+      ← H.map_comp, CategoryTheory.Limits.Sigma.ι_map]
+    rw [Category.assoc,
+      CategoryTheory.Limits.ι_comp_sigmaComparison, ← H.map_comp]
+  haveI : IsIso (σK ≫ H.map (CategoryTheory.Limits.Sigma.map f)) := by
+    rw [hnat]
+    infer_instance
+  exact @IsIso.of_isIso_comp_left _ _ _ _ _ σK
+    (H.map (CategoryTheory.Limits.Sigma.map f)) inferInstance inferInstance
+
+set_option linter.style.haveILetI false in
+/-- A functor to chain complexes which preserves a finite coproduct carries a coproduct of
+maps sent to quasi-isomorphisms to a quasi-isomorphism. -/
+public theorem quasiIso_map_finite_coproduct
+    {C : Type u} [Category.{v} C] {I : Type} [Finite I]
+    (F : C ⥤ FirstQuadrantChainComplex.{0})
+    [HasColimitsOfShape (Discrete I) C]
+    [PreservesColimitsOfShape (Discrete I) F]
+    (K L : I → C) (f : ∀ i, K i ⟶ L i)
+    (hf : ∀ i, QuasiIso (F.map (f i))) :
+    QuasiIso (F.map (CategoryTheory.Limits.Sigma.map f)) := by
+  let σK := sigmaComparison F K
+  let σL := sigmaComparison F L
+  let sf := CategoryTheory.Limits.Sigma.map (fun i ↦ F.map (f i))
+  haveI : IsIso σK := by dsimp [σK]; infer_instance
+  haveI : IsIso σL := by dsimp [σL]; infer_instance
+  haveI : QuasiIso sf := quasiIso_finite_coproduct
+    (fun i ↦ F.obj (K i)) (fun i ↦ F.obj (L i))
+    (fun i ↦ F.map (f i)) hf
+  have hnat : σK ≫ F.map (CategoryTheory.Limits.Sigma.map f) = sf ≫ σL := by
+    apply Sigma.hom_ext
+    intro i
+    simp only [← Category.assoc, σK, σL, sf,
+      CategoryTheory.Limits.ι_comp_sigmaComparison,
+      ← F.map_comp, CategoryTheory.Limits.Sigma.ι_map]
+    rw [Category.assoc,
+      CategoryTheory.Limits.ι_comp_sigmaComparison, ← F.map_comp]
+  haveI : QuasiIso σK := inferInstance
+  haveI : QuasiIso σL := inferInstance
+  haveI : QuasiIso (σK ≫ F.map (CategoryTheory.Limits.Sigma.map f)) := by
+    rw [hnat]
+    infer_instance
+  exact quasiIso_of_comp_left σK
+    (F.map (CategoryTheory.Limits.Sigma.map f))
+
+/-- The simplicial face presentation, regarded as an arrow. -/
+public noncomputable def boundarySevenSimplicialFacePresentationArrow : Arrow SSet :=
+  Arrow.mk boundarySevenSimplicialFacePresentation
+
+/-- The simplicial face presentation evaluated in one inner simplicial degree. -/
+public noncomputable def boundarySevenSimplicialFacePresentationEvaluationArrow
+    (n : SimplexCategoryᵒᵖ) : Arrow (Type 0) :=
+  Arrow.mk (boundarySevenSimplicialFacePresentation.app n)
+
+/-- A chosen splitting of the evaluated simplicial face presentation. -/
+public noncomputable def boundarySevenSimplicialFacePresentationEvaluationSplitEpi
+    (n : SimplexCategoryᵒᵖ) :
+    SplitEpi (boundarySevenSimplicialFacePresentationEvaluationArrow n).hom := by
+  let h := boundarySevenSimplicialFacePresentation_app_surjective n
+  exact
+    { section_ := ↾ fun z ↦ Function.surjInv h z
+      id := by
+        ext z
+        exact Function.rightInverse_surjInv h z }
+
+/-- The evaluated simplicial face-presentation Cech nerve has an extra degeneracy. -/
+public noncomputable def boundarySevenSimplicialFaceEvaluationExtraDegeneracy
+    (n : SimplexCategoryᵒᵖ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenSimplicialFacePresentationEvaluationArrow n).augmentedCechNerve :=
+  Arrow.AugmentedCechNerve.extraDegeneracy
+    (boundarySevenSimplicialFacePresentationEvaluationArrow n)
+    (boundarySevenSimplicialFacePresentationEvaluationSplitEpi n)
+
+/-- Integral coefficients on the evaluated augmented Cech nerve of the simplicial face
+presentation. -/
+public noncomputable abbrev boundarySevenSimplicialFaceIntegralEvaluationCech
+    (k : ℕ) : SimplicialObject.Augmented AddCommGrpCat :=
+  ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (boundarySevenSimplicialFacePresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk k))).augmentedCechNerve
+
+/-- The integral evaluated face-presentation Cech nerve retains its extra degeneracy. -/
+public noncomputable def boundarySevenSimplicialFaceIntegralEvaluationExtraDegeneracy
+    (k : ℕ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenSimplicialFaceIntegralEvaluationCech k) :=
+  (boundarySevenSimplicialFaceEvaluationExtraDegeneracy
+    (Opposite.op (SimplexCategory.mk k))).map
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))
+
+/-- Each horizontal row of the augmented face-presentation Cech complex contracts onto the
+corresponding chain group of the simplicial boundary. -/
+public noncomputable def boundarySevenSimplicialFaceIntegralCechRowHomotopyEquiv
+    (k : ℕ) :
+    HomotopyEquiv
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenSimplicialFaceIntegralEvaluationCech k)))
+      ((ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenSimplicialFaceIntegralEvaluationCech k))) :=
+  (boundarySevenSimplicialFaceIntegralEvaluationExtraDegeneracy k).homotopyEquiv
+
+/-- Thus every horizontal row augmentation of the simplicial face resolution is a
+quasi-isomorphism. -/
+public theorem boundarySevenSimplicialFaceIntegralCechRowAugmentation_quasiIso
+    (k : ℕ) :
+    QuasiIso (AlternatingFaceMapComplex.ε.app
+      (boundarySevenSimplicialFaceIntegralEvaluationCech k)) :=
+  (boundarySevenSimplicialFaceIntegralCechRowHomotopyEquiv k).quasiIso_hom
+
+/-- The map of the two degree-zero Cech presentation objects is literally the finite coproduct
+of the eight canonical local face comparisons. -/
+public theorem boundarySevenFacePresentationSourceMap_eq_sigmaMap :
+    boundarySevenFacePresentationSourceMap =
+      CategoryTheory.Limits.Sigma.map
+        (fun i : Fin 8 ↦ boundarySevenFaceNeighborhoodLocalComparisonSSetMap i) := by
+  apply Sigma.hom_ext
+  intro i
+  rw [boundarySevenFacePresentationSourceMap_iota,
+    CategoryTheory.Limits.Sigma.ι_map]
+  rfl
+
+set_option linter.style.haveILetI false in
+/-- Consequently the canonical map on the degree-zero Cech presentation objects induces a
+quasi-isomorphism on integral chains.  This is the first graded piece of the vertical-column
+filtration of the Cech total map. -/
+public theorem boundarySevenFacePresentationSourceIntegralChainMap_quasiIso :
+    QuasiIso (SSet.chainComplexMap boundarySevenFacePresentationSourceMap
+      (AddCommGrpCat.of ℤ)) := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  let K : Fin 8 → SSet.{0} := fun _ ↦ (Δ[6] : SSet.{0})
+  let L : Fin 8 → SSet.{0} := fun i ↦
+    TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i))
+  let f : ∀ i, K i ⟶ L i :=
+    fun i ↦ boundarySevenFaceNeighborhoodLocalComparisonSSetMap i
+  letI : PreservesColimitsOfShape (Discrete (Fin 8)) F := by
+    apply HomologicalComplex.preservesColimitsOfShape_of_eval
+    intro n
+    change PreservesColimitsOfShape (Discrete (Fin 8))
+      ((evaluation SimplexCategoryᵒᵖ Type).obj
+        (Opposite.op (SimplexCategory.mk n)) ⋙
+          sigmaConst.obj (AddCommGrpCat.of ℤ))
+    infer_instance
+  have hf : ∀ i, QuasiIso (F.map (f i)) := by
+    intro i
+    exact boundarySevenFaceNeighborhoodLocalIntegralComparison_quasiIso i
+  have h := quasiIso_map_finite_coproduct F K L f hf
+  rw [boundarySevenFacePresentationSourceMap_eq_sigmaMap]
+  exact h
+
+/-- The augmented Cech nerve of the simplicial face presentation. -/
+public noncomputable def boundarySevenSimplicialFaceAugmentedCechNerve :
+    SimplicialObject.Augmented SSet :=
+  boundarySevenSimplicialFacePresentationArrow.augmentedCechNerve
+
+/-- Integral chains in the inner simplicial direction of the face-presentation Cech nerve. -/
+public noncomputable def boundarySevenSimplicialFaceAugmentedCechChains :
+    SimplicialObject.Augmented (ChainComplex AddCommGrpCat ℕ) :=
+  ((SimplicialObject.Augmented.whiskering SSet
+    (ChainComplex AddCommGrpCat ℕ)).obj
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ))).obj
+        boundarySevenSimplicialFaceAugmentedCechNerve
+
+/-- The Cech--simplicial bicomplex of the eight standard faces. -/
+public noncomputable def boundarySevenSimplicialFaceCechBicomplex :
+    FirstQuadrantBicomplex :=
+  AlternatingFaceMapComplex.obj
+    (SimplicialObject.Augmented.drop.obj
+      boundarySevenSimplicialFaceAugmentedCechChains)
+
+/-- The direct-sum total of the Cech--simplicial bicomplex. -/
+public noncomputable def boundarySevenSimplicialFaceCechTotal :
+    FirstQuadrantChainComplex :=
+  boundarySevenSimplicialFaceCechBicomplex.total (ComplexShape.down ℕ)
+
+/-- The outer augmentation of the Cech--simplicial bicomplex. -/
+public noncomputable def boundarySevenSimplicialFaceCechOuterAugmentation :
+    boundarySevenSimplicialFaceCechBicomplex ⟶
+      firstQuadrantSingleZeroBicomplex
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)) :=
+  AlternatingFaceMapComplex.ε.app boundarySevenSimplicialFaceAugmentedCechChains
+
+/-- The map of augmented Cech nerves induced by the facewise local comparison square. -/
+public noncomputable def boundarySevenFaceAugmentedCechNerveMap :
+    boundarySevenSimplicialFaceAugmentedCechNerve ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechNerve :=
+  Arrow.mapAugmentedCechNerve boundarySevenFacePresentationArrowMap
+
+/-- Apply integral chains to the map of augmented Cech nerves. -/
+public noncomputable def boundarySevenFaceAugmentedCechChainMap :
+    boundarySevenSimplicialFaceAugmentedCechChains ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechChains :=
+  ((SimplicialObject.Augmented.whiskering SSet
+    (ChainComplex AddCommGrpCat ℕ)).obj
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ))).map
+        boundarySevenFaceAugmentedCechNerveMap
+
+/-- The induced morphism of the two first-quadrant Cech bicomplexes. -/
+public noncomputable def boundarySevenFaceCechBicomplexMap :
+    boundarySevenSimplicialFaceCechBicomplex ⟶
+      boundarySevenFaceNeighborhoodCechBicomplex :=
+  AlternatingFaceMapComplex.map
+    (SimplicialObject.Augmented.drop.map boundarySevenFaceAugmentedCechChainMap)
+
+/-- The induced map of direct-sum total complexes. -/
+public noncomputable def boundarySevenFaceCechTotalMap :
+    boundarySevenSimplicialFaceCechTotal ⟶
+      boundarySevenFaceNeighborhoodCechTotal :=
+  HomologicalComplex₂.total.map boundarySevenFaceCechBicomplexMap
+    (ComplexShape.down ℕ)
+
+/-- Totalize the Cech--simplicial augmentation and identify the total of its unique target
+column with the ordinary simplicial chain complex. -/
+public noncomputable def boundarySevenSimplicialFaceCechTotalAugmentation :
+    boundarySevenSimplicialFaceCechTotal ⟶
+      (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) :=
+  HomologicalComplex₂.total.map boundarySevenSimplicialFaceCechOuterAugmentation
+      (ComplexShape.down ℕ) ≫
+    firstQuadrantTotalToSingleZero
+      ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))
+
+/-- The canonical totalized augmentation from the face-neighbourhood Cech total to cover-small
+integral singular chains. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechTotalAugmentation :
+    boundarySevenFaceNeighborhoodCechTotal ⟶
+      CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood :=
+  HomologicalComplex₂.total.map boundarySevenFaceNeighborhoodCechOuterAugmentation
+      (ComplexShape.down ℕ) ≫
+    firstQuadrantTotalToSingleZero
+      (CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood)
+
+/-- The evaluated horizontal row of the outer neighbourhood-Cech augmentation, in the precise
+coefficient presentation furnished by the evaluated augmented Cech nerve. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechOuterAugmentationRow (k : ℕ) :
+    AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)) ⟶
+      (ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)) :=
+  AlternatingFaceMapComplex.ε.app
+    (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)
+
+/-- The previously constructed extra degeneracy proves that every actual horizontal row of the
+outer augmentation is a quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodCechOuterAugmentationRow_quasiIso (k : ℕ) :
+    QuasiIso (boundarySevenFaceNeighborhoodCechOuterAugmentationRow k) := by
+  exact boundarySevenFaceNeighborhoodIntegralCechRowAugmentation_quasiIso k
+
+/-- Naturality of the alternating-complex augmentation, before totalization. -/
+public theorem boundarySevenFaceCechBicomplexMap_comp_outerAugmentation :
+    boundarySevenFaceCechBicomplexMap ≫
+        boundarySevenFaceNeighborhoodCechOuterAugmentation =
+      boundarySevenSimplicialFaceCechOuterAugmentation ≫
+        (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map
+          (SSet.chainComplexMap
+            (simplicialToCoverSmallSingularSet
+              (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+              boundarySevenComparisonUnitLandsInFaceNeighborhoods)
+            (AddCommGrpCat.of ℤ)) := by
+  exact AlternatingFaceMapComplex.ε.naturality
+    boundarySevenFaceAugmentedCechChainMap
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The inclusion into the total of a zero-column bicomplex is natural in the column. -/
+public theorem firstQuadrantSingleZeroToTotal_naturality
+    {K L : FirstQuadrantChainComplex} (f : K ⟶ L) :
+    f ≫ firstQuadrantSingleZeroToTotal L =
+      firstQuadrantSingleZeroToTotal K ≫
+        HomologicalComplex₂.total.map
+          ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map f)
+          (ComplexShape.down ℕ) := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  simp only [HomologicalComplex.comp_f]
+  dsimp only [firstQuadrantSingleZeroToTotal,
+    firstQuadrantZeroColumnToTotal]
+  simp only [HomologicalComplex.comp_f]
+  simp only [show firstQuadrantSingleZeroColumnIso K = Iso.refl K by
+      exact ChainComplex.single₀ObjXSelf K,
+    show firstQuadrantSingleZeroColumnIso L = Iso.refl L by
+      exact ChainComplex.single₀ObjXSelf L,
+    Iso.refl_inv, HomologicalComplex.id_f, Category.id_comp]
+  rw [HomologicalComplex₂.ιTotal_map]
+  simp
+
+set_option linter.style.haveILetI false in
+/-- The projection from the total of a zero-column bicomplex is natural in the column. -/
+public theorem firstQuadrantTotalToSingleZero_naturality
+    {K L : FirstQuadrantChainComplex} (f : K ⟶ L) :
+    HomologicalComplex₂.total.map
+          ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map f)
+          (ComplexShape.down ℕ) ≫
+        firstQuadrantTotalToSingleZero L =
+      firstQuadrantTotalToSingleZero K ≫ f := by
+  letI : IsIso (firstQuadrantSingleZeroToTotal K) :=
+    (firstQuadrantSingleZeroTotalIso K).isIso_inv
+  apply (cancel_epi (firstQuadrantSingleZeroToTotal K)).1
+  rw [← Category.assoc, ← firstQuadrantSingleZeroToTotal_naturality]
+  rw [Category.assoc, firstQuadrantSingleZeroToTotal_comp_projection]
+  rw [Category.comp_id, ← Category.assoc,
+    firstQuadrantSingleZeroToTotal_comp_projection, Category.id_comp]
+
+/-- The total Cech map commutes strictly with the canonical totalized augmentations. -/
+public theorem boundarySevenFaceCechTotalMap_comp_augmentation :
+    boundarySevenFaceCechTotalMap ≫
+        boundarySevenFaceNeighborhoodCechTotalAugmentation =
+      boundarySevenSimplicialFaceCechTotalAugmentation ≫
+        simplicialToCoverSmallSingularChainMap
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods := by
+  let φ := simplicialToCoverSmallSingularChainMap
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  let S := boundarySevenSimplicialFaceCechOuterAugmentation
+  let T := boundarySevenFaceNeighborhoodCechOuterAugmentation
+  let F := boundarySevenFaceCechBicomplexMap
+  change HomologicalComplex₂.total.map F (ComplexShape.down ℕ) ≫
+      (HomologicalComplex₂.total.map T (ComplexShape.down ℕ) ≫
+        firstQuadrantTotalToSingleZero _) =
+    (HomologicalComplex₂.total.map S (ComplexShape.down ℕ) ≫
+      firstQuadrantTotalToSingleZero _) ≫ φ
+  calc
+    _ = (HomologicalComplex₂.total.map F (ComplexShape.down ℕ) ≫
+          HomologicalComplex₂.total.map T (ComplexShape.down ℕ)) ≫
+          firstQuadrantTotalToSingleZero _ :=
+      (Category.assoc _ _ _).symm
+    _ = HomologicalComplex₂.total.map (F ≫ T) (ComplexShape.down ℕ) ≫
+          firstQuadrantTotalToSingleZero _ := by
+      rw [HomologicalComplex₂.total.map_comp]
+    _ = HomologicalComplex₂.total.map
+          (S ≫ (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map φ)
+          (ComplexShape.down ℕ) ≫ firstQuadrantTotalToSingleZero _ := by
+      rw [show F ≫ T =
+          S ≫ (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map φ by
+        exact boundarySevenFaceCechBicomplexMap_comp_outerAugmentation]
+    _ = (HomologicalComplex₂.total.map S (ComplexShape.down ℕ) ≫
+          HomologicalComplex₂.total.map
+            ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).map φ)
+            (ComplexShape.down ℕ)) ≫ firstQuadrantTotalToSingleZero _ := by
+      rw [HomologicalComplex₂.total.map_comp]
+    _ = HomologicalComplex₂.total.map S (ComplexShape.down ℕ) ≫
+          (firstQuadrantTotalToSingleZero _ ≫ φ) := by
+      rw [Category.assoc, firstQuadrantTotalToSingleZero_naturality]
+    _ = _ := by rw [Category.assoc]
+
+/-! ## Exact low-degree assembly endpoint -/
+
+/-- The remaining input for the low-degree global comparison, after the canonical Cech maps
+and their strict augmentation square have been constructed above.  The lift is the output of
+totalizing a contraction of the simplicial face-presentation resolution; the other four fields
+are precisely the degree-two and degree-three conclusions of the rowwise-to-total argument. -/
+public structure BoundarySevenCechLowAssemblyInput where
+  sourceLift :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenSimplicialFaceCechTotal
+  sourceLift_fac :
+    sourceLift ≫ boundarySevenSimplicialFaceCechTotalAugmentation = 𝟙 _
+  sourceLift_quasiIsoAt_two : QuasiIsoAt sourceLift 2
+  sourceLift_quasiIsoAt_three : QuasiIsoAt sourceLift 3
+  cechMap_quasiIsoAt_two : QuasiIsoAt boundarySevenFaceCechTotalMap 2
+  cechMap_quasiIsoAt_three : QuasiIsoAt boundarySevenFaceCechTotalMap 3
+  augmentation_quasiIsoAt_two :
+    QuasiIsoAt boundarySevenFaceNeighborhoodCechTotalAugmentation 2
+  augmentation_quasiIsoAt_three :
+    QuasiIsoAt boundarySevenFaceNeighborhoodCechTotalAugmentation 3
+
+/-- The canonical map from boundary chains to the neighbourhood Cech total obtained from a
+contracting lift of the simplicial face resolution. -/
+public noncomputable def boundarySevenBoundaryToFaceNeighborhoodCechTotal
+    (h : BoundarySevenCechLowAssemblyInput) :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenFaceNeighborhoodCechTotal :=
+  h.sourceLift ≫ boundarySevenFaceCechTotalMap
+
+/-- The constructed boundary-to-Cech map has exactly the required canonical composite. -/
+public theorem boundarySevenBoundaryToFaceNeighborhoodCechTotal_fac
+    (h : BoundarySevenCechLowAssemblyInput) :
+    boundarySevenBoundaryToFaceNeighborhoodCechTotal h ≫
+        boundarySevenFaceNeighborhoodCechTotalAugmentation =
+      simplicialToCoverSmallSingularChainMap
+        (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+        boundarySevenComparisonUnitLandsInFaceNeighborhoods := by
+  unfold boundarySevenBoundaryToFaceNeighborhoodCechTotal
+  rw [Category.assoc, boundarySevenFaceCechTotalMap_comp_augmentation]
+  rw [← Category.assoc, h.sourceLift_fac, Category.id_comp]
+
+/-- The exact low-degree Cech package consumed by the six-sphere homology reduction. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechLowComparison_of_assembly
+    (h : BoundarySevenCechLowAssemblyInput) :
+    BoundarySevenFaceNeighborhoodCechLowComparison where
+  boundaryToCech := boundarySevenBoundaryToFaceNeighborhoodCechTotal h
+  augmentation := boundarySevenFaceNeighborhoodCechTotalAugmentation
+  fac := boundarySevenBoundaryToFaceNeighborhoodCechTotal_fac h
+  boundaryToCech_quasiIsoAt_two :=
+    quasiIsoAt_comp h.sourceLift boundarySevenFaceCechTotalMap 2
+      (hφ := h.sourceLift_quasiIsoAt_two)
+      (hφ' := h.cechMap_quasiIsoAt_two)
+  boundaryToCech_quasiIsoAt_three :=
+    quasiIsoAt_comp h.sourceLift boundarySevenFaceCechTotalMap 3
+      (hφ := h.sourceLift_quasiIsoAt_three)
+      (hφ' := h.cechMap_quasiIsoAt_three)
+  augmentation_quasiIsoAt_two := h.augmentation_quasiIsoAt_two
+  augmentation_quasiIsoAt_three := h.augmentation_quasiIsoAt_three
+
+/-- Consequently the remaining low-degree Cech assembly input is sufficient for both desired
+six-sphere homology vanishings and the disk-cover local acyclicity package. -/
+public theorem sixSphere_lowHomology_and_diskLocalAcyclic_of_cechAssembly
+    (h : BoundarySevenCechLowAssemblyInput) :
+    (IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3)) ∧
+      DiskSevenCoverLocalRelativeLowAcyclic :=
+  sixSphere_lowHomology_and_diskLocalAcyclic_of_cechLow
+    (boundarySevenFaceNeighborhoodCechLowComparison_of_assembly h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechLowAssemblyProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechLowAssemblyProof.lean
@@ -1,0 +1,209 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechGlobalComparison
+
+/-!
+# Low-degree assembly for the boundary-seven Cech comparison
+
+This file isolates the three genuinely global steps left in the Cech comparison: rowwise
+globalization (including the pointwise-limit coherence), a strict chain-level section of the
+simplicial-face Cech augmentation, and the low-degree comparison of the two Cech totals.
+
+The definitions below are deliberately expressed using the actual bicomplexes and maps from
+`BoundarySevenCechGlobalComparison`, rather than replacing either step by an informal
+"spectral sequence" hypothesis.  We also prove that the two quasi-isomorphism fields for the
+strict section in `BoundarySevenCechLowAssemblyInput` are redundant: they follow formally
+from the section equation and the corresponding assertion for the augmentation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The horizontal chain complex obtained from a first-quadrant bicomplex by evaluating its
+vertical chain-complex entries in degree `q`. -/
+public noncomputable def firstQuadrantHorizontalRow
+    (K : FirstQuadrantBicomplex) (q : ℕ) : FirstQuadrantChainComplex :=
+  ((HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q).mapHomologicalComplex
+    (ComplexShape.down ℕ)).obj K
+
+/-- Evaluation of a bicomplex map on a horizontal row. -/
+public noncomputable def firstQuadrantHorizontalRowMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (q : ℕ) :
+    firstQuadrantHorizontalRow K q ⟶ firstQuadrantHorizontalRow L q :=
+  ((HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q).mapHomologicalComplex
+    (ComplexShape.down ℕ)).map f
+
+/-- The exact generic homological-algebra statement needed to totalize the existing row
+contractions.  It is kept as a proposition, not an axiom or typeclass, so downstream results
+must display this missing proof as an explicit argument.
+
+For first-quadrant direct-sum totals this follows from the finite brutal-column filtration:
+each total degree sees only finitely many columns. -/
+public def FirstQuadrantRowwiseTotalization : Prop :=
+  ∀ {K L : FirstQuadrantBicomplex} (f : K ⟶ L),
+    (∀ q : ℕ, QuasiIso (firstQuadrantHorizontalRowMap f q)) →
+      QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ))
+
+/-- A strict right inverse to the simplicial-face total augmentation.  This is the exact
+chain-level datum which cannot be recovered merely by choosing inverses on homology. -/
+public structure BoundarySevenCechStrictSourceSplit where
+  sourceLift :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenSimplicialFaceCechTotal
+  sourceLift_fac :
+    sourceLift ≫ boundarySevenSimplicialFaceCechTotalAugmentation = 𝟙 _
+
+/-- The remaining comparison for the map between the two Cech totals.  Its proof is the
+finite-coproduct decomposition of the ordered intersections, followed by the local comparison
+theorems and rowwise totalization. -/
+public structure BoundarySevenFaceCechTotalLowComparison where
+  quasiIsoAt_two : QuasiIsoAt boundarySevenFaceCechTotalMap 2
+  quasiIsoAt_three : QuasiIsoAt boundarySevenFaceCechTotalMap 3
+
+/-- The coherence isomorphisms identifying evaluation of the two constructed Cech
+bicomplexes with the separately constructed evaluated Cech nerves.  These isomorphisms are
+canonical pointwise-limit comparisons, but they are not definitional equalities: the Cech
+nerve contains wide pullbacks in a functor category. -/
+public structure BoundarySevenCechAugmentationRowIdentifications where
+  sourceRowArrowIso (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenSimplicialFaceCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q))
+  targetRowArrowIso (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenFaceNeighborhoodCechOuterAugmentation q) ≅
+      Arrow.mk (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q)
+
+/-- The single homological-algebra/coherence package needed to globalize the already-proved
+row contractions.  Its first field is the brutal-prefix theorem, and its second field records
+the pointwise wide-pullback comparisons needed to apply that theorem to the actual Cech
+bicomplexes. -/
+public structure BoundarySevenCechRowwiseGlobalization where
+  totalization : FirstQuadrantRowwiseTotalization
+  rowIdentifications : BoundarySevenCechAugmentationRowIdentifications
+
+/-- A section of a quasi-isomorphism in one degree is automatically a quasi-isomorphism in
+that degree. -/
+public theorem quasiIsoAt_of_strict_section
+    {K L : FirstQuadrantChainComplex} (s : K ⟶ L) (p : L ⟶ K)
+    (fac : s ≫ p = 𝟙 K) (n : ℕ) [QuasiIsoAt p n] : QuasiIsoAt s n := by
+  haveI : QuasiIsoAt (s ≫ p) n := by
+    rw [fac]
+    infer_instance
+  exact quasiIsoAt_of_comp_right s p n
+
+/-- Rowwise totalization turns the already-proved source row augmentations into a global
+quasi-isomorphism of total complexes. -/
+public theorem boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+    (hrow : FirstQuadrantRowwiseTotalization)
+    (hident : BoundarySevenCechAugmentationRowIdentifications) :
+    QuasiIso boundarySevenSimplicialFaceCechTotalAugmentation := by
+  let T := HomologicalComplex₂.total.map
+    boundarySevenSimplicialFaceCechOuterAugmentation (ComplexShape.down ℕ)
+  have hT : QuasiIso T := by
+    apply hrow boundarySevenSimplicialFaceCechOuterAugmentation
+    intro q
+    letI : QuasiIso (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q)) :=
+      boundarySevenSimplicialFaceIntegralCechRowAugmentation_quasiIso q
+    exact quasiIso_of_arrow_mk_iso
+      (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q))
+      (firstQuadrantHorizontalRowMap
+        boundarySevenSimplicialFaceCechOuterAugmentation q)
+      (hident.sourceRowArrowIso q).symm
+  have hP : QuasiIso (firstQuadrantTotalToSingleZero
+      ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))) := by
+    letI : IsIso (firstQuadrantTotalToSingleZero
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))) :=
+      (firstQuadrantSingleZeroTotalIso
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))).isIso_hom
+    infer_instance
+  exact quasiIso_comp T _
+
+/-- Rowwise totalization likewise promotes the existing neighbourhood-row contractions to
+the actual totalized neighbourhood Cech augmentation. -/
+public theorem boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+    (hrow : FirstQuadrantRowwiseTotalization)
+    (hident : BoundarySevenCechAugmentationRowIdentifications) :
+    QuasiIso boundarySevenFaceNeighborhoodCechTotalAugmentation := by
+  let T := HomologicalComplex₂.total.map
+    boundarySevenFaceNeighborhoodCechOuterAugmentation (ComplexShape.down ℕ)
+  have hT : QuasiIso T := by
+    apply hrow boundarySevenFaceNeighborhoodCechOuterAugmentation
+    intro q
+    letI : QuasiIso (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q) :=
+      boundarySevenFaceNeighborhoodCechOuterAugmentationRow_quasiIso q
+    exact quasiIso_of_arrow_mk_iso
+      (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q)
+      (firstQuadrantHorizontalRowMap
+        boundarySevenFaceNeighborhoodCechOuterAugmentation q)
+      (hident.targetRowArrowIso q).symm
+  have hP : QuasiIso (firstQuadrantTotalToSingleZero
+      (CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood)) := by
+    letI : IsIso (firstQuadrantTotalToSingleZero
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)) :=
+      (firstQuadrantSingleZeroTotalIso
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)).isIso_hom
+    infer_instance
+  exact quasiIso_comp T _
+
+/-- Once the generic first-quadrant theorem, the strict source split, and the geometric
+comparison of the two Cech totals are supplied, all eight fields of the original low-assembly
+package are canonical.  In particular, no separate proof about the source lift on homology is
+needed. -/
+public noncomputable def boundarySevenCechLowAssemblyInput_of_global_steps
+    (hglobal : BoundarySevenCechRowwiseGlobalization)
+    (hsplit : BoundarySevenCechStrictSourceSplit)
+    (hcech : BoundarySevenFaceCechTotalLowComparison) :
+    BoundarySevenCechLowAssemblyInput where
+  sourceLift := hsplit.sourceLift
+  sourceLift_fac := hsplit.sourceLift_fac
+  sourceLift_quasiIsoAt_two := by
+    letI : QuasiIso boundarySevenSimplicialFaceCechTotalAugmentation :=
+      boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    exact quasiIsoAt_of_strict_section hsplit.sourceLift
+      boundarySevenSimplicialFaceCechTotalAugmentation hsplit.sourceLift_fac 2
+  sourceLift_quasiIsoAt_three := by
+    letI : QuasiIso boundarySevenSimplicialFaceCechTotalAugmentation :=
+      boundarySevenSimplicialFaceCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    exact quasiIsoAt_of_strict_section hsplit.sourceLift
+      boundarySevenSimplicialFaceCechTotalAugmentation hsplit.sourceLift_fac 3
+  cechMap_quasiIsoAt_two := hcech.quasiIsoAt_two
+  cechMap_quasiIsoAt_three := hcech.quasiIsoAt_three
+  augmentation_quasiIsoAt_two := by
+    letI : QuasiIso boundarySevenFaceNeighborhoodCechTotalAugmentation :=
+      boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    infer_instance
+  augmentation_quasiIsoAt_three := by
+    letI : QuasiIso boundarySevenFaceNeighborhoodCechTotalAugmentation :=
+      boundarySevenFaceNeighborhoodCechTotalAugmentation_quasiIso
+        hglobal.totalization hglobal.rowIdentifications
+    infer_instance
+
+/-- Exact final residual for the current Cech route.  It records, without disguising any
+obligation, that rowwise globalization, the strict face-resolution split, and
+the ordered-intersection comparison together construct the requested assembly input. -/
+public theorem boundarySevenCechLowAssemblyInput_of_exact_residual
+    (hglobal : BoundarySevenCechRowwiseGlobalization)
+    (hsplit : BoundarySevenCechStrictSourceSplit)
+    (hcech : BoundarySevenFaceCechTotalLowComparison) :
+    Nonempty BoundarySevenCechLowAssemblyInput :=
+  ⟨boundarySevenCechLowAssemblyInput_of_global_steps hglobal hsplit hcech⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedLocalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedLocalComparison.lean
@@ -1,0 +1,382 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTuples
+
+/-!
+# Local comparison for ordered boundary-seven Cech tuples
+
+For an ordered tuple with proper support, its common simplicial face is representable by the
+standard simplex on the complementary vertices.  The order on `Fin 8` makes this
+representability canonical.  We use it to compare that common face with singular simplices in
+the corresponding intersection of affine face neighbourhoods.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+set_option maxHeartbeats 800000
+
+/-- The dimension of the standard simplex whose vertices are the complement of a proper Cech
+tuple's support. -/
+public def boundarySevenProperCechTupleFaceDimension
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) : ℕ :=
+  a.1.supportᶜ.card - 1
+
+/-- The canonical increasing enumeration of the complementary vertices. -/
+public noncomputable def boundarySevenProperCechTupleFaceOrderIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    Fin (boundarySevenProperCechTupleFaceDimension a + 1) ≃o
+      ↑(a.1.supportᶜ) := by
+  apply Finset.orderIsoOfFin
+  have hpos : 0 < a.1.supportᶜ.card :=
+    Finset.card_pos.mpr a.support_compl_nonempty
+  dsimp [boundarySevenProperCechTupleFaceDimension]
+  omega
+
+/-- The common face is canonically representable by the standard simplex on the complementary
+vertices. -/
+public noncomputable def boundarySevenProperCechTupleFaceIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≅
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) :=
+  SSet.stdSimplex.isoOfRepresentableBy
+    (SSet.stdSimplex.faceRepresentableBy a.1.supportᶜ
+      (boundarySevenProperCechTupleFaceDimension a)
+      (boundarySevenProperCechTupleFaceOrderIso a))
+
+/-- The simplex-category arrow which inserts the increasing complementary vertices into the
+eight ambient vertices. -/
+public noncomputable def boundarySevenProperCechTupleComplementSimplexHom
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    SimplexCategory.mk (boundarySevenProperCechTupleFaceDimension a) ⟶
+      SimplexCategory.mk 7 :=
+  SimplexCategory.Hom.mk
+    { toFun := fun j ↦ (boundarySevenProperCechTupleFaceOrderIso a j).1
+      monotone' := fun _ _ h ↦
+        (boundarySevenProperCechTupleFaceOrderIso a).monotone h }
+
+/-- The common complementary face includes canonically in the simplicial boundary. -/
+public noncomputable def boundarySevenProperCechTupleFaceToBoundarySSetMap
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ⟶
+      (∂Δ[7] : SSet.{0}) := by
+  let i := Classical.choose a.support_nonempty
+  have hi : i ∈ a.1.support := Classical.choose_spec a.support_nonempty
+  apply SSet.Subcomplex.homOfLE
+  have hface : SSet.stdSimplex.face a.1.supportᶜ ≤
+      SSet.stdSimplex.face ({i} : Finset (Fin 8))ᶜ :=
+    (SSet.stdSimplex.face_le_face_iff _ _).mpr (by
+      intro j hj
+      simp only [Finset.mem_compl, Finset.mem_singleton]
+      intro hji
+      subst j
+      exact (Finset.mem_compl.mp hj) hi)
+  exact hface.trans (SSet.face_singleton_compl_le_boundary i)
+
+/-- Forgetting the boundary subtype recovers the ordinary inclusion of the common face in the
+ambient standard simplex. -/
+@[reassoc]
+public theorem boundarySevenProperCechTupleFaceToBoundarySSetMap_comp_inclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenProperCechTupleFaceToBoundarySSetMap a ≫
+        (SSet.boundary 7).ι =
+      (SSet.stdSimplex.face a.1.supportᶜ).ι := by
+  simp [boundarySevenProperCechTupleFaceToBoundarySSetMap]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The representability isomorphism uses exactly the increasing complementary-vertex
+inclusion. -/
+public theorem boundarySevenProperCechTupleFaceIso_hom_comp_faceInclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (boundarySevenProperCechTupleFaceIso a).hom ≫
+        (SSet.stdSimplex.face a.1.supportᶜ).ι =
+      SSet.stdSimplex.map
+        (boundarySevenProperCechTupleComplementSimplexHom a) := by
+  rfl
+
+/-- Insert the barycentric coordinates of the complementary standard simplex into the eight
+coordinates of the ambient seven-simplex. -/
+public noncomputable def boundarySevenProperCechTupleCoordinatePoint
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    stdSimplex ℝ (Fin 8) :=
+  stdSimplex.map
+    (fun j ↦ (boundarySevenProperCechTupleFaceOrderIso a j).1)
+    (SimplexCategory.toTopHomeo
+      (SimplexCategory.mk (boundarySevenProperCechTupleFaceDimension a)) x)
+
+/-- In barycentric coordinates, realizing the common-face inclusion is the literal insertion
+of the complementary coordinates. -/
+public theorem boundarySevenComparisonToStdSimplex_faceToBoundary_faceIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    boundarySevenComparisonToStdSimplex
+        (SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a)
+          (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).hom x)) =
+      boundarySevenProperCechTupleCoordinatePoint a x := by
+  unfold boundarySevenComparisonToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a)
+          (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).hom x))) = _
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    boundarySevenProperCechTupleFaceToBoundarySSetMap_comp_inclusion]
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    boundarySevenProperCechTupleFaceIso_hom_comp_faceInclusion]
+  exact SimplexCategory.toTopHomeo_naturality_apply
+    (boundarySevenProperCechTupleComplementSimplexHom a) x
+
+/-- Coordinates indexed by the tuple's support vanish in the complementary coordinate point. -/
+public theorem boundarySevenProperCechTupleCoordinatePoint_apply_of_mem_support
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}))
+    {i : Fin 8} (hi : i ∈ a.1.support) :
+    boundarySevenProperCechTupleCoordinatePoint a x i = 0 := by
+  apply stdSimplex_map_apply_eq_zero_of_not_mem_range
+  rintro ⟨j, rfl⟩
+  exact (Finset.mem_compl.mp
+    (boundarySevenProperCechTupleFaceOrderIso a j).2) hi
+
+/-- The complementary coordinate point lies in the ordinary simplex boundary. -/
+public theorem boundarySevenProperCechTupleCoordinatePoint_mem_boundary
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    ∃ i, boundarySevenProperCechTupleCoordinatePoint a x i = 0 := by
+  exact ⟨a.1 0,
+    boundarySevenProperCechTupleCoordinatePoint_apply_of_mem_support a x
+      (a.1.mem_support 0)⟩
+
+/-- The literal coordinate inclusion from the complementary standard simplex into the
+intersection belonging to the tuple support. -/
+public noncomputable def boundarySevenProperCechTupleStandardSimplexToIntersection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    C((SSet.toTop.obj
+        (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) : Type),
+      boundarySevenFaceNeighborhoodIntersection a.1.support) := by
+  let q : C((SSet.toTop.obj
+        (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) : Type),
+      StandardSimplexBoundary 7) :=
+    ⟨fun x ↦ ⟨boundarySevenProperCechTupleCoordinatePoint a x,
+        boundarySevenProperCechTupleCoordinatePoint_mem_boundary a x⟩,
+      (stdSimplex.continuous_map
+        (fun j ↦ (boundarySevenProperCechTupleFaceOrderIso a j).1)).comp
+          (SimplexCategory.toTopHomeo
+            (SimplexCategory.mk
+              (boundarySevenProperCechTupleFaceDimension a))).continuous |>.subtype_mk _⟩
+  have hmem (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+      boundarySevenRealizationHomeomorphStandardBoundary.symm (q x) ∈
+        boundarySevenFaceNeighborhoodIntersection a.1.support := by
+    rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+    intro i hi
+    have hcoord :
+        boundarySevenComparisonToStdSimplex
+            (boundarySevenRealizationHomeomorphStandardBoundary.symm (q x)) i = 0 := by
+      rw [← boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+      rw [Homeomorph.apply_symm_apply]
+      exact boundarySevenProperCechTupleCoordinatePoint_apply_of_mem_support a x hi
+    rw [hcoord]
+    norm_num
+  exact
+    ⟨fun x ↦
+        ⟨boundarySevenRealizationHomeomorphStandardBoundary.symm (q x), hmem x⟩,
+      (boundarySevenRealizationHomeomorphStandardBoundary.symm.continuous.comp
+        q.continuous).subtype_mk (fun x ↦ hmem x)⟩
+
+/-- The underlying boundary point of the literal coordinate map. -/
+@[simp]
+public theorem boundarySevenProperCechTupleStandardSimplexToIntersection_val
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (x : SSet.toTop.obj
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
+    (boundarySevenProperCechTupleStandardSimplexToIntersection a x).1 =
+      boundarySevenRealizationHomeomorphStandardBoundary.symm
+        ⟨boundarySevenProperCechTupleCoordinatePoint a x,
+          boundarySevenProperCechTupleCoordinatePoint_mem_boundary a x⟩ := by
+  rfl
+
+/-- The literal coordinate inclusion with the common face itself as source.  The inverse of the
+canonical representability isomorphism merely changes from face coordinates to the ordered
+complementary standard-simplex coordinates. -/
+public noncomputable def boundarySevenProperCechTupleFaceToIntersection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    C((SSet.toTop.obj
+        (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) : Type),
+      boundarySevenFaceNeighborhoodIntersection a.1.support) :=
+  (boundarySevenProperCechTupleStandardSimplexToIntersection a).comp
+    (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).inv).hom
+
+/-- The underlying inclusion of a face-neighbourhood intersection into the realized simplicial
+boundary. -/
+public def boundarySevenFaceNeighborhoodIntersectionToBoundary
+    (s : Finset (Fin 8)) :
+    C(boundarySevenFaceNeighborhoodIntersection s,
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :=
+  ⟨Subtype.val, continuous_subtype_val⟩
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The literal local coordinate map, followed by the ambient inclusion, is exactly the
+realization of the canonical inclusion of the common face in the simplicial boundary. -/
+public theorem boundarySevenProperCechTupleFaceToIntersection_comp_ambientInclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (boundarySevenFaceNeighborhoodIntersectionToBoundary a.1.support).comp
+        (boundarySevenProperCechTupleFaceToIntersection a) =
+      (SSet.toTop.map
+        (boundarySevenProperCechTupleFaceToBoundarySSetMap a)).hom := by
+  apply ContinuousMap.ext
+  intro x
+  let J := boundarySevenProperCechTupleFaceIso a
+  change (boundarySevenProperCechTupleFaceToIntersection a x).1 =
+    SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a) x
+  change (boundarySevenProperCechTupleStandardSimplexToIntersection a
+    (SSet.toTop.map J.inv x)).1 = _
+  apply boundarySevenRealizationHomeomorphStandardBoundary.injective
+  rw [boundarySevenProperCechTupleStandardSimplexToIntersection_val]
+  rw [Homeomorph.apply_symm_apply]
+  apply Subtype.ext
+  change boundarySevenProperCechTupleCoordinatePoint a
+      (SSet.toTop.map J.inv x) =
+    (boundarySevenRealizationHomeomorphStandardBoundary
+      (SSet.toTop.map
+        (boundarySevenProperCechTupleFaceToBoundarySSetMap a) x) :
+          stdSimplex ℝ (Fin 8))
+  rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+  rw [← boundarySevenComparisonToStdSimplex_faceToBoundary_faceIso a
+    (SSet.toTop.map J.inv x)]
+  congr 2
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    Iso.inv_hom_id, SSet.toTop.map_id]
+  rfl
+
+/-- Categorical form of the ambient-inclusion compatibility, stated with the standard
+topological-subset inclusion used by the Cech comparison. -/
+@[reassoc]
+public theorem boundarySevenProperCechTupleFaceToIntersection_comp_subsetInclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    TopCat.ofHom (boundarySevenProperCechTupleFaceToIntersection a) ≫
+        topologicalSubsetInclusion
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          (boundarySevenFaceNeighborhoodIntersection a.1.support) =
+      SSet.toTop.map
+        (boundarySevenProperCechTupleFaceToBoundarySSetMap a) := by
+  apply ConcreteCategory.hom_ext
+  intro x
+  exact DFunLike.congr_fun
+    (boundarySevenProperCechTupleFaceToIntersection_comp_ambientInclusion a) x
+
+/-- The canonical simplicial map from the common face to singular simplices in the matching
+face-neighbourhood intersection. -/
+public noncomputable def boundarySevenProperCechTupleLocalComparisonSSetMap
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ⟶
+      TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) :=
+  sSetTopAdj.unit.app
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ≫
+    TopCat.toSSet.map
+      (TopCat.ofHom (boundarySevenProperCechTupleFaceToIntersection a))
+
+/-- The integral chain map induced by the ordered-tuple local comparison. -/
+public noncomputable def boundarySevenProperCechTupleLocalIntegralComparison
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}).chainComplex
+        (AddCommGrpCat.of ℤ) ⟶
+      (TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))).chainComplex
+          (AddCommGrpCat.of ℤ) :=
+  SSet.chainComplexMap
+    (boundarySevenProperCechTupleLocalComparisonSSetMap a)
+      (AddCommGrpCat.of ℤ)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Precomposing the face comparison by its canonical representability isomorphism gives the
+standard-simplex comparison associated to the literal coordinate inclusion. -/
+public theorem boundarySevenProperCechTupleFaceIso_hom_comp_localComparisonSSetMap
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    (boundarySevenProperCechTupleFaceIso a).hom ≫
+        boundarySevenProperCechTupleLocalComparisonSSetMap a =
+      sSetTopAdj.unit.app
+          (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≫
+        TopCat.toSSet.map (TopCat.ofHom
+          (boundarySevenProperCechTupleStandardSimplexToIntersection a)) := by
+  let J := boundarySevenProperCechTupleFaceIso a
+  have hnat := sSetTopAdj.unit.naturality J.hom
+  rw [boundarySevenProperCechTupleLocalComparisonSSetMap]
+  change (((𝟭 SSet).map J.hom ≫ sSetTopAdj.unit.app
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0})) ≫
+    TopCat.toSSet.map (TopCat.ofHom
+      (boundarySevenProperCechTupleFaceToIntersection a))) = _
+  rw [hnat]
+  change (sSetTopAdj.unit.app
+      (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≫
+    TopCat.toSSet.map (SSet.toTop.map J.hom)) ≫
+      TopCat.toSSet.map (TopCat.ofHom
+        (boundarySevenProperCechTupleFaceToIntersection a)) = _
+  simp only [Category.assoc]
+  rw [← Functor.map_comp]
+  apply congrArg (fun f ↦ sSetTopAdj.unit.app
+    (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0}) ≫
+      TopCat.toSSet.map f)
+  apply ConcreteCategory.hom_ext
+  intro x
+  change boundarySevenProperCechTupleStandardSimplexToIntersection a
+      (SSet.toTop.map J.inv (SSet.toTop.map J.hom x)) =
+    boundarySevenProperCechTupleStandardSimplexToIntersection a x
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    Iso.hom_inv_id, SSet.toTop.map_id]
+  rfl
+
+/-- Chain-level form of the preceding representability identity. -/
+public theorem boundarySevenProperCechTupleFaceIso_chainMap_comp_localIntegralComparison
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    SSet.chainComplexMap (boundarySevenProperCechTupleFaceIso a).hom
+        (AddCommGrpCat.of ℤ) ≫
+      boundarySevenProperCechTupleLocalIntegralComparison a =
+    standardSimplexToContractibleSingularChainMap (AddCommGrpCat.of ℤ)
+      (boundarySevenProperCechTupleFaceDimension a)
+      (boundarySevenProperCechTupleStandardSimplexToIntersection a) := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  have h := F.congr_map
+    (boundarySevenProperCechTupleFaceIso_hom_comp_localComparisonSSetMap a)
+  rw [Functor.map_comp, Functor.map_comp] at h
+  exact h
+
+/-- The canonical integral comparison on every proper ordered Cech tuple is a
+quasi-isomorphism. -/
+public theorem boundarySevenProperCechTupleLocalIntegralComparison_quasiIso
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    QuasiIso (boundarySevenProperCechTupleLocalIntegralComparison a) := by
+  let P := SSet.chainComplexMap (boundarySevenProperCechTupleFaceIso a).hom
+    (AddCommGrpCat.of ℤ)
+  let L := boundarySevenProperCechTupleLocalIntegralComparison a
+  letI : IsIso (boundarySevenProperCechTupleFaceIso a).hom := inferInstance
+  letI : IsIso P := by
+    dsimp only [P]
+    infer_instance
+  let hstandard : QuasiIso
+      (standardSimplexToContractibleSingularChainMap (AddCommGrpCat.of ℤ)
+        (boundarySevenProperCechTupleFaceDimension a)
+        (boundarySevenProperCechTupleStandardSimplexToIntersection a)) :=
+    standardSimplexToBoundarySevenFaceNeighborhoodIntersection_quasiIso
+      (AddCommGrpCat.of ℤ) (boundarySevenProperCechTupleFaceDimension a)
+      a.1.support a.support_nonempty a.2
+      (boundarySevenProperCechTupleStandardSimplexToIntersection a)
+  have hcomp : QuasiIso (P ≫ L) := by
+    rw [show P ≫ L =
+        standardSimplexToContractibleSingularChainMap (AddCommGrpCat.of ℤ)
+          (boundarySevenProperCechTupleFaceDimension a)
+          (boundarySevenProperCechTupleStandardSimplexToIntersection a) by
+      exact boundarySevenProperCechTupleFaceIso_chainMap_comp_localIntegralComparison a]
+    exact hstandard
+  exact quasiIso_of_comp_left P L
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedSource.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedSource.lean
@@ -1,0 +1,396 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTuples
+public import Mathlib.CategoryTheory.Limits.Types.Coproducts
+
+/-!
+# Ordered-intersection decomposition of the simplicial-face Cech nerve
+
+In a fixed outer Cech degree, a compatible ordered tuple of facets of the seven-simplex
+has common simplicial face indexed by the complement of the tuple's support.  Full-support
+tuples have empty common face and are omitted.  This file identifies the coproduct of all
+remaining common faces with the corresponding object of the canonical pullback Cech nerve.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The common simplicial face belonging to a proper ordered Cech tuple. -/
+public abbrev boundarySevenOrderedSourceCommonFace
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) : SSet.{0} :=
+  (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0})
+
+/-- The common face includes into the facet selected in slot `i`, expressed in the standard
+`Delta[6]` parametrization used by the face presentation. -/
+public noncomputable def boundarySevenOrderedSourceCommonFaceToFacet
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFace a ⟶ (Δ[6] : SSet.{0}) :=
+  SSet.Subcomplex.homOfLE (by
+      rw [SSet.stdSimplex.face_le_face_iff]
+      intro j hj
+      apply Finset.mem_compl.mpr
+      simp only [Finset.mem_singleton]
+      intro hja
+      subst j
+      exact (Finset.mem_compl.mp hj) (a.1.mem_support i)) ≫
+    (SSet.stdSimplex.faceSingletonComplIso (a.1 i)).inv
+
+/-- The common face includes into the simplicial boundary. -/
+public noncomputable def boundarySevenOrderedSourceCommonFaceToBoundary
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCommonFace a ⟶ (∂Δ[7] : SSet.{0}) :=
+  boundarySevenOrderedSourceCommonFaceToFacet a 0 ≫
+    SSet.boundary.ι (a.1 0)
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCommonFaceToBoundary a ≫
+        (SSet.boundary 7).ι =
+      (SSet.stdSimplex.face a.1.supportᶜ).ι := by
+  simp [boundarySevenOrderedSourceCommonFaceToBoundary,
+    boundarySevenOrderedSourceCommonFaceToFacet]
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFaceToFacet a i ≫
+        SSet.boundary.ι (a.1 i) =
+      boundarySevenOrderedSourceCommonFaceToBoundary a := by
+  apply (cancel_mono (SSet.boundary 7).ι).1
+  simp only [Category.assoc,
+    boundarySevenOrderedSourceCommonFaceToFacet,
+    SSet.boundary.faceSingletonComplIso_inv_ι,
+    SSet.boundary.faceι_ι,
+    SSet.Subcomplex.homOfLE_ι]
+  exact (boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion a).symm
+
+/-- The leg from a common face to the coproduct presentation object in slot `i`. -/
+public noncomputable def boundarySevenOrderedSourcePresentationLeg
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFace a ⟶
+      boundarySevenSimplicialFacePresentationSource :=
+  boundarySevenOrderedSourceCommonFaceToFacet a i ≫
+    Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) (a.1 i)
+
+@[reassoc]
+public theorem boundarySevenOrderedSourcePresentationLeg_comp_presentation
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourcePresentationLeg a i ≫
+        boundarySevenSimplicialFacePresentation =
+      boundarySevenOrderedSourceCommonFaceToBoundary a := by
+  simp [boundarySevenOrderedSourcePresentationLeg,
+    boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary]
+
+/-- A common face determines a point of the pullback Cech object. -/
+public noncomputable def boundarySevenOrderedSourceCechSummand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCommonFace a ⟶
+      boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n :=
+  WidePullback.lift (boundarySevenOrderedSourceCommonFaceToBoundary a)
+    (boundarySevenOrderedSourcePresentationLeg a)
+    (boundarySevenOrderedSourcePresentationLeg_comp_presentation a)
+
+/-- The canonical map from the coproduct of proper common faces to the source Cech object. -/
+public noncomputable def boundarySevenOrderedSourceToCech
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      boundarySevenOrderedSourceCommonFace a) ⟶
+      boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n :=
+  Sigma.desc boundarySevenOrderedSourceCechSummand
+
+/-- Projection from the source Cech object to one selected presentation leg. -/
+public noncomputable def boundarySevenSourceCechProjection
+    (n : SimplexCategoryᵒᵖ) (i : Fin (n.unop.len + 1)) :
+    boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n ⟶
+      boundarySevenSimplicialFacePresentationSource :=
+  WidePullback.π
+    (fun _ : Fin (n.unop.len + 1) ↦
+      boundarySevenSimplicialFacePresentation) i
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem boundarySevenOrderedSourceCechSummand_comp_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCechSummand a ≫
+        boundarySevenSourceCechProjection n i =
+      boundarySevenOrderedSourcePresentationLeg a i := by
+  simpa [boundarySevenOrderedSourceCechSummand,
+    boundarySevenSourceCechProjection,
+    boundarySevenSimplicialFaceAugmentedCechNerve,
+    boundarySevenSimplicialFacePresentationArrow] using
+      (WidePullback.lift_π
+        (fun _ : Fin (n.unop.len + 1) ↦
+          boundarySevenSimplicialFacePresentation)
+        (boundarySevenOrderedSourceCommonFaceToBoundary a)
+        (boundarySevenOrderedSourcePresentationLeg a)
+        (boundarySevenOrderedSourcePresentationLeg_comp_presentation a) i)
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceToCech_comp_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n ↦
+        boundarySevenOrderedSourceCommonFace b) a ≫
+        boundarySevenOrderedSourceToCech n ≫
+        boundarySevenSourceCechProjection n i =
+      boundarySevenOrderedSourcePresentationLeg a i := by
+  rw [← Category.assoc, boundarySevenOrderedSourceToCech, Sigma.ι_desc]
+  exact boundarySevenOrderedSourceCechSummand_comp_projection a i
+
+public noncomputable def boundarySevenSourceCoproductAppIsColimit
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) :
+    IsColimit (Cofan.mk ((∐ X).obj q) (fun i => (Sigma.ι X i).app q)) :=
+  isColimitCofanMkObjOfIsColimit ((evaluation _ _).obj q) X
+    (fun i ↦ Sigma.ι X i) (coproductIsCoproduct X)
+
+public theorem boundarySevenSourceCoproduct_app_jointly_surjective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ)
+    (x : (∐ X).obj q) : ∃ i y, (Sigma.ι X i).app q y = x :=
+  Cofan.inj_jointly_surjective_of_isColimit
+    (boundarySevenSourceCoproductAppIsColimit X q) x
+
+public theorem boundarySevenSourceCoproduct_app_index_eq
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ)
+    {i j : ι} (x : (X i).obj q) (y : (X j).obj q)
+    (h : (Sigma.ι X i).app q x = (Sigma.ι X j).app q y) : i = j :=
+  Cofan.eq_of_inj_apply_eq_of_isColimit
+    (boundarySevenSourceCoproductAppIsColimit X q) x y h
+
+public theorem boundarySevenSourceCoproduct_app_injective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) (i : ι) :
+    Function.Injective ((Sigma.ι X i).app q) :=
+  Cofan.inj_injective_of_isColimit
+    (boundarySevenSourceCoproductAppIsColimit X q) i
+
+public theorem boundarySevenSourceCech_app_ext
+    {n q : SimplexCategoryᵒᵖ}
+    (x y : (boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n).obj q)
+    (h : ∀ i, (boundarySevenSourceCechProjection n i).app q x =
+      (boundarySevenSourceCechProjection n i).app q y) : x = y := by
+  let arrows := fun _ : Fin (n.unop.len + 1) ↦
+    boundarySevenSimplicialFacePresentation
+  let D := WidePullbackShape.wideCospan
+    (boundarySevenSimplicialFacePresentationArrow.right)
+    (fun _ : Fin (n.unop.len + 1) ↦
+      boundarySevenSimplicialFacePresentationArrow.left) arrows
+  let ev := (evaluation SimplexCategoryᵒᵖ (Type _)).obj q
+  have hlim : IsLimit (Functor.mapCone ev (limit.cone D)) :=
+    isLimitOfPreserves ev (limit.isLimit D)
+  apply (Types.isLimitEquivSections hlim).injective
+  apply Subtype.ext
+  funext j
+  cases j with
+  | none =>
+      have hx := congrArg (fun k ↦ k.app q x) (WidePullback.π_arrow arrows 0)
+      have hy := congrArg (fun k ↦ k.app q y) (WidePullback.π_arrow arrows 0)
+      exact hx.symm.trans
+        ((congrArg (fun z ↦ boundarySevenSimplicialFacePresentation.app q z)
+          (h 0)).trans hy)
+  | some i => exact h i
+
+public theorem boundarySevenOrderedSourceCommonFaceToFacet_app_injective
+    {n q : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Function.Injective
+      ((boundarySevenOrderedSourceCommonFaceToFacet a i).app q) := by
+  let _ : Mono (boundarySevenOrderedSourceCommonFaceToFacet a i) := by
+    dsimp [boundarySevenOrderedSourceCommonFaceToFacet]
+    infer_instance
+  exact (CategoryTheory.mono_iff_injective _).mp inferInstance
+
+public theorem boundarySevenOrderedSourceToCech_app_injective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Injective ((boundarySevenOrderedSourceToCech n).app q) := by
+  let X := fun a : BoundarySevenProperCechTuple n ↦
+    boundarySevenOrderedSourceCommonFace a
+  let Y := fun _j : Fin 8 ↦ (Δ[6] : SSet.{0})
+  intro x y hxy
+  obtain ⟨a, xa, rfl⟩ :=
+    boundarySevenSourceCoproduct_app_jointly_surjective X q x
+  obtain ⟨b, xb, rfl⟩ :=
+    boundarySevenSourceCoproduct_app_jointly_surjective X q y
+  have hcoord (i : Fin (n.unop.len + 1)) :
+      (Sigma.ι Y (a.1 i)).app q
+          ((boundarySevenOrderedSourceCommonFaceToFacet a i).app q xa) =
+        (Sigma.ι Y (b.1 i)).app q
+          ((boundarySevenOrderedSourceCommonFaceToFacet b i).app q xb) := by
+    have hproj := congrArg
+      (fun z ↦ (boundarySevenSourceCechProjection n i).app q z) hxy
+    have ha := congrArg (fun k ↦ k.app q xa)
+      (boundarySevenOrderedSourceToCech_comp_projection a i)
+    have hb := congrArg (fun k ↦ k.app q xb)
+      (boundarySevenOrderedSourceToCech_comp_projection b i)
+    exact ha.symm.trans (hproj.trans hb)
+  have hab : a = b := by
+    apply Subtype.ext
+    funext i
+    exact boundarySevenSourceCoproduct_app_index_eq Y q _ _ (hcoord i)
+  subst b
+  have hfacet :
+      (boundarySevenOrderedSourceCommonFaceToFacet a 0).app q xa =
+        (boundarySevenOrderedSourceCommonFaceToFacet a 0).app q xb :=
+    boundarySevenSourceCoproduct_app_injective Y q (a.1 0) (hcoord 0)
+  have habSimplex : xa = xb :=
+    boundarySevenOrderedSourceCommonFaceToFacet_app_injective a 0 hfacet
+  exact congrArg ((Sigma.ι X a).app q) habSimplex
+
+public theorem boundarySevenSimplicialFacePresentation_iota_app_injective
+    (q : SimplexCategoryᵒᵖ) (i : Fin 8) :
+    Function.Injective ((SSet.boundary.ι i).app q) := by
+  exact (CategoryTheory.mono_iff_injective _).mp inferInstance
+
+public theorem boundarySevenOrderedSourceToCech_app_surjective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Surjective ((boundarySevenOrderedSourceToCech n).app q) := by
+  rcases q with ⟨⟨d⟩⟩
+  let q : SimplexCategoryᵒᵖ := Opposite.op (SimplexCategory.mk d)
+  let X := fun a : BoundarySevenProperCechTuple n ↦
+    boundarySevenOrderedSourceCommonFace a
+  let Y := fun _j : Fin 8 ↦ (Δ[6] : SSet.{0})
+  intro x
+  have hex (i : Fin (n.unop.len + 1)) :
+      ∃ j y, (Sigma.ι Y j).app q y =
+        (boundarySevenSourceCechProjection n i).app q x :=
+    boundarySevenSourceCoproduct_app_jointly_surjective Y q _
+  choose a y hy using hex
+  let arrows := fun _ : Fin (n.unop.len + 1) ↦
+    boundarySevenSimplicialFacePresentation
+  have hboundary (i : Fin (n.unop.len + 1)) :
+      (SSet.boundary.ι (a i)).app q (y i) =
+        (SSet.boundary.ι (a 0)).app q (y 0) := by
+    have hpresi := congrArg (fun k ↦ k.app q (y i))
+      (boundarySevenSimplicialFacePresentation_iota (a i))
+    have hpres0 := congrArg (fun k ↦ k.app q (y 0))
+      (boundarySevenSimplicialFacePresentation_iota (a 0))
+    have hyi := congrArg
+      (fun z ↦ boundarySevenSimplicialFacePresentation.app q z) (hy i)
+    have hy0 := congrArg
+      (fun z ↦ boundarySevenSimplicialFacePresentation.app q z) (hy 0)
+    have hpi := congrArg (fun k ↦ k.app q x)
+      (WidePullback.π_arrow arrows i)
+    have hp0 := congrArg (fun k ↦ k.app q x)
+      (WidePullback.π_arrow arrows 0)
+    exact hpresi.symm.trans
+      (hyi.trans (hpi.trans (hp0.symm.trans (hy0.symm.trans hpres0))))
+  let zBoundary := (SSet.boundary.ι (a 0)).app q (y 0)
+  let zOrder := (SSet.stdSimplex.objEquiv zBoundary.1).toOrderHom
+  have havoid (k : Fin (q.unop.len + 1)) : zOrder k ∉
+      BoundarySevenCechTuple.support a := by
+    intro hk
+    obtain ⟨i, -, hai⟩ := Finset.mem_image.mp hk
+    have hiFace :=
+      ((SSet.stdSimplex.faceSingletonComplIso (a i)).hom.app q (y i)).2
+    rw [SSet.stdSimplex.mem_face_iff] at hiFace
+    have hne :
+        (SSet.stdSimplex.objEquiv
+            ((SSet.stdSimplex.faceSingletonComplIso (a i)).hom.app q (y i)).1).toOrderHom k ≠
+          a i := by
+      dsimp [q] at hiFace ⊢
+      simpa using hiFace k
+    have hfacetBoundary :
+        (SSet.stdSimplex.faceSingletonComplIso (a i)).hom ≫
+            SSet.boundary.faceι (a i) =
+          SSet.boundary.ι (a i) := by
+      apply (cancel_mono (SSet.boundary 7).ι).1
+      simp
+    have himage := congrArg Subtype.val
+      (ConcreteCategory.congr_hom (congr_app hfacetBoundary q) (y i))
+    apply hne
+    have himagek := congrArg
+      (fun t : (Δ[7] : SSet.{0}).obj q ↦
+        (SSet.stdSimplex.objEquiv t).toOrderHom k) himage
+    have hboundaryk := congrArg
+      (fun t : (∂Δ[7] : SSet.{0}).obj q ↦
+        (SSet.stdSimplex.objEquiv t.1).toOrderHom k) (hboundary i)
+    exact himagek.trans (hboundaryk.trans hai.symm)
+  have hproper : BoundarySevenCechTuple.support a ≠ Finset.univ := by
+    intro ha
+    exact havoid 0 (by rw [ha]; simp)
+  let ap : BoundarySevenProperCechTuple n := ⟨a, hproper⟩
+  let z : (boundarySevenOrderedSourceCommonFace ap).obj q :=
+    ⟨zBoundary.1, by
+      rw [SSet.stdSimplex.mem_face_iff]
+      intro k
+      dsimp [q, zOrder] at havoid ⊢
+      simpa using havoid k⟩
+  have hz (i : Fin (n.unop.len + 1)) :
+      (boundarySevenOrderedSourceCommonFaceToFacet ap i).app q z = y i := by
+    apply boundarySevenSimplicialFacePresentation_iota_app_injective q (a i)
+    have hfac :
+        (SSet.boundary.ι (a i)).app q
+            ((boundarySevenOrderedSourceCommonFaceToFacet ap i).app q z) =
+          (boundarySevenOrderedSourceCommonFaceToBoundary ap).app q z := by
+      simpa using ConcreteCategory.congr_hom
+        (congr_app
+          (boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary ap i) q) z
+    rw [hfac]
+    have hcommon :
+        (boundarySevenOrderedSourceCommonFaceToBoundary ap).app q z = zBoundary := by
+      apply Subtype.ext
+      have hinc := ConcreteCategory.congr_hom
+        (congr_app
+          (boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion ap) q) z
+      change ((boundarySevenOrderedSourceCommonFaceToBoundary ap).app q z).1 = z.1 at hinc
+      simpa [z] using hinc
+    rw [hcommon]
+    exact (hboundary i).symm
+  refine ⟨(Sigma.ι X ap).app q z, ?_⟩
+  apply boundarySevenSourceCech_app_ext
+  intro i
+  calc
+    (boundarySevenSourceCechProjection n i).app q
+        ((boundarySevenOrderedSourceToCech n).app q ((Sigma.ι X ap).app q z)) =
+      (Sigma.ι Y (a i)).app q
+        ((boundarySevenOrderedSourceCommonFaceToFacet ap i).app q z) := by
+          simpa [X, Y, boundarySevenOrderedSourcePresentationLeg] using
+            congrArg (fun k ↦ k.app q z)
+            (boundarySevenOrderedSourceToCech_comp_projection ap i)
+    _ = (Sigma.ι Y (a i)).app q (y i) := congrArg _ (hz i)
+    _ = (boundarySevenSourceCechProjection n i).app q x := hy i
+
+/-- In every outer degree, the coproduct of proper common simplicial faces is canonically
+isomorphic to the corresponding object of the simplicial-face Cech nerve. -/
+public noncomputable def boundarySevenOrderedSourceCechIso
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      boundarySevenOrderedSourceCommonFace a) ≅
+      boundarySevenSimplicialFaceAugmentedCechNerve.left.obj n := by
+  let _ : ∀ q, IsIso ((boundarySevenOrderedSourceToCech n).app q) := fun q ↦
+    (CategoryTheory.isIso_iff_bijective _).mpr
+      ⟨boundarySevenOrderedSourceToCech_app_injective n q,
+        boundarySevenOrderedSourceToCech_app_surjective n q⟩
+  let _ : IsIso (boundarySevenOrderedSourceToCech n) :=
+    NatIso.isIso_of_isIso_app (boundarySevenOrderedSourceToCech n)
+  exact asIso (boundarySevenOrderedSourceToCech n)
+
+@[simp]
+public theorem boundarySevenOrderedSourceCechIso_hom
+    (n : SimplexCategoryᵒᵖ) :
+    (boundarySevenOrderedSourceCechIso n).hom =
+      boundarySevenOrderedSourceToCech n :=
+  rfl
+
+@[reassoc]
+public theorem boundarySevenOrderedSourceCechIso_hom_comp_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n ↦
+        boundarySevenOrderedSourceCommonFace b) a ≫
+        (boundarySevenOrderedSourceCechIso n).hom ≫
+        boundarySevenSourceCechProjection n i =
+      boundarySevenOrderedSourcePresentationLeg a i := by
+  rw [boundarySevenOrderedSourceCechIso_hom]
+  exact boundarySevenOrderedSourceToCech_comp_projection a i
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedTarget.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedTarget.lean
@@ -1,0 +1,435 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTuples
+public import Mathlib.CategoryTheory.Limits.Types.Coproducts
+
+/-!
+# Ordered-tuple decomposition of the boundary-seven target Cech nerve
+
+The iterated pullback in each outer Cech degree is the coproduct of the singular simplicial
+sets of the corresponding ordered intersections.  Since the intersection of all eight face
+neighbourhoods is empty, only tuples with proper support occur.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+public abbrev boundarySevenTargetAmbient : TopCat :=
+  SSet.toTop.obj (∂Δ[7] : SSet.{0})
+
+/-- Inclusion of an ordered proper intersection into one of its selected cover members. -/
+public def boundarySevenTargetIntersectionToMember
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support) ⟶
+      TopCat.of (boundarySevenComparisonFaceNeighborhood (a.1 i)) :=
+  TopCat.ofHom
+    { toFun := fun x => ⟨x.1, by
+        exact (mem_boundarySevenFaceNeighborhoodIntersection_iff a.1.support x).mp x.2
+          (a.1 i) (BoundarySevenCechTuple.mem_support a.1 i)⟩
+      continuous_toFun := by fun_prop }
+
+@[reassoc]
+public theorem boundarySevenTargetIntersectionToMember_comp_inclusion
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenTargetIntersectionToMember a i ≫
+        topologicalSubsetInclusion boundarySevenTargetAmbient
+          (boundarySevenComparisonFaceNeighborhood (a.1 i)) =
+      topologicalSubsetInclusion boundarySevenTargetAmbient
+        (boundarySevenFaceNeighborhoodIntersection a.1.support) := by
+  ext x
+  rfl
+
+/-- The leg from an ordered intersection to the selected summand of the presentation source. -/
+public noncomputable def boundarySevenTargetIntersectionToPresentationLeg
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) ⟶
+      boundarySevenFaceNeighborhoodPresentationSource :=
+  TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) ≫
+    Sigma.ι (fun j : Fin 8 => TopCat.toSSet.obj
+      (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i)
+
+public noncomputable def boundarySevenTargetIntersectionToSmall
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) ⟶
+      coverSmallSingularSubcomplex boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood :=
+  TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a 0) ≫
+    coverMemberToSmallSingularSet boundarySevenTargetAmbient
+      boundarySevenComparisonFaceNeighborhood (a.1 0)
+
+public theorem boundarySevenTargetIntersectionToPresentationLeg_condition
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenTargetIntersectionToPresentationLeg a i ≫
+        boundarySevenFaceNeighborhoodPresentation =
+      boundarySevenTargetIntersectionToSmall a := by
+  rw [← cancel_mono
+    (coverSmallSingularSubcomplex boundarySevenTargetAmbient
+      boundarySevenComparisonFaceNeighborhood).ι]
+  simp only [boundarySevenTargetIntersectionToPresentationLeg,
+    boundarySevenFaceNeighborhoodPresentation, Category.assoc, Sigma.ι_desc_assoc,
+    coverMemberToSmallSingularSet_comp_inclusion,
+    boundarySevenTargetIntersectionToSmall]
+  rw [← Functor.map_comp, ← Functor.map_comp]
+  congr 1
+
+/-- The canonical map from one ordered-intersection summand to the corresponding Cech
+wide pullback. -/
+public noncomputable def boundarySevenTargetIntersectionToCechSummand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support)) ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n :=
+  WidePullback.lift (boundarySevenTargetIntersectionToSmall a)
+    (boundarySevenTargetIntersectionToPresentationLeg a)
+    (boundarySevenTargetIntersectionToPresentationLeg_condition a)
+
+/-- The coproduct map from all proper ordered intersections to the target Cech object. -/
+public noncomputable def boundarySevenOrderedTargetCechMap
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))) ⟶
+      boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n :=
+  Sigma.desc boundarySevenTargetIntersectionToCechSummand
+
+private noncomputable def boundarySevenSSetCoproductAppIsColimit
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) :
+    IsColimit (Cofan.mk ((∐ X).obj q) (fun i => (Sigma.ι X i).app q)) :=
+  isColimitCofanMkObjOfIsColimit ((evaluation _ _).obj q) X
+    (fun i => Sigma.ι X i) (coproductIsCoproduct X)
+
+private theorem boundarySevenSSetCoproduct_app_jointly_surjective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) (x : (∐ X).obj q) :
+    ∃ i y, (Sigma.ι X i).app q y = x :=
+  Cofan.inj_jointly_surjective_of_isColimit
+    (boundarySevenSSetCoproductAppIsColimit X q) x
+
+private theorem boundarySevenSSetCoproduct_app_index_eq
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ)
+    {i j : ι} (x : (X i).obj q) (y : (X j).obj q)
+    (h : (Sigma.ι X i).app q x = (Sigma.ι X j).app q y) : i = j :=
+  Cofan.eq_of_inj_apply_eq_of_isColimit
+    (boundarySevenSSetCoproductAppIsColimit X q) x y h
+
+private theorem boundarySevenSSetCoproduct_app_injective
+    {ι : Type} (X : ι → SSet) (q : SimplexCategoryᵒᵖ) (i : ι) :
+    Function.Injective ((Sigma.ι X i).app q) :=
+  Cofan.inj_injective_of_isColimit
+    (boundarySevenSSetCoproductAppIsColimit X q) i
+
+/-- Projection from the target Cech wide pullback to a selected presentation leg. -/
+public noncomputable def boundarySevenTargetCechProjection
+    (n : SimplexCategoryᵒᵖ) (i : Fin (n.unop.len + 1)) :
+    boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n ⟶
+      boundarySevenFaceNeighborhoodPresentationSource :=
+  WidePullback.π (fun _ : Fin (n.unop.len + 1) =>
+    boundarySevenFaceNeighborhoodPresentation) i
+
+private theorem boundarySevenTargetCech_app_ext
+    {n q : SimplexCategoryᵒᵖ}
+    (x y : (boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n).obj q)
+    (h : ∀ i, (boundarySevenTargetCechProjection n i).app q x =
+      (boundarySevenTargetCechProjection n i).app q y) : x = y := by
+  let arrows := fun _ : Fin (n.unop.len + 1) =>
+    boundarySevenFaceNeighborhoodPresentation
+  let D := WidePullbackShape.wideCospan
+    (coverSmallSingularSubcomplex boundarySevenTargetAmbient
+      boundarySevenComparisonFaceNeighborhood : SSet)
+    (fun _ : Fin (n.unop.len + 1) =>
+      boundarySevenFaceNeighborhoodPresentationSource) arrows
+  let ev := (evaluation SimplexCategoryᵒᵖ (Type _)).obj q
+  have hlim : IsLimit (Functor.mapCone ev (limit.cone D)) :=
+    isLimitOfPreserves ev (limit.isLimit D)
+  apply (Types.isLimitEquivSections hlim).injective
+  apply Subtype.ext
+  funext j
+  cases j with
+  | none =>
+      have hx := congrArg (fun k => k.app q x) (WidePullback.π_arrow arrows 0)
+      have hy := congrArg (fun k => k.app q y) (WidePullback.π_arrow arrows 0)
+      exact hx.symm.trans ((congrArg
+        (fun z => (arrows 0).app q z) (h 0)).trans hy)
+  | some i => exact h i
+
+/-- On a summand, the ordered-target map followed by a Cech projection is the selected
+intersection inclusion into the corresponding presentation summand. -/
+@[reassoc]
+public theorem boundarySevenOrderedTargetCechMap_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n =>
+        TopCat.toSSet.obj
+          (TopCat.of (boundarySevenFaceNeighborhoodIntersection b.1.support))) a ≫
+        boundarySevenOrderedTargetCechMap n ≫
+        boundarySevenTargetCechProjection n i =
+      TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) ≫
+        Sigma.ι (fun j : Fin 8 => TopCat.toSSet.obj
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i) := by
+  rw [← Category.assoc, boundarySevenOrderedTargetCechMap, Sigma.ι_desc]
+  change WidePullback.lift (boundarySevenTargetIntersectionToSmall a)
+      (boundarySevenTargetIntersectionToPresentationLeg a)
+      (boundarySevenTargetIntersectionToPresentationLeg_condition a) ≫
+        WidePullback.π (fun _ : Fin (n.unop.len + 1) =>
+          boundarySevenFaceNeighborhoodPresentation) i = _
+  rw [WidePullback.lift_π]
+  rfl
+
+private theorem boundarySevenTargetIntersectionToMember_app_injective
+    {n q : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Function.Injective
+      ((TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i)).app q) := by
+  let _ : Mono (boundarySevenTargetIntersectionToMember a i) :=
+    (TopCat.mono_iff_injective _).mpr
+      (fun _ _ h => Subtype.ext
+        (congrArg (fun z : boundarySevenComparisonFaceNeighborhood (a.1 i) => z.1) h))
+  let _ : Mono (TopCat.toSSet.map
+      (boundarySevenTargetIntersectionToMember a i)) :=
+    Functor.map_mono TopCat.toSSet _
+  exact (CategoryTheory.mono_iff_injective _).mp inferInstance
+
+public theorem boundarySevenOrderedTargetCechMap_app_injective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Injective ((boundarySevenOrderedTargetCechMap n).app q) := by
+  let X := fun a : BoundarySevenProperCechTuple n =>
+    TopCat.toSSet.obj
+      (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))
+  let Y := fun j : Fin 8 => TopCat.toSSet.obj
+    (TopCat.of (boundarySevenComparisonFaceNeighborhood j))
+  intro x y hxy
+  obtain ⟨a, xa, rfl⟩ :=
+    boundarySevenSSetCoproduct_app_jointly_surjective X q x
+  obtain ⟨b, xb, rfl⟩ :=
+    boundarySevenSSetCoproduct_app_jointly_surjective X q y
+  have hcoord (i : Fin (n.unop.len + 1)) :
+      (Sigma.ι Y (a.1 i)).app q
+          ((TopCat.toSSet.map
+            (boundarySevenTargetIntersectionToMember a i)).app q xa) =
+        (Sigma.ι Y (b.1 i)).app q
+          ((TopCat.toSSet.map
+            (boundarySevenTargetIntersectionToMember b i)).app q xb) := by
+    have hproj := congrArg
+      (fun z => (boundarySevenTargetCechProjection n i).app q z) hxy
+    have ha := congrArg (fun k => k.app q xa)
+      (boundarySevenOrderedTargetCechMap_projection a i)
+    have hb := congrArg (fun k => k.app q xb)
+      (boundarySevenOrderedTargetCechMap_projection b i)
+    exact ha.symm.trans (hproj.trans hb)
+  have hab : a = b := by
+    apply Subtype.ext
+    funext i
+    exact boundarySevenSSetCoproduct_app_index_eq Y q _ _ (hcoord i)
+  subst b
+  have hmember :
+      (TopCat.toSSet.map
+        (boundarySevenTargetIntersectionToMember a 0)).app q xa =
+      (TopCat.toSSet.map
+        (boundarySevenTargetIntersectionToMember a 0)).app q xb :=
+    boundarySevenSSetCoproduct_app_injective Y q (a.1 0) (hcoord 0)
+  have habSimplex : xa = xb :=
+    boundarySevenTargetIntersectionToMember_app_injective a 0 hmember
+  exact congrArg ((Sigma.ι X a).app q) habSimplex
+
+private theorem boundarySevenTargetPresentation_ι (j : Fin 8) :
+    Sigma.ι (fun k : Fin 8 => TopCat.toSSet.obj
+      (TopCat.of (boundarySevenComparisonFaceNeighborhood k))) j ≫
+        boundarySevenFaceNeighborhoodPresentation =
+      coverMemberToSmallSingularSet boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood j := by
+  rw [boundarySevenFaceNeighborhoodPresentation, Sigma.ι_desc]
+
+private theorem boundarySevenToSSetObjEquiv_map_apply
+    {X Y : TopCat} (f : X ⟶ Y) (q : SimplexCategoryᵒᵖ)
+    (x : (TopCat.toSSet.obj X).obj q)
+    (z : stdSimplex ℝ (Fin (q.unop.len + 1))) :
+    (TopCat.toSSetObjEquiv Y q) ((TopCat.toSSet.map f).app q x) z =
+      f ((TopCat.toSSetObjEquiv X q x) z) := by
+  rfl
+
+public theorem boundarySevenOrderedTargetCechMap_app_surjective
+    (n q : SimplexCategoryᵒᵖ) :
+    Function.Surjective ((boundarySevenOrderedTargetCechMap n).app q) := by
+  let X := fun a : BoundarySevenProperCechTuple n =>
+    TopCat.toSSet.obj
+      (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))
+  let Y := fun j : Fin 8 => TopCat.toSSet.obj
+    (TopCat.of (boundarySevenComparisonFaceNeighborhood j))
+  intro x
+  have hex (i : Fin (n.unop.len + 1)) :
+      ∃ j y, (Sigma.ι Y j).app q y =
+        (boundarySevenTargetCechProjection n i).app q x :=
+    boundarySevenSSetCoproduct_app_jointly_surjective Y q _
+  choose a y hy using hex
+  let arrows := fun _ : Fin (n.unop.len + 1) =>
+    boundarySevenFaceNeighborhoodPresentation
+  have hsmall (i : Fin (n.unop.len + 1)) :
+      (coverMemberToSmallSingularSet boundarySevenTargetAmbient
+          boundarySevenComparisonFaceNeighborhood (a i)).app q (y i) =
+        (coverMemberToSmallSingularSet boundarySevenTargetAmbient
+          boundarySevenComparisonFaceNeighborhood (a 0)).app q (y 0) := by
+    have hpresi := congrArg (fun k => k.app q (y i))
+      (boundarySevenTargetPresentation_ι (a i))
+    have hpres0 := congrArg (fun k => k.app q (y 0))
+      (boundarySevenTargetPresentation_ι (a 0))
+    have hyi := congrArg
+      (fun z => boundarySevenFaceNeighborhoodPresentation.app q z) (hy i)
+    have hy0 := congrArg
+      (fun z => boundarySevenFaceNeighborhoodPresentation.app q z) (hy 0)
+    have hpi := congrArg (fun k => k.app q x) (WidePullback.π_arrow arrows i)
+    have hp0 := congrArg (fun k => k.app q x) (WidePullback.π_arrow arrows 0)
+    exact hpresi.symm.trans
+      (hyi.trans (hpi.trans (hp0.symm.trans (hy0.symm.trans hpres0))))
+  have hfull (i : Fin (n.unop.len + 1)) :
+      (TopCat.toSSet.map
+        (topologicalSubsetInclusion boundarySevenTargetAmbient
+          (boundarySevenComparisonFaceNeighborhood (a i)))).app q (y i) =
+      (TopCat.toSSet.map
+        (topologicalSubsetInclusion boundarySevenTargetAmbient
+          (boundarySevenComparisonFaceNeighborhood (a 0)))).app q (y 0) := by
+    have hi := congrArg (fun k => k.app q (y i))
+      (coverMemberToSmallSingularSet_comp_inclusion boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood (a i))
+    have h0 := congrArg (fun k => k.app q (y 0))
+      (coverMemberToSmallSingularSet_comp_inclusion boundarySevenTargetAmbient
+        boundarySevenComparisonFaceNeighborhood (a 0))
+    exact hi.symm.trans
+      ((congrArg (fun z =>
+        (coverSmallSingularSubcomplex boundarySevenTargetAmbient
+          boundarySevenComparisonFaceNeighborhood).ι.app q z) (hsmall i)).trans h0)
+  let y0Map := TopCat.toSSetObjEquiv
+    (TopCat.of (boundarySevenComparisonFaceNeighborhood (a 0))) q (y 0)
+  have haProper : BoundarySevenCechTuple.support a ≠ Finset.univ := by
+    intro ha
+    let p : stdSimplex ℝ (Fin (q.unop.len + 1)) := stdSimplex.barycenter
+    have hp : (y0Map p).1 ∈
+        boundarySevenFaceNeighborhoodIntersection
+          (BoundarySevenCechTuple.support a) := by
+      rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+      intro j hj
+      obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hj
+      have heq := congrArg (fun s =>
+        (TopCat.toSSetObjEquiv boundarySevenTargetAmbient q s) p) (hfull i)
+      rw [boundarySevenToSSetObjEquiv_map_apply,
+        boundarySevenToSSetObjEquiv_map_apply] at heq
+      change ((TopCat.toSSetObjEquiv
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).1 =
+          (y0Map p).1 at heq
+      rw [← heq]
+      exact ((TopCat.toSSetObjEquiv
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).2
+    rw [ha, boundarySevenFaceNeighborhoodIntersection_univ_eq_empty] at hp
+    exact hp
+  let ap : BoundarySevenProperCechTuple n := ⟨a, haProper⟩
+  let zMap : C(stdSimplex ℝ (Fin (q.unop.len + 1)),
+      boundarySevenFaceNeighborhoodIntersection
+        (BoundarySevenCechTuple.support a)) :=
+    { toFun := fun p => ⟨(y0Map p).1, by
+        rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+        intro j hj
+        obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hj
+        have heq := congrArg (fun s =>
+          (TopCat.toSSetObjEquiv boundarySevenTargetAmbient q s) p) (hfull i)
+        rw [boundarySevenToSSetObjEquiv_map_apply,
+          boundarySevenToSSetObjEquiv_map_apply] at heq
+        change ((TopCat.toSSetObjEquiv
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).1 =
+            (y0Map p).1 at heq
+        rw [← heq]
+        exact ((TopCat.toSSetObjEquiv
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q (y i)) p).2⟩
+      continuous_toFun := by fun_prop }
+  let z := (TopCat.toSSetObjEquiv
+    (TopCat.of (boundarySevenFaceNeighborhoodIntersection
+      (BoundarySevenCechTuple.support a))) q).symm zMap
+  have hz (i : Fin (n.unop.len + 1)) :
+      (TopCat.toSSet.map
+        (boundarySevenTargetIntersectionToMember ap i)).app q z = y i := by
+    apply (TopCat.toSSetObjEquiv
+      (TopCat.of (boundarySevenComparisonFaceNeighborhood (a i))) q).injective
+    ext p
+    have heq := congrArg (fun s =>
+      (TopCat.toSSetObjEquiv boundarySevenTargetAmbient q s) p) (hfull i)
+    rw [boundarySevenToSSetObjEquiv_map_apply,
+      boundarySevenToSSetObjEquiv_map_apply] at heq
+    rw [boundarySevenToSSetObjEquiv_map_apply]
+    simp only [z]
+    exact heq.symm
+  refine ⟨(Sigma.ι X ap).app q z, ?_⟩
+  apply boundarySevenTargetCech_app_ext
+  intro i
+  calc
+    (boundarySevenTargetCechProjection n i).app q
+        ((boundarySevenOrderedTargetCechMap n).app q
+          ((Sigma.ι X ap).app q z)) =
+      (Sigma.ι Y (a i)).app q
+        ((TopCat.toSSet.map
+          (boundarySevenTargetIntersectionToMember ap i)).app q z) := by
+            simpa using congrArg (fun k => k.app q z)
+              (boundarySevenOrderedTargetCechMap_projection ap i)
+    _ = (Sigma.ι Y (a i)).app q (y i) := congrArg _ (hz i)
+    _ = (boundarySevenTargetCechProjection n i).app q x := hy i
+
+/-- Objectwise, the target Cech nerve is the coproduct of the singular simplicial sets of
+proper ordered face-neighbourhood intersections. -/
+public noncomputable def boundarySevenOrderedTargetCechIso
+    (n : SimplexCategoryᵒᵖ) :
+    (∐ fun a : BoundarySevenProperCechTuple n =>
+      TopCat.toSSet.obj
+        (TopCat.of (boundarySevenFaceNeighborhoodIntersection a.1.support))) ≅
+      boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj n := by
+  let _ : ∀ q, IsIso ((boundarySevenOrderedTargetCechMap n).app q) := fun q =>
+    (CategoryTheory.isIso_iff_bijective _).mpr
+      ⟨boundarySevenOrderedTargetCechMap_app_injective n q,
+        boundarySevenOrderedTargetCechMap_app_surjective n q⟩
+  let _ : IsIso (boundarySevenOrderedTargetCechMap n) :=
+    NatIso.isIso_of_isIso_app (boundarySevenOrderedTargetCechMap n)
+  exact asIso (boundarySevenOrderedTargetCechMap n)
+
+@[simp]
+public theorem boundarySevenOrderedTargetCechIso_hom
+    (n : SimplexCategoryᵒᵖ) :
+    (boundarySevenOrderedTargetCechIso n).hom =
+      boundarySevenOrderedTargetCechMap n :=
+  rfl
+
+/-- The public isomorphism restricts on each coproduct summand to the canonical wide-pullback
+lift from that ordered intersection. -/
+@[reassoc]
+public theorem boundarySevenOrderedTargetCechIso_hom_summand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n =>
+        TopCat.toSSet.obj
+          (TopCat.of (boundarySevenFaceNeighborhoodIntersection b.1.support))) a ≫
+        (boundarySevenOrderedTargetCechIso n).hom =
+      boundarySevenTargetIntersectionToCechSummand a := by
+  rw [boundarySevenOrderedTargetCechIso_hom,
+    boundarySevenOrderedTargetCechMap, Sigma.ι_desc]
+
+/-- Projection formula stated directly for the public objectwise isomorphism. -/
+@[reassoc]
+public theorem boundarySevenOrderedTargetCechIso_hom_projection
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    Sigma.ι (fun b : BoundarySevenProperCechTuple n =>
+        TopCat.toSSet.obj
+          (TopCat.of (boundarySevenFaceNeighborhoodIntersection b.1.support))) a ≫
+        (boundarySevenOrderedTargetCechIso n).hom ≫
+        boundarySevenTargetCechProjection n i =
+      TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) ≫
+        Sigma.ι (fun j : Fin 8 => TopCat.toSSet.obj
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i) := by
+  rw [boundarySevenOrderedTargetCechIso_hom]
+  exact boundarySevenOrderedTargetCechMap_projection a i
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedTuples.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedTuples.lean
@@ -1,0 +1,70 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechGlobalComparison
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersectionHomology
+
+/-!
+# Ordered tuples for the boundary-seven Cech nerves
+
+This file contains only the common finite indexing data used by the independent source- and
+target-side objectwise decompositions of the two Cech nerves.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- An ordered choice of one of the eight facets in every slot of an outer Cech degree. -/
+public abbrev BoundarySevenCechTuple (n : SimplexCategoryᵒᵖ) :=
+  Fin (n.unop.len + 1) → Fin 8
+
+namespace BoundarySevenCechTuple
+
+/-- The unordered support of an ordered Cech tuple. -/
+public def support {n : SimplexCategoryᵒᵖ} (a : BoundarySevenCechTuple n) :
+    Finset (Fin 8) :=
+  Finset.univ.image a
+
+@[simp]
+public theorem mem_support {n : SimplexCategoryᵒᵖ} (a : BoundarySevenCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    a i ∈ a.support :=
+  Finset.mem_image.mpr ⟨i, Finset.mem_univ i, rfl⟩
+
+public theorem support_nonempty {n : SimplexCategoryᵒᵖ} (a : BoundarySevenCechTuple n) :
+    a.support.Nonempty :=
+  ⟨a 0, a.mem_support 0⟩
+
+end BoundarySevenCechTuple
+
+/-- Tuples with proper support.  The omitted full-support tuples correspond on both sides to
+the empty eightfold intersection. -/
+public abbrev BoundarySevenProperCechTuple (n : SimplexCategoryᵒᵖ) :=
+  {a : BoundarySevenCechTuple n // a.support ≠ Finset.univ}
+
+namespace BoundarySevenProperCechTuple
+
+public theorem support_nonempty {n : SimplexCategoryᵒᵖ}
+    (a : BoundarySevenProperCechTuple n) :
+    a.1.support.Nonempty :=
+  a.1.support_nonempty
+
+public theorem support_ssubset_univ {n : SimplexCategoryᵒᵖ}
+    (a : BoundarySevenProperCechTuple n) :
+    a.1.support ⊂ Finset.univ :=
+  Finset.ssubset_iff_subset_ne.mpr ⟨Finset.subset_univ _, a.2⟩
+
+public theorem support_compl_nonempty {n : SimplexCategoryᵒᵖ}
+    (a : BoundarySevenProperCechTuple n) :
+    a.1.supportᶜ.Nonempty := by
+  apply Finset.nonempty_of_ne_empty
+  intro h
+  exact a.2 ((Finset.compl_eq_empty_iff _).mp h)
+
+end BoundarySevenProperCechTuple
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechRowIdentificationsProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechRowIdentificationsProof.lean
@@ -1,0 +1,681 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechLowAssemblyProof
+
+/-!
+# Row identifications for the boundary-seven Cech bicomplexes
+
+This file identifies evaluation of the two actual Cech bicomplex augmentations with the
+separately constructed evaluated augmented-Cech rows.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+noncomputable def cechPresentationEvaluationArrow
+    (A : Arrow SSet) (q : ℕ) : Arrow (Type 0) :=
+  Arrow.mk (A.hom.app (Opposite.op (SimplexCategory.mk q)))
+
+noncomputable def cechPresentationWideCospanEvaluationIso
+    (A : Arrow SSet) (p q : ℕ) :
+    WidePullbackShape.wideCospan A.right
+        (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom) ⋙
+          (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)) ≅
+      WidePullbackShape.wideCospan
+        ((cechPresentationEvaluationArrow A q).right)
+        (fun _ : Fin (p + 1) ↦ (cechPresentationEvaluationArrow A q).left)
+        (fun _ ↦ (cechPresentationEvaluationArrow A q).hom) :=
+  NatIso.ofComponents
+    (fun x ↦ by cases x <;> exact Iso.refl _)
+    (by
+      intro X Y f
+      cases f <;> rfl)
+
+noncomputable def cechPresentationEvaluationIso
+    (A : Arrow SSet) (p q : ℕ) :
+    (A.augmentedCechNerve.left.obj
+        (Opposite.op (SimplexCategory.mk p))).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (cechPresentationEvaluationArrow A q).augmentedCechNerve.left.obj
+        (Opposite.op (SimplexCategory.mk p)) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  change E.obj (widePullback A.right (fun _ : Fin (p + 1) ↦ A.left)
+      (fun _ ↦ A.hom)) ≅
+    widePullback (E.obj A.right) (fun _ : Fin (p + 1) ↦ E.obj A.left)
+      (fun _ ↦ E.map A.hom)
+  exact preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+    (cechPresentationWideCospanEvaluationIso A p q)
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+theorem cechPresentationEvaluationIso_hom_π
+    (A : Arrow SSet) (p q : ℕ) (i : Fin (p + 1)) :
+    (cechPresentationEvaluationIso A p q).hom ≫
+        WidePullback.π
+          (fun _ : Fin (p + 1) ↦
+            (cechPresentationEvaluationArrow A q).hom) i =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π (fun _ : Fin (p + 1) ↦ A.hom) i) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app (some i) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let B := cechPresentationEvaluationArrow A q
+  let D' := WidePullbackShape.wideCospan B.right
+    (fun _ : Fin (p + 1) ↦ B.left) (fun _ ↦ B.hom)
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (cechPresentationWideCospanEvaluationIso A p q)).hom) ≫
+      limit.π D' (some i) = E.map (limit.π D (some i)) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app (some i)
+  dsimp only [D']
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (cechPresentationWideCospanEvaluationIso A p q) (some i)]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+theorem cechPresentationEvaluationIso_hom_base
+    (A : Arrow SSet) (p q : ℕ) :
+    (cechPresentationEvaluationIso A p q).hom ≫
+        WidePullback.base
+          (fun _ : Fin (p + 1) ↦ (cechPresentationEvaluationArrow A q).hom) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (p + 1) ↦ A.hom)) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app none := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let B := cechPresentationEvaluationArrow A q
+  let D' := WidePullbackShape.wideCospan B.right
+    (fun _ : Fin (p + 1) ↦ B.left) (fun _ ↦ B.hom)
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (cechPresentationWideCospanEvaluationIso A p q)).hom) ≫
+      limit.π D' none = E.map (limit.π D none) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app none
+  dsimp only [D']
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (cechPresentationWideCospanEvaluationIso A p q) none]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cechPresentationEvaluation_map_π_comp_diagramIso
+    (A : Arrow SSet) (p q : ℕ) (i : Fin (p + 1)) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π (fun _ : Fin (p + 1) ↦ A.hom) i) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app (some i) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π (fun _ : Fin (p + 1) ↦ A.hom) i) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cechPresentationEvaluation_map_base_comp_diagramIso
+    (A : Arrow SSet) (p q : ℕ) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (p + 1) ↦ A.hom)) ≫
+        (cechPresentationWideCospanEvaluationIso A p q).hom.app none =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (p + 1) ↦ A.hom)) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+theorem cechPresentationEvaluationIso_naturality
+    (A : Arrow SSet) (q : ℕ) {a b : SimplexCategoryᵒᵖ} (f : a ⟶ b) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (A.augmentedCechNerve.left.map f) ≫
+        (cechPresentationEvaluationIso A b.unop.len q).hom =
+      (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+        (cechPresentationEvaluationArrow A q).augmentedCechNerve.left.map f := by
+  let B := cechPresentationEvaluationArrow A q
+  let D := WidePullbackShape.wideCospan B.right
+    (fun _ : Fin (b.unop.len + 1) ↦ B.left) (fun _ ↦ B.hom)
+  apply limit.hom_ext (F := D)
+  intro j
+  cases j with
+  | some i =>
+    rw [Category.assoc, cechPresentationEvaluationIso_hom_π]
+    rw [cechPresentationEvaluation_map_π_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (A.cechNerve.map f ≫
+            WidePullback.π (fun _ : Fin (b.unop.len + 1) ↦ A.hom) i) =
+      (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+        ((cechPresentationEvaluationArrow A q).cechNerve.map f ≫
+          WidePullback.π
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (cechPresentationEvaluationArrow A q).hom) i)
+    simp only [Arrow.cechNerve_map, WidePullback.lift_π]
+    rw [cechPresentationEvaluationIso_hom_π,
+      cechPresentationEvaluation_map_π_comp_diagramIso]
+  | none =>
+    rw [Category.assoc, cechPresentationEvaluationIso_hom_base]
+    rw [cechPresentationEvaluation_map_base_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (A.cechNerve.map f ≫
+            WidePullback.base (fun _ : Fin (b.unop.len + 1) ↦ A.hom)) =
+      (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+        ((cechPresentationEvaluationArrow A q).cechNerve.map f ≫
+          WidePullback.base
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (cechPresentationEvaluationArrow A q).hom))
+    simp only [Arrow.cechNerve_map, WidePullback.lift_base]
+    rw [cechPresentationEvaluationIso_hom_base,
+      cechPresentationEvaluation_map_base_comp_diagramIso]
+
+noncomputable def cechPresentationSimplicialEvaluationIso
+    (A : Arrow SSet) (q : ℕ) :
+    A.augmentedCechNerve.left ⋙
+        (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (cechPresentationEvaluationArrow A q).augmentedCechNerve.left :=
+  NatIso.ofComponents
+    (fun a ↦ cechPresentationEvaluationIso A a.unop.len q)
+    (by
+      intro a b f
+      exact cechPresentationEvaluationIso_naturality A q f)
+
+noncomputable def cechPresentationAugmentedEvaluationIso
+    (A : Arrow SSet) (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj A.augmentedCechNerve ≅
+      (cechPresentationEvaluationArrow A q).augmentedCechNerve :=
+  Comma.isoMk
+    (cechPresentationSimplicialEvaluationIso A q)
+    (Iso.refl _)
+    (by
+      apply NatTrans.ext
+      funext a
+      simp only [NatTrans.comp_app, Functor.id_map]
+      dsimp only [cechPresentationSimplicialEvaluationIso,
+        SimplicialObject.Augmented.whiskering,
+        SimplicialObject.Augmented.whiskeringObj]
+      change (cechPresentationEvaluationIso A a.unop.len q).hom ≫
+          WidePullback.base
+            (fun _ : Fin (a.unop.len + 1) ↦
+              (cechPresentationEvaluationArrow A q).hom) =
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base (fun _ : Fin (a.unop.len + 1) ↦ A.hom))
+      rw [cechPresentationEvaluationIso_hom_base,
+        cechPresentationEvaluation_map_base_comp_diagramIso])
+
+noncomputable def boundarySevenFaceNeighborhoodWideCospanEvaluationIso
+    (p q : ℕ) :
+    WidePullbackShape.wideCospan
+        boundarySevenFaceNeighborhoodPresentationArrow.right
+        (fun _ : Fin (p + 1) ↦ boundarySevenFaceNeighborhoodPresentationArrow.left)
+        (fun _ ↦ boundarySevenFaceNeighborhoodPresentationArrow.hom) ⋙
+          (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)) ≅
+      WidePullbackShape.wideCospan
+        (boundarySevenFaceNeighborhoodPresentationArrow.right.obj
+          (Opposite.op (SimplexCategory.mk q)))
+        (fun _ : Fin (p + 1) ↦
+          boundarySevenFaceNeighborhoodPresentationArrow.left.obj
+            (Opposite.op (SimplexCategory.mk q)))
+        (fun _ ↦ boundarySevenFaceNeighborhoodPresentationArrow.hom.app
+          (Opposite.op (SimplexCategory.mk q))) :=
+  NatIso.ofComponents
+    (fun x ↦ by cases x <;> exact Iso.refl _)
+    (by
+      intro X Y f
+      cases f <;> rfl)
+
+@[simp]
+private theorem boundarySevenFaceNeighborhoodWideCospanEvaluationIso_hom_app
+    (p q : ℕ) (x : WidePullbackShape (Fin (p + 1))) :
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app x =
+      eqToHom (by cases x <;> rfl) := by
+  cases x <;> rfl
+
+@[simp]
+private theorem boundarySevenFaceNeighborhoodWideCospanEvaluationIso_hom_app_some
+    (p q : ℕ) (i : Fin (p + 1)) :
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app (some i) =
+      𝟙 _ := by
+  rfl
+
+@[simp]
+private theorem boundarySevenFaceNeighborhoodWideCospanEvaluationIso_hom_app_none
+    (p q : ℕ) :
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none = 𝟙 _ := by
+  rfl
+
+noncomputable def boundarySevenFaceNeighborhoodCechEvaluationIso
+    (p q : ℕ) :
+    (boundarySevenFaceNeighborhoodAugmentedCechNerve.left.obj
+        (Opposite.op (SimplexCategory.mk p))).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve.left.obj
+          (Opposite.op (SimplexCategory.mk p)) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let A := boundarySevenFaceNeighborhoodPresentationArrow
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  change E.obj (widePullback A.right (fun _ : Fin (p + 1) ↦ A.left)
+      (fun _ ↦ A.hom)) ≅
+    widePullback (E.obj A.right) (fun _ : Fin (p + 1) ↦ E.obj A.left)
+      (fun _ ↦ E.map A.hom)
+  exact preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q)
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+private theorem boundarySevenFaceNeighborhoodCechEvaluationIso_hom_π
+    (p q : ℕ) (i : Fin (p + 1)) :
+    (boundarySevenFaceNeighborhoodCechEvaluationIso p q).hom ≫
+        WidePullback.π
+          (fun _ : Fin (p + 1) ↦
+            (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+              (Opposite.op (SimplexCategory.mk q))).hom) i =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom) i) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app
+          (some i) := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let A := boundarySevenFaceNeighborhoodPresentationArrow
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let D' := WidePullbackShape.wideCospan
+    (A.right.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ : Fin (p + 1) ↦
+      A.left.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ ↦ A.hom.app (Opposite.op (SimplexCategory.mk q)))
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q)).hom) ≫
+      limit.π D' (some i) = E.map (limit.π D (some i)) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app
+          (some i)
+  dsimp only [D', E, A]
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q) (some i)]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+private theorem boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base
+    (p q : ℕ) :
+    (boundarySevenFaceNeighborhoodCechEvaluationIso p q).hom ≫
+        WidePullback.base
+          (fun _ : Fin (p + 1) ↦
+            (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+              (Opposite.op (SimplexCategory.mk q))).hom) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom)) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none := by
+  let E := (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+    (Opposite.op (SimplexCategory.mk q))
+  let A := boundarySevenFaceNeighborhoodPresentationArrow
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (p + 1) ↦ A.left) (fun _ ↦ A.hom)
+  let D' := WidePullbackShape.wideCospan
+    (A.right.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ : Fin (p + 1) ↦
+      A.left.obj (Opposite.op (SimplexCategory.mk q)))
+    (fun _ ↦ A.hom.app (Opposite.op (SimplexCategory.mk q)))
+  change ((preservesLimitIso E D ≪≫ HasLimit.isoOfNatIso
+      (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q)).hom) ≫
+      limit.π D' none = E.map (limit.π D none) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none
+  dsimp only [D', E, A]
+  rw [Iso.trans_hom, Category.assoc]
+  rw [HasLimit.isoOfNatIso_hom_π
+    (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q) none]
+  rw [← Category.assoc, preservesLimitIso_hom_π]
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+private theorem boundarySevenFaceNeighborhoodEvaluation_map_π_comp_diagramIso
+    (p q : ℕ) (i : Fin (p + 1)) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom) i) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app
+          (some i) =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.π
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom) i) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+private theorem boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso
+    (p q : ℕ) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom)) ≫
+        (boundarySevenFaceNeighborhoodWideCospanEvaluationIso p q).hom.app none =
+      ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (p + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom)) := by
+  rfl
+
+private noncomputable def boundarySevenFaceNeighborhoodCechRowXIso
+    (q p : ℕ) :
+    (firstQuadrantHorizontalRow
+        boundarySevenFaceNeighborhoodCechBicomplex q).X p ≅
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech q))).X p :=
+  (sigmaConst.obj (AddCommGrpCat.of ℤ)).mapIso
+    (boundarySevenFaceNeighborhoodCechEvaluationIso p q)
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem boundarySevenFaceNeighborhoodCechEvaluationIso_naturality
+    (q : ℕ) {a b : SimplexCategoryᵒᵖ} (f : a ⟶ b) :
+    ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (boundarySevenFaceNeighborhoodAugmentedCechNerve.left.map f) ≫
+        (boundarySevenFaceNeighborhoodCechEvaluationIso b.unop.len q).hom =
+      (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+        (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+          (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve.left.map f := by
+  let A := boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+    (Opposite.op (SimplexCategory.mk q))
+  let D := WidePullbackShape.wideCospan A.right
+    (fun _ : Fin (b.unop.len + 1) ↦ A.left) (fun _ ↦ A.hom)
+  apply limit.hom_ext (F := D)
+  intro j
+  cases j with
+  | some i =>
+    rw [Category.assoc,
+      boundarySevenFaceNeighborhoodCechEvaluationIso_hom_π]
+    rw [boundarySevenFaceNeighborhoodEvaluation_map_π_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (boundarySevenFaceNeighborhoodPresentationArrow.cechNerve.map f ≫
+            WidePullback.π
+              (fun _ : Fin (b.unop.len + 1) ↦
+                boundarySevenFaceNeighborhoodPresentationArrow.hom) i) =
+      (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+        ((boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+            (Opposite.op (SimplexCategory.mk q))).cechNerve.map f ≫
+          WidePullback.π
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+                (Opposite.op (SimplexCategory.mk q))).hom) i)
+    simp only [Arrow.cechNerve_map, WidePullback.lift_π]
+    rw [boundarySevenFaceNeighborhoodCechEvaluationIso_hom_π,
+      boundarySevenFaceNeighborhoodEvaluation_map_π_comp_diagramIso]
+  | none =>
+    rw [Category.assoc,
+      boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base]
+    rw [boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso]
+    rw [← Functor.map_comp]
+    change ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+        (Opposite.op (SimplexCategory.mk q))).map
+          (boundarySevenFaceNeighborhoodPresentationArrow.cechNerve.map f ≫
+            WidePullback.base
+              (fun _ : Fin (b.unop.len + 1) ↦
+                boundarySevenFaceNeighborhoodPresentationArrow.hom)) =
+      (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+        ((boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+            (Opposite.op (SimplexCategory.mk q))).cechNerve.map f ≫
+          WidePullback.base
+            (fun _ : Fin (b.unop.len + 1) ↦
+              (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+                (Opposite.op (SimplexCategory.mk q))).hom))
+    simp only [Arrow.cechNerve_map, WidePullback.lift_base]
+    rw [boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base,
+      boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso]
+
+noncomputable def boundarySevenFaceNeighborhoodCechSimplicialEvaluationIso
+    (q : ℕ) :
+    boundarySevenFaceNeighborhoodAugmentedCechNerve.left ⋙
+        (evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)) ≅
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve.left :=
+  NatIso.ofComponents
+    (fun a ↦ boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q)
+    (by
+      intro a b f
+      exact boundarySevenFaceNeighborhoodCechEvaluationIso_naturality q f)
+
+noncomputable def boundarySevenFaceNeighborhoodCechAugmentedEvaluationIso
+    (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj
+          boundarySevenFaceNeighborhoodAugmentedCechNerve ≅
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk q))).augmentedCechNerve :=
+  Comma.isoMk
+    (boundarySevenFaceNeighborhoodCechSimplicialEvaluationIso q)
+    (Iso.refl _)
+    (by
+      apply NatTrans.ext
+      funext a
+      simp only [NatTrans.comp_app, Functor.id_map]
+      dsimp only [boundarySevenFaceNeighborhoodCechSimplicialEvaluationIso,
+        SimplicialObject.Augmented.whiskering,
+        SimplicialObject.Augmented.whiskeringObj]
+      change (boundarySevenFaceNeighborhoodCechEvaluationIso a.unop.len q).hom ≫
+          WidePullback.base
+            (fun _ : Fin (a.unop.len + 1) ↦
+              (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+                (Opposite.op (SimplexCategory.mk q))).hom) =
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q))).map
+          (WidePullback.base
+            (fun _ : Fin (a.unop.len + 1) ↦
+              boundarySevenFaceNeighborhoodPresentationArrow.hom))
+      rw [boundarySevenFaceNeighborhoodCechEvaluationIso_hom_base,
+        boundarySevenFaceNeighborhoodEvaluation_map_base_comp_diagramIso])
+
+noncomputable def boundarySevenFaceNeighborhoodIntegralCechAugmentedRowIso
+    (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+        (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+          ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)))).obj
+              boundarySevenFaceNeighborhoodAugmentedCechNerve) ≅
+      boundarySevenFaceNeighborhoodIntegralEvaluationCech q :=
+  Functor.mapIso _ (boundarySevenFaceNeighborhoodCechAugmentedEvaluationIso q)
+
+set_option backward.isDefEq.respectTransparency false in
+noncomputable def boundarySevenFaceNeighborhoodCechRowArrowIso
+    (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+        boundarySevenFaceNeighborhoodCechOuterAugmentation q) ≅
+      Arrow.mk (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q) := by
+  let e := boundarySevenFaceNeighborhoodIntegralCechAugmentedRowIso q
+  let X := ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj
+            boundarySevenFaceNeighborhoodAugmentedCechNerve)
+  let F := HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q
+  let Y := SimplicialObject.Augmented.drop.obj
+    boundarySevenFaceNeighborhoodAugmentedCechChains
+  let l₀ : firstQuadrantHorizontalRow
+      boundarySevenFaceNeighborhoodCechBicomplex q ≅
+      AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj X) :=
+    eqToIso (Functor.congr_obj (map_alternatingFaceMapComplex F) Y)
+  let r₀ : firstQuadrantHorizontalRow
+      ((ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).obj
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)) q ≅
+      (ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj X) :=
+    (HomologicalComplex.singleMapHomologicalComplex F
+      (ComplexShape.down ℕ) 0).app
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood)
+  let e₀ : Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenFaceNeighborhoodCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app X) :=
+    Arrow.isoMk' _ _ l₀ r₀ (by
+      ext n x
+      rcases n with _ | n
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenFaceNeighborhoodCechOuterAugmentation,
+          boundarySevenFaceNeighborhoodCechBicomplex,
+          boundarySevenFaceNeighborhoodAugmentedCechChains,
+          SSet.chainComplexFunctor,
+          AlternatingFaceMapComplex.ε_app_f_zero]
+        change (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenFaceNeighborhoodAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x =
+          (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenFaceNeighborhoodAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x
+        rfl
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenFaceNeighborhoodCechOuterAugmentation,
+          AlternatingFaceMapComplex.ε_app_f_succ])
+  let e₁ := Arrow.isoMk'
+    (AlternatingFaceMapComplex.ε.app X)
+    (boundarySevenFaceNeighborhoodCechOuterAugmentationRow q)
+    ((alternatingFaceMapComplex AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.drop.mapIso e))
+    ((ChainComplex.single₀ AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.point.mapIso e))
+    (by
+      exact AlternatingFaceMapComplex.ε.naturality e.hom)
+  exact e₀ ≪≫ e₁
+
+noncomputable def boundarySevenSimplicialFaceIntegralCechAugmentedRowIso
+    (q : ℕ) :
+    ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+        (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+          ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+            (Opposite.op (SimplexCategory.mk q)))).obj
+              boundarySevenSimplicialFaceAugmentedCechNerve) ≅
+      boundarySevenSimplicialFaceIntegralEvaluationCech q :=
+  Functor.mapIso _
+    (cechPresentationAugmentedEvaluationIso
+      boundarySevenSimplicialFacePresentationArrow q)
+
+set_option backward.isDefEq.respectTransparency false in
+noncomputable def boundarySevenSimplicialFaceCechRowArrowIso
+    (q : ℕ) :
+    Arrow.mk (firstQuadrantHorizontalRowMap
+        boundarySevenSimplicialFaceCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app
+        (boundarySevenSimplicialFaceIntegralEvaluationCech q)) := by
+  let e := boundarySevenSimplicialFaceIntegralCechAugmentedRowIso q
+  let X := ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (((SimplicialObject.Augmented.whiskering SSet (Type 0)).obj
+        ((evaluation SimplexCategoryᵒᵖ (Type 0)).obj
+          (Opposite.op (SimplexCategory.mk q)))).obj
+            boundarySevenSimplicialFaceAugmentedCechNerve)
+  let F := HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) q
+  let Y := SimplicialObject.Augmented.drop.obj
+    boundarySevenSimplicialFaceAugmentedCechChains
+  let l₀ : firstQuadrantHorizontalRow
+      boundarySevenSimplicialFaceCechBicomplex q ≅
+      AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj X) :=
+    eqToIso (Functor.congr_obj (map_alternatingFaceMapComplex F) Y)
+  let r₀ : firstQuadrantHorizontalRow
+      (firstQuadrantSingleZeroBicomplex
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))) q ≅
+      (ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj X) :=
+    (HomologicalComplex.singleMapHomologicalComplex F
+      (ComplexShape.down ℕ) 0).app
+        ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))
+  let e₀ : Arrow.mk (firstQuadrantHorizontalRowMap
+      boundarySevenSimplicialFaceCechOuterAugmentation q) ≅
+      Arrow.mk (AlternatingFaceMapComplex.ε.app X) :=
+    Arrow.isoMk' _ _ l₀ r₀ (by
+      ext n x
+      rcases n with _ | n
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenSimplicialFaceCechOuterAugmentation,
+          boundarySevenSimplicialFaceCechBicomplex,
+          boundarySevenSimplicialFaceAugmentedCechChains,
+          SSet.chainComplexFunctor,
+          AlternatingFaceMapComplex.ε_app_f_zero]
+        change (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenSimplicialFaceAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x =
+          (AddCommGrpCat.Hom.hom
+            ((sigmaConst.obj (AddCommGrpCat.of ℤ)).map
+              ((boundarySevenSimplicialFaceAugmentedCechNerve.hom.app
+                (Opposite.op (SimplexCategory.mk 0))).app
+                  (Opposite.op (SimplexCategory.mk q))))) x
+        rfl
+      · simp [l₀, r₀, X, F, Y, firstQuadrantHorizontalRowMap,
+          firstQuadrantHorizontalRow,
+          boundarySevenSimplicialFaceCechOuterAugmentation,
+          AlternatingFaceMapComplex.ε_app_f_succ])
+  let e₁ := Arrow.isoMk'
+    (AlternatingFaceMapComplex.ε.app X)
+    (AlternatingFaceMapComplex.ε.app
+      (boundarySevenSimplicialFaceIntegralEvaluationCech q))
+    ((alternatingFaceMapComplex AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.drop.mapIso e))
+    ((ChainComplex.single₀ AddCommGrpCat).mapIso
+      (SimplicialObject.Augmented.point.mapIso e))
+    (by
+      exact AlternatingFaceMapComplex.ε.naturality e.hom)
+  exact e₀ ≪≫ e₁
+
+/-- The actual horizontal rows of both boundary-seven Cech augmentations are canonically the
+evaluated rows used by the extra-degeneracy contractions. -/
+public noncomputable def boundarySevenCechAugmentationRowIdentifications :
+    BoundarySevenCechAugmentationRowIdentifications where
+  sourceRowArrowIso q := boundarySevenSimplicialFaceCechRowArrowIso q
+  targetRowArrowIso q := boundarySevenFaceNeighborhoodCechRowArrowIso q
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechRowwiseGlobalizationProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechRowwiseGlobalizationProof.lean
@@ -1,0 +1,31 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantRowwiseTotalizationProof
+public import SphereSixComplex.Topology.BoundarySevenCechRowIdentificationsProof
+
+/-!
+# Concrete rowwise globalization for the boundary-seven Cech bicomplexes
+
+This file combines the first-quadrant rowwise totalization theorem with the canonical
+identifications of the actual Cech rows.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace SphereSixComplex
+
+/-- The rowwise globalization package used by the boundary-seven low-assembly argument. -/
+public noncomputable def boundarySevenCechRowwiseGlobalization :
+    BoundarySevenCechRowwiseGlobalization where
+  totalization := firstQuadrantRowwiseTotalization
+  rowIdentifications := boundarySevenCechAugmentationRowIdentifications
+
+/-- The boundary-seven rowwise globalization package exists without any additional
+homological-algebra or coherence hypotheses. -/
+public theorem boundarySevenCechRowwiseGlobalization_nonempty :
+    Nonempty BoundarySevenCechRowwiseGlobalization :=
+  ⟨boundarySevenCechRowwiseGlobalization⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenCechTotalQuasiIsoProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechTotalQuasiIsoProof.lean
@@ -1,0 +1,274 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedSource
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedTarget
+public import SphereSixComplex.Topology.BoundarySevenCechOrderedLocalComparison
+public import SphereSixComplex.Topology.BoundarySevenCechComparisonAssemblyProof
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLowAcyclic
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyModTwo
+
+/-!
+# The boundary-seven Cech total comparison
+
+The object in every outer Cech degree is a coproduct over proper ordered tuples.  On each
+summand, the canonical map is the comparison from the common simplicial face to singular
+simplices in the corresponding face-neighbourhood intersection.  Those local maps are
+quasi-isomorphisms, so finite-coproduct assembly and first-quadrant column totalization prove
+that the actual map of Cech totals is a quasi-isomorphism.  The strict augmentation square then
+gives the canonical integral simplicial-to-singular comparison for `∂Δ[7]`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The map of augmented Cech nerves commutes with every projection to a selected presentation
+leg. -/
+@[reassoc]
+public theorem boundarySevenFaceAugmentedCechNerveMap_comp_projection
+    (n : SimplexCategoryᵒᵖ) (i : Fin (n.unop.len + 1)) :
+    boundarySevenFaceAugmentedCechNerveMap.left.app n ≫
+        boundarySevenTargetCechProjection n i =
+      boundarySevenSourceCechProjection n i ≫
+        boundarySevenFacePresentationSourceMap := by
+  change WidePullback.lift _ _ _ ≫ WidePullback.π _ i = _
+  rw [WidePullback.lift_π]
+  rfl
+
+/-- The two independently constructed common-face inclusions into the simplicial boundary are
+equal. -/
+public theorem boundarySevenProperCechTupleFaceToBoundarySSetMap_eq_source
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenProperCechTupleFaceToBoundarySSetMap a =
+      boundarySevenOrderedSourceCommonFaceToBoundary a := by
+  apply (cancel_mono (SSet.boundary 7).ι).1
+  rw [boundarySevenOrderedSourceCommonFaceToBoundary_comp_inclusion]
+  simp [boundarySevenProperCechTupleFaceToBoundarySSetMap]
+
+set_option linter.style.haveILetI false in
+set_option backward.isDefEq.respectTransparency false in
+/-- On realized spaces, passing from a common face through a selected facet is the same as
+passing through its full ordered intersection. -/
+public theorem boundarySevenOrderedCommonFace_local_topologicalCompatibility
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    SSet.toTop.map (boundarySevenOrderedSourceCommonFaceToFacet a i) ≫
+        boundarySevenFaceToComparisonFaceNeighborhood (a.1 i) =
+      TopCat.ofHom (boundarySevenProperCechTupleFaceToIntersection a) ≫
+        boundarySevenTargetIntersectionToMember a i := by
+  letI : Mono
+      (topologicalSubsetInclusion
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        (boundarySevenComparisonFaceNeighborhood (a.1 i))) :=
+    (TopCat.mono_iff_injective _).mpr (fun _ _ h ↦ Subtype.ext h)
+  apply (cancel_mono
+    (topologicalSubsetInclusion
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      (boundarySevenComparisonFaceNeighborhood (a.1 i)))).1
+  rw [Category.assoc,
+    boundarySevenFaceToComparisonFaceNeighborhood_comp_inclusion]
+  rw [Category.assoc,
+    boundarySevenTargetIntersectionToMember_comp_inclusion]
+  rw [boundarySevenProperCechTupleFaceToIntersection_comp_subsetInclusion]
+  rw [← SSet.toTop.map_comp,
+    boundarySevenOrderedSourceCommonFaceToFacet_comp_boundary]
+  rw [boundarySevenProperCechTupleFaceToBoundarySSetMap_eq_source]
+
+set_option linter.style.haveILetI false in
+set_option backward.isDefEq.respectTransparency false in
+/-- Simplicially, the local tuple comparison commutes with every selected facet leg. -/
+public theorem boundarySevenProperCechTupleLocalComparison_comp_member
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
+    (i : Fin (n.unop.len + 1)) :
+    boundarySevenOrderedSourceCommonFaceToFacet a i ≫
+        boundarySevenFaceNeighborhoodLocalComparisonSSetMap (a.1 i) =
+      boundarySevenProperCechTupleLocalComparisonSSetMap a ≫
+        TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i) := by
+  rw [boundarySevenFaceNeighborhoodLocalComparisonSSetMap,
+    boundarySevenProperCechTupleLocalComparisonSSetMap]
+  change (((𝟭 SSet).map
+      (boundarySevenOrderedSourceCommonFaceToFacet a i) ≫
+        sSetTopAdj.unit.app (Δ[6] : SSet.{0})) ≫
+      TopCat.toSSet.map
+        (boundarySevenFaceToComparisonFaceNeighborhood (a.1 i))) = _
+  rw [sSetTopAdj.unit.naturality]
+  change (sSetTopAdj.unit.app
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ≫
+    TopCat.toSSet.map
+      (SSet.toTop.map (boundarySevenOrderedSourceCommonFaceToFacet a i)) ≫
+    TopCat.toSSet.map
+      (boundarySevenFaceToComparisonFaceNeighborhood (a.1 i))) =
+    sSetTopAdj.unit.app
+      (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0}) ≫
+    TopCat.toSSet.map
+      (TopCat.ofHom (boundarySevenProperCechTupleFaceToIntersection a)) ≫
+    TopCat.toSSet.map (boundarySevenTargetIntersectionToMember a i)
+  simp only [← Functor.map_comp]
+  congr 1
+  exact TopCat.toSSet.congr_map
+    (boundarySevenOrderedCommonFace_local_topologicalCompatibility a i)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The compatibility square on one ordered-tuple summand of a fixed outer Cech degree. -/
+public theorem boundarySevenOrderedCechComparison_summand
+    {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n) :
+    boundarySevenOrderedSourceCechSummand a ≫
+        boundarySevenFaceAugmentedCechNerveMap.left.app n =
+      boundarySevenProperCechTupleLocalComparisonSSetMap a ≫
+        boundarySevenTargetIntersectionToCechSummand a := by
+  have htargetProj (i : Fin (n.unop.len + 1)) :
+      boundarySevenTargetIntersectionToCechSummand a ≫
+          boundarySevenTargetCechProjection n i =
+        boundarySevenTargetIntersectionToPresentationLeg a i := by
+    change WidePullback.lift _ _ _ ≫ WidePullback.π _ i = _
+    rw [WidePullback.lift_π]
+  have hproj (i : Fin (n.unop.len + 1)) :
+      (boundarySevenOrderedSourceCechSummand a ≫
+          boundarySevenFaceAugmentedCechNerveMap.left.app n) ≫
+          boundarySevenTargetCechProjection n i =
+        (boundarySevenProperCechTupleLocalComparisonSSetMap a ≫
+          boundarySevenTargetIntersectionToCechSummand a) ≫
+          boundarySevenTargetCechProjection n i := by
+    rw [Category.assoc,
+      boundarySevenFaceAugmentedCechNerveMap_comp_projection]
+    rw [← Category.assoc,
+      boundarySevenOrderedSourceCechSummand_comp_projection]
+    rw [Category.assoc, htargetProj]
+    rw [boundarySevenOrderedSourcePresentationLeg,
+      boundarySevenTargetIntersectionToPresentationLeg]
+    simp only [Category.assoc]
+    rw [boundarySevenFacePresentationSourceMap_iota]
+    exact congrArg
+      (fun k ↦ k ≫ Sigma.ι
+        (fun j : Fin 8 ↦ TopCat.toSSet.obj
+          (TopCat.of (boundarySevenComparisonFaceNeighborhood j))) (a.1 i))
+      (boundarySevenProperCechTupleLocalComparison_comp_member a i)
+  apply WidePullback.hom_ext
+  · exact hproj
+  · change _ ≫ WidePullback.base
+        (fun _ : Fin (n.unop.len + 1) ↦
+          boundarySevenFaceNeighborhoodPresentation) =
+      _ ≫ WidePullback.base
+        (fun _ : Fin (n.unop.len + 1) ↦
+          boundarySevenFaceNeighborhoodPresentation)
+    rw [show WidePullback.base
+        (fun _ : Fin (n.unop.len + 1) ↦
+          boundarySevenFaceNeighborhoodPresentation) =
+        boundarySevenTargetCechProjection n 0 ≫
+          boundarySevenFaceNeighborhoodPresentation by
+      exact (WidePullback.π_arrow
+        (fun _ : Fin (n.unop.len + 1) ↦
+          boundarySevenFaceNeighborhoodPresentation) 0).symm]
+    simp only [← Category.assoc]
+    rw [hproj 0]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- In a fixed outer degree, conjugating the actual Cech map by the two objectwise
+decompositions gives the coproduct of the tuplewise local comparisons. -/
+public theorem boundarySevenOrderedCechComparison_component
+    (n : SimplexCategoryᵒᵖ) :
+    (boundarySevenOrderedSourceCechIso n).hom ≫
+        boundarySevenFaceAugmentedCechNerveMap.left.app n =
+      CategoryTheory.Limits.Sigma.map
+          (fun a : BoundarySevenProperCechTuple n ↦
+            boundarySevenProperCechTupleLocalComparisonSSetMap a) ≫
+        (boundarySevenOrderedTargetCechIso n).hom := by
+  apply Sigma.hom_ext
+  intro a
+  simp only [← Category.assoc]
+  rw [boundarySevenOrderedSourceCechIso_hom,
+    boundarySevenOrderedSourceToCech, Sigma.ι_desc]
+  change _ =
+    (Sigma.ι
+      (fun a : BoundarySevenProperCechTuple n ↦
+        (SSet.stdSimplex.face a.1.supportᶜ : SSet.{0})) a ≫
+      CategoryTheory.Limits.Sigma.map
+        (fun a : BoundarySevenProperCechTuple n ↦
+          boundarySevenProperCechTupleLocalComparisonSSetMap a)) ≫ _
+  rw [CategoryTheory.Limits.Sigma.ι_map]
+  rw [Category.assoc,
+    boundarySevenOrderedTargetCechIso_hom_summand]
+  exact boundarySevenOrderedCechComparison_summand a
+
+/-- Every outer column of the actual boundary-seven Cech bicomplex map is a
+quasi-isomorphism. -/
+public theorem boundarySevenFaceCechBicomplexMap_column_quasiIso (p : ℕ) :
+    QuasiIso (boundarySevenFaceCechBicomplexMap.f p) := by
+  change QuasiIso (SSet.chainComplexMap
+    (boundarySevenFaceAugmentedCechNerveMap.left.app
+      (Opposite.op (SimplexCategory.mk p))) (AddCommGrpCat.of ℤ))
+  apply quasiIso_sSetIntegralChains_of_finiteCoproduct_conjugation
+    (fun a : BoundarySevenProperCechTuple
+        (Opposite.op (SimplexCategory.mk p)) ↦
+      boundarySevenOrderedSourceCommonFace a)
+    (fun a : BoundarySevenProperCechTuple
+        (Opposite.op (SimplexCategory.mk p)) ↦
+      TopCat.toSSet.obj (TopCat.of
+        (boundarySevenFaceNeighborhoodIntersection a.1.support)))
+    (fun a ↦ boundarySevenProperCechTupleLocalComparisonSSetMap a)
+    (boundarySevenOrderedSourceCechIso
+      (Opposite.op (SimplexCategory.mk p)))
+    (boundarySevenOrderedTargetCechIso
+      (Opposite.op (SimplexCategory.mk p)))
+    (boundarySevenFaceAugmentedCechNerveMap.left.app
+      (Opposite.op (SimplexCategory.mk p)))
+  · exact boundarySevenOrderedCechComparison_component
+      (Opposite.op (SimplexCategory.mk p))
+  · intro a
+    exact boundarySevenProperCechTupleLocalIntegralComparison_quasiIso a
+
+/-- The canonical map between the two direct-sum Cech totals is a quasi-isomorphism in all
+degrees. -/
+public theorem boundarySevenFaceCechTotalMap_quasiIso :
+    QuasiIso boundarySevenFaceCechTotalMap :=
+  boundarySevenFaceCechTotalMap_quasiIso_of_columns
+    boundarySevenFaceCechBicomplexMap_column_quasiIso
+
+/-- The canonical integral simplicial-to-singular comparison for the boundary of the
+seven-simplex. -/
+public theorem boundarySeven_integralComparison_proof :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  boundarySeven_integralComparison_of_faceCechTotalMap_quasiIso
+    boundarySevenFaceCechTotalMap_quasiIso
+
+/-- The low-degree integral comparison used by the disk-cover and Kervaire branches. -/
+public theorem boundarySevenLowIntegralComparison_proof :
+    BoundarySevenLowIntegralComparison :=
+  boundarySevenLowIntegralComparison_of_quasiIso
+    boundarySeven_integralComparison_proof
+
+/-- The four local disk-cover relative vanishings follow from the now-unconditional boundary
+comparison. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_proof :
+    DiskSevenCoverLocalRelativeLowAcyclic :=
+  diskSevenCoverLocalRelativeLowAcyclic_of_boundaryLowComparison
+    boundarySevenLowIntegralComparison_proof
+
+/-- Hence the explicit cover-small relative disk complex is acyclic in degrees three and four. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_proof :
+    DiskSevenCoverSmallRelativeLowAcyclic :=
+  diskSevenCoverSmallRelativeLowAcyclic_of_localAcyclic
+    diskSevenCoverLocalRelativeLowAcyclic_proof
+
+/-- The required middle mod-two homology of the standard six-sphere vanishes. -/
+public theorem sixSphere_modTwoHomology_three_isZero_proof :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) :=
+  sixSphere_modTwoHomology_three_isZero_of_coverSmallRelative
+    diskSevenCoverSmallRelativeLowAcyclic_proof
+
+/-- The same mod-two vanishing holds for every marked smooth homotopy six-sphere. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_proof
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_coverSmallRelative
+    diskSevenCoverSmallRelativeLowAcyclic_proof S
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodComparison.lean
@@ -1,0 +1,467 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparisonProof
+public import Mathlib.Algebra.Category.Grp.Adjunctions
+public import Mathlib.Algebra.Homology.TotalComplex
+public import Mathlib.AlgebraicTopology.CechNerve
+public import Mathlib.AlgebraicTopology.ExtraDegeneracy
+
+/-!
+# The face-neighborhood Čech reduction for `∂Δ[7]`
+
+This file develops the concrete finite-cover input for the comparison map.  The eight open sets
+are the inverse images of the inequalities `x i < 1 / 8`.  Their total intersection is empty,
+and the canonical presentation of the cover-small singular set is degreewise surjective.  Thus,
+after evaluating in any singular degree, its augmented Čech nerve has an extra degeneracy and
+its alternating complex contracts onto the cover-small chain group in that degree.
+
+The final structure below isolates the remaining totalization/local-comparison step: a map from
+the boundary chains to the Čech--singular total complex and the standard Čech augmentation,
+both quasi-isomorphisms and with the expected composite.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The intersection of the affine face neighborhoods indexed by `s`. -/
+public def boundarySevenFaceNeighborhoodIntersection (s : Finset (Fin 8)) :
+    Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
+  ⋂ i ∈ s, boundarySevenComparisonFaceNeighborhood i
+
+@[simp]
+public theorem mem_boundarySevenFaceNeighborhoodIntersection_iff
+    (s : Finset (Fin 8)) (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
+    x ∈ boundarySevenFaceNeighborhoodIntersection s ↔
+      ∀ i ∈ s, boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8 := by
+  simp [boundarySevenFaceNeighborhoodIntersection,
+    boundarySevenComparisonFaceNeighborhood]
+
+/-- Every finite intersection of the eight face neighborhoods is open. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_isOpen (s : Finset (Fin 8)) :
+    IsOpen (boundarySevenFaceNeighborhoodIntersection s) := by
+  apply isOpen_biInter_finset
+  intro i _
+  exact boundarySevenComparisonFaceNeighborhood_isOpen i
+
+/-- All eight face neighborhoods have empty intersection. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_univ_eq_empty :
+    boundarySevenFaceNeighborhoodIntersection Finset.univ = ∅ := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  intro x hx
+  have hcoord :=
+    (mem_boundarySevenFaceNeighborhoodIntersection_iff Finset.univ x).mp hx
+  have hsum :
+      ∑ i : Fin 8, boundarySevenComparisonToStdSimplex x i <
+        ∑ _i : Fin 8, (1 : ℝ) / 8 := by
+    apply Finset.sum_lt_sum
+    · intro i _
+      exact (hcoord i (Finset.mem_univ i)).le
+    · exact ⟨0, Finset.mem_univ 0, hcoord 0 (Finset.mem_univ 0)⟩
+  rw [stdSimplex.sum_eq_one] at hsum
+  norm_num at hsum
+
+/-- Every point of the realized simplicial boundary is represented by a point of one of its
+codimension-one faces.  This is the concrete joint-surjectivity consequence of the canonical
+colimit presentation of a presheaf by representables. -/
+public theorem boundarySevenRealization_exists_face_representation
+    (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
+    ∃ (i : Fin 8) (y : SSet.toTop.obj (Δ[6] : SSet.{0})),
+      SSet.toTop.map (SSet.boundary.ι i) y = x := by
+  let c := SSet.toTop.mapCocone
+    (Presheaf.coconeOfRepresentable (∂Δ[7] : SSet.{0}))
+  let hc : IsColimit c := isColimitOfPreserves SSet.toTop
+    (Presheaf.colimitOfRepresentable (∂Δ[7] : SSet.{0}))
+  obtain ⟨j, z, hz⟩ := Concrete.isColimit_exists_rep _ hc x
+  let a := j.unop.2
+  have ha := a.2
+  simp only [SSet.boundary_eq_iSup, SSet.stdSimplex.face_singleton_compl,
+    Subfunctor.iSup_obj, Set.mem_iUnion,
+    SSet.Subcomplex.mem_ofSimplex_obj_iff, Opposite.op_unop] at ha
+  obtain ⟨i, ⟨y, hy⟩⟩ := ha
+  let y' : (Δ[6] : SSet.{0}).obj j.unop.1 := SSet.stdSimplex.objEquiv.symm y
+  have hay : (SSet.boundary.ι i).app j.unop.1 y' = a := by
+    apply Subtype.ext
+    change (SSet.stdSimplex.map (SimplexCategory.δ i)).app j.unop.1 y' = a.1
+    exact hy
+  refine ⟨i, SSet.toTop.map (SSet.yonedaEquiv.symm y') z, ?_⟩
+  have hcomp :
+      SSet.toTop.map (SSet.yonedaEquiv.symm y') ≫
+          SSet.toTop.map (SSet.boundary.ι i) =
+        SSet.toTop.map (SSet.yonedaEquiv.symm a) := by
+    rw [← SSet.toTop.map_comp, SSet.yonedaEquiv_symm_comp, hay]
+  have happ := ConcreteCategory.congr_hom hcomp z
+  change SSet.toTop.map (SSet.boundary.ι i)
+      (SSet.toTop.map (SSet.yonedaEquiv.symm y') z) =
+        SSet.toTop.map (SSet.yonedaEquiv.symm a) z at happ
+  change SSet.toTop.map (SSet.yonedaEquiv.symm a) z = x at hz
+  exact happ.trans hz
+
+/-- The comparison map from the realization really lands in the affine boundary. -/
+public theorem boundarySevenComparisonMapLandsInAffineBoundary :
+    BoundarySevenComparisonMapLandsInAffineBoundary := by
+  intro x
+  obtain ⟨i, y, rfl⟩ := boundarySevenRealization_exists_face_representation x
+  refine ⟨i, ?_⟩
+  rw [boundarySevenComparisonToStdSimplex_face]
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  apply Finset.sum_eq_zero
+  intro j hj
+  exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+
+/-- Consequently, the eight explicit face neighborhoods cover the whole realization. -/
+public theorem boundarySevenComparisonFaceNeighborhood_iUnion_unconditional :
+    ⋃ i, boundarySevenComparisonFaceNeighborhood i = Set.univ :=
+  boundarySevenComparisonFaceNeighborhood_iUnion
+    boundarySevenComparisonMapLandsInAffineBoundary
+
+/-- With the global cover assertion discharged, the canonical integral comparison is
+unconditionally equivalent to the explicit face-neighborhood lift. -/
+public theorem boundarySeven_integralComparison_iff_faceNeighborhoodLift_unconditional :
+    SimplicialToSingularComparisonQuasiIsomorphism
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ↔
+      BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism :=
+  boundarySeven_integralComparison_iff_faceNeighborhoodLift
+    boundarySevenComparisonMapLandsInAffineBoundary
+
+/-- The coproduct of the eight standard simplicial faces. -/
+public noncomputable abbrev boundarySevenSimplicialFacePresentationSource : SSet.{0} :=
+  sigmaObj (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0}))
+
+/-- The canonical simplicial face presentation of `∂Δ[7]`. -/
+public noncomputable def boundarySevenSimplicialFacePresentation :
+    boundarySevenSimplicialFacePresentationSource ⟶ (∂Δ[7] : SSet.{0}) :=
+  Sigma.desc fun i ↦ SSet.boundary.ι i
+
+/-- The simplicial face presentation is degreewise surjective. -/
+public theorem boundarySevenSimplicialFacePresentation_app_surjective
+    (n : SimplexCategoryᵒᵖ) :
+    Function.Surjective (boundarySevenSimplicialFacePresentation.app n) := by
+  intro x
+  have hx := x.2
+  simp only [SSet.boundary_eq_iSup, SSet.stdSimplex.face_singleton_compl,
+    Subfunctor.iSup_obj, Set.mem_iUnion,
+    SSet.Subcomplex.mem_ofSimplex_obj_iff, Opposite.op_unop] at hx
+  obtain ⟨i, ⟨y, hy⟩⟩ := hx
+  let y' : (Δ[6] : SSet.{0}).obj n := SSet.stdSimplex.objEquiv.symm y
+  refine ⟨(Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i).app n y', ?_⟩
+  apply Subtype.ext
+  change ((Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i ≫
+    boundarySevenSimplicialFacePresentation).app n y').1 = x.1
+  rw [boundarySevenSimplicialFacePresentation, Sigma.ι_desc]
+  exact hy
+
+/-- The simplicial face presentation is an epimorphism. -/
+public instance boundarySevenSimplicialFacePresentation_epi :
+    Epi boundarySevenSimplicialFacePresentation := by
+  rw [NatTrans.epi_iff_epi_app]
+  intro n
+  rw [CategoryTheory.epi_iff_surjective]
+  exact boundarySevenSimplicialFacePresentation_app_surjective n
+
+/-- The coproduct of the singular simplicial sets of the eight face neighborhoods. -/
+public noncomputable abbrev boundarySevenFaceNeighborhoodPresentationSource : SSet.{0} :=
+  sigmaObj (fun i : Fin 8 ↦
+    TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i)))
+
+/-- The canonical presentation of the face-neighborhood-small singular simplicial set. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentation :
+    boundarySevenFaceNeighborhoodPresentationSource ⟶
+      coverSmallSingularSubcomplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood :=
+  Sigma.desc fun i ↦
+    coverMemberToSmallSingularSet
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood i
+
+/-- In every simplicial degree, the face-neighborhood presentation is surjective. -/
+public theorem boundarySevenFaceNeighborhoodPresentation_app_surjective
+    (n : SimplexCategoryᵒᵖ) :
+    Function.Surjective (boundarySevenFaceNeighborhoodPresentation.app n) := by
+  intro z
+  obtain ⟨i, y, hy⟩ :=
+    (mem_coverSmallSingularSubcomplex_iff_exists_preimage
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood z.1).mp z.2
+  refine ⟨(Sigma.ι (fun i : Fin 8 ↦
+    TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i).app n y, ?_⟩
+  apply Subtype.ext
+  have hcat :
+      Sigma.ι (fun i : Fin 8 ↦
+          TopCat.toSSet.obj
+            (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i ≫
+          boundarySevenFaceNeighborhoodPresentation ≫
+          (coverSmallSingularSubcomplex
+            (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+            boundarySevenComparisonFaceNeighborhood).ι =
+        TopCat.toSSet.map
+          (topologicalSubsetInclusion (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+            (boundarySevenComparisonFaceNeighborhood i)) := by
+    rw [boundarySevenFaceNeighborhoodPresentation, ← Category.assoc, Sigma.ι_desc,
+      coverMemberToSmallSingularSet_comp_inclusion]
+  have happ := ConcreteCategory.congr_hom (congr_app hcat n) y
+  exact happ.trans hy
+
+/-- The cover presentation is an epimorphism of simplicial sets. -/
+public instance boundarySevenFaceNeighborhoodPresentation_epi :
+    Epi boundarySevenFaceNeighborhoodPresentation := by
+  rw [NatTrans.epi_iff_epi_app]
+  intro n
+  rw [CategoryTheory.epi_iff_surjective]
+  exact boundarySevenFaceNeighborhoodPresentation_app_surjective n
+
+/-- Facewise, the realized simplicial unit maps the coproduct of standard faces to the
+coproduct of singular sets of the corresponding open neighborhoods. -/
+public noncomputable def boundarySevenFacePresentationSourceMap :
+    boundarySevenSimplicialFacePresentationSource ⟶
+      boundarySevenFaceNeighborhoodPresentationSource :=
+  Sigma.desc fun i ↦
+    sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+      TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i) ≫
+        Sigma.ι (fun i : Fin 8 ↦
+          TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenSimplicialFacePresentation_iota (i : Fin 8) :
+    Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i ≫
+        boundarySevenSimplicialFacePresentation =
+      SSet.boundary.ι i := by
+  apply Sigma.ι_desc
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenFacePresentationSourceMap_iota (i : Fin 8) :
+    Sigma.ι (fun _i : Fin 8 ↦ (Δ[6] : SSet.{0})) i ≫
+        boundarySevenFacePresentationSourceMap =
+      sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+        TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i) ≫
+          Sigma.ι (fun i : Fin 8 ↦
+            TopCat.toSSet.obj
+              (TopCat.of (boundarySevenComparisonFaceNeighborhood i))) i := by
+  apply Sigma.ι_desc
+
+/-- The facewise presentation map commutes with the two augmentations. -/
+public theorem boundarySevenFacePresentationSourceMap_comp_presentation :
+    boundarySevenFacePresentationSourceMap ≫
+        boundarySevenFaceNeighborhoodPresentation =
+      boundarySevenSimplicialFacePresentation ≫
+        simplicialToCoverSmallSingularSet
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods := by
+  apply Sigma.hom_ext
+  intro i
+  simp only [← Category.assoc,
+    boundarySevenFacePresentationSourceMap_iota,
+    boundarySevenSimplicialFacePresentation_iota]
+  rw [Category.assoc, Category.assoc]
+  rw [boundarySevenFaceNeighborhoodPresentation, Sigma.ι_desc]
+  change boundarySevenFaceUnitToSmallSingularSet i =
+    SSet.boundary.ι i ≫
+      simplicialToCoverSmallSingularSet
+        (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+        boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  apply (cancel_mono
+    (coverSmallSingularSubcomplex
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood).ι).mp
+  rw [boundarySevenFaceUnitToSmallSingularSet_comp_inclusion,
+    Category.assoc, simplicialToCoverSmallSingularSet_comp_inclusion]
+
+/-- The preceding commuting square as a morphism of arrows. -/
+public noncomputable def boundarySevenFacePresentationArrowMap :
+    Arrow.mk boundarySevenSimplicialFacePresentation ⟶
+      Arrow.mk boundarySevenFaceNeighborhoodPresentation where
+  left := boundarySevenFacePresentationSourceMap
+  right := simplicialToCoverSmallSingularSet
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  w := boundarySevenFacePresentationSourceMap_comp_presentation
+
+/-- The presentation evaluated at one singular degree, as an arrow of types. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+    (n : SimplexCategoryᵒᵖ) : Arrow (Type 0) :=
+  Arrow.mk (boundarySevenFaceNeighborhoodPresentation.app n)
+
+/-- A chosen splitting of the evaluated presentation.  Choice is harmless here: this splitting
+is used only horizontally, to contract one Čech row. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentationEvaluationSplitEpi
+    (n : SimplexCategoryᵒᵖ) :
+    SplitEpi (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n).hom := by
+  let h := boundarySevenFaceNeighborhoodPresentation_app_surjective n
+  exact
+    { section_ := ↾fun z ↦ Function.surjInv h z
+      id := by
+        ext z
+        exact Function.rightInverse_surjInv h z }
+
+/-- The evaluated augmented Čech nerve has an extra degeneracy. -/
+public noncomputable def boundarySevenFaceNeighborhoodEvaluationExtraDegeneracy
+    (n : SimplexCategoryᵒᵖ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n).augmentedCechNerve :=
+  Arrow.AugmentedCechNerve.extraDegeneracy
+    (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n)
+    (boundarySevenFaceNeighborhoodPresentationEvaluationSplitEpi n)
+
+/-- Apply the free abelian group functor to an evaluated augmented Čech nerve. -/
+public noncomputable abbrev boundarySevenFaceNeighborhoodFreeEvaluationCech
+    (n : SimplexCategoryᵒᵖ) : SimplicialObject.Augmented AddCommGrpCat :=
+  ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    AddCommGrpCat.free).obj
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow n).augmentedCechNerve
+
+/-- The free-abelian evaluated Čech nerve retains the extra degeneracy. -/
+public noncomputable def boundarySevenFaceNeighborhoodFreeEvaluationExtraDegeneracy
+    (n : SimplexCategoryᵒᵖ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenFaceNeighborhoodFreeEvaluationCech n) :=
+  (boundarySevenFaceNeighborhoodEvaluationExtraDegeneracy n).map AddCommGrpCat.free
+
+/-- Rowwise Čech exactness: in every singular degree, the alternating Čech complex is
+chain-homotopy equivalent to the free group on the cover-small simplices in that degree. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechRowHomotopyEquiv
+    (n : SimplexCategoryᵒᵖ) :
+    HomotopyEquiv
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodFreeEvaluationCech n)))
+      ((ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenFaceNeighborhoodFreeEvaluationCech n))) :=
+  (boundarySevenFaceNeighborhoodFreeEvaluationExtraDegeneracy n).homotopyEquiv
+
+/-- The same evaluated Čech nerve with the coefficient functor actually used by integral
+simplicial chains: a coproduct of copies of `ℤ`. -/
+public noncomputable abbrev boundarySevenFaceNeighborhoodIntegralEvaluationCech
+    (k : ℕ) : SimplicialObject.Augmented AddCommGrpCat :=
+  ((SimplicialObject.Augmented.whiskering (Type 0) AddCommGrpCat).obj
+    (sigmaConst.obj (AddCommGrpCat.of ℤ))).obj
+      (boundarySevenFaceNeighborhoodPresentationEvaluationArrow
+        (Opposite.op (SimplexCategory.mk k))).augmentedCechNerve
+
+/-- The integral evaluated Čech nerve has the same row contraction. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralEvaluationExtraDegeneracy
+    (k : ℕ) :
+    SimplicialObject.Augmented.ExtraDegeneracy
+      (boundarySevenFaceNeighborhoodIntegralEvaluationCech k) :=
+  (boundarySevenFaceNeighborhoodEvaluationExtraDegeneracy
+    (Opposite.op (SimplexCategory.mk k))).map
+      (sigmaConst.obj (AddCommGrpCat.of ℤ))
+
+/-- Rowwise exactness in the precise coefficient model used by the singular chain complex. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralCechRowHomotopyEquiv
+    (k : ℕ) :
+    HomotopyEquiv
+      (AlternatingFaceMapComplex.obj
+        (SimplicialObject.Augmented.drop.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)))
+      ((ChainComplex.single₀ AddCommGrpCat).obj
+        (SimplicialObject.Augmented.point.obj
+          (boundarySevenFaceNeighborhoodIntegralEvaluationCech k))) :=
+  (boundarySevenFaceNeighborhoodIntegralEvaluationExtraDegeneracy k).homotopyEquiv
+
+/-- The target of the integral row contraction is definitionally the degree-`k` group of the
+cover-small singular chain complex. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralEvaluationPointIso
+    (k : ℕ) :
+    SimplicialObject.Augmented.point.obj
+        (boundarySevenFaceNeighborhoodIntegralEvaluationCech k) ≅
+      (CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood).X k :=
+  Iso.refl _
+
+/-- Equivalently, every horizontal integral Čech-row augmentation is a
+quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodIntegralCechRowAugmentation_quasiIso
+    (k : ℕ) :
+    QuasiIso (AlternatingFaceMapComplex.ε.app
+      (boundarySevenFaceNeighborhoodIntegralEvaluationCech k)) :=
+  (boundarySevenFaceNeighborhoodIntegralCechRowHomotopyEquiv k).quasiIso_hom
+
+/-- The face-neighborhood presentation, bundled as an arrow of simplicial sets. -/
+public noncomputable def boundarySevenFaceNeighborhoodPresentationArrow : Arrow SSet :=
+  Arrow.mk boundarySevenFaceNeighborhoodPresentation
+
+/-- The augmented Čech nerve of the face-neighborhood presentation. -/
+public noncomputable def boundarySevenFaceNeighborhoodAugmentedCechNerve :
+    SimplicialObject.Augmented SSet :=
+  boundarySevenFaceNeighborhoodPresentationArrow.augmentedCechNerve
+
+/-- Apply integral simplicial chains in the singular direction to the augmented Čech nerve. -/
+public noncomputable def boundarySevenFaceNeighborhoodAugmentedCechChains :
+    SimplicialObject.Augmented (ChainComplex AddCommGrpCat ℕ) :=
+  ((SimplicialObject.Augmented.whiskering SSet
+    (ChainComplex AddCommGrpCat ℕ)).obj
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ))).obj
+        boundarySevenFaceNeighborhoodAugmentedCechNerve
+
+/-- The Čech--singular bicomplex for the eight explicit face neighborhoods. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechBicomplex :
+    HomologicalComplex₂ AddCommGrpCat (ComplexShape.down ℕ) (ComplexShape.down ℕ) :=
+  AlternatingFaceMapComplex.obj
+    (SimplicialObject.Augmented.drop.obj
+      boundarySevenFaceNeighborhoodAugmentedCechChains)
+
+/-- The direct-sum total Čech--singular complex for the eight explicit face neighborhoods. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechTotal :
+    ChainComplex AddCommGrpCat ℕ :=
+  boundarySevenFaceNeighborhoodCechBicomplex.total (ComplexShape.down ℕ)
+
+/-- The canonical outer Čech augmentation before totalization.  Its target is the horizontal
+degree-zero complex on the cover-small singular chain complex. -/
+public noncomputable def boundarySevenFaceNeighborhoodCechOuterAugmentation :
+    boundarySevenFaceNeighborhoodCechBicomplex ⟶
+      (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).obj
+        (CoverSmallIntegralSingularChainComplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood) :=
+  AlternatingFaceMapComplex.ε.app
+    boundarySevenFaceNeighborhoodAugmentedCechChains
+
+/-- Exact data still needed to turn rowwise Čech exactness and the local face contractions
+into the comparison theorem.  The first map is the local face/intersection comparison; the
+second is the totalized canonical Čech augmentation. -/
+public structure BoundarySevenFaceNeighborhoodCechTotalComparison where
+  boundaryToCech :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenFaceNeighborhoodCechTotal
+  augmentation :
+    boundarySevenFaceNeighborhoodCechTotal ⟶
+      CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood
+  fac : boundaryToCech ≫ augmentation =
+    simplicialToCoverSmallSingularChainMap
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  boundaryToCech_quasiIso : QuasiIso boundaryToCech
+  augmentation_quasiIso : QuasiIso augmentation
+
+/-- A Čech total comparison supplies the remaining face-neighborhood lift
+quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodLiftQuasiIsomorphism_of_cechTotalComparison
+    (h : BoundarySevenFaceNeighborhoodCechTotalComparison) :
+    BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism := by
+  unfold BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism
+  rw [← h.fac]
+  let _ : QuasiIso h.boundaryToCech := h.boundaryToCech_quasiIso
+  let _ : QuasiIso h.augmentation := h.augmentation_quasiIso
+  infer_instance
+
+/-- The Čech total comparison also gives the original canonical integral comparison, since the
+global affine-boundary cover assertion was proved above. -/
+public theorem boundarySeven_integralComparison_of_cechTotalComparison
+    (h : BoundarySevenFaceNeighborhoodCechTotalComparison) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  boundarySeven_integralComparison_of_faceNeighborhoodLift
+    boundarySevenComparisonMapLandsInAffineBoundary
+    (boundarySevenFaceNeighborhoodLiftQuasiIsomorphism_of_cechTotalComparison h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodDeformation.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodDeformation.lean
@@ -1,0 +1,426 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenRealizationInjective
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodComparison
+public import SphereSixComplex.Topology.HomotopySphereHomology
+
+/-!
+# Deformation of a boundary-face neighbourhood onto its face
+
+For a fixed barycentric coordinate `i`, the open subset `w i < 1 / 8` of the boundary of the
+standard seven-simplex deformation retracts onto the face `w i = 0`.  The retraction sets the
+`i`-th coordinate to zero and divides all other coordinates by `1 - w i`.
+
+This file develops the affine formula independently of the total-complex argument.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The ordinary barycentric version of the `i`-th open face neighbourhood. -/
+public def standardBoundarySevenFaceNeighborhood (i : Fin 8) :
+    Set (StandardSimplexBoundary 7) :=
+  {w | w.1 i < (1 : ℝ) / 8}
+
+/-- On the `i`-th face neighbourhood, the sum of the other coordinates is positive. -/
+public theorem standardBoundarySevenFaceNeighborhood_one_sub_pos
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    0 < 1 - w.1.1 i := by
+  have hw : w.1.1 i < (1 : ℝ) / 8 := w.2
+  linarith
+
+/-- Delete the `i`-th coordinate and renormalize the remaining seven coordinates. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodRetractionCoordinates
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    stdSimplex ℝ (Fin 7) := by
+  let d : ℝ := 1 - w.1.1 i
+  have hd : 0 < d := standardBoundarySevenFaceNeighborhood_one_sub_pos i w
+  refine ⟨fun j ↦ w.1.1 (i.succAbove j) / d, ⟨?_, ?_⟩⟩
+  · intro j
+    exact div_nonneg (w.1.1.2.1 _) hd.le
+  · have hsum := w.1.1.2.2
+    change (∑ k : Fin 8, w.1.1 k) = 1 at hsum
+    have hother : (∑ j : Fin 7, w.1.1 (i.succAbove j)) = d := by
+      rw [Fin.sum_univ_succAbove (fun k ↦ w.1.1 k) i] at hsum
+      dsimp [d]
+      linarith
+    rw [← Finset.sum_div, hother, div_self hd.ne']
+
+/-- The retraction coordinates vary continuously over the open face neighbourhood. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodRetractionCoordinates
+    (i : Fin 8) :
+    Continuous (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i) := by
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro j
+  exact (((continuous_apply (i.succAbove j)).comp
+      (continuous_subtype_val.comp continuous_subtype_val)).comp
+        continuous_subtype_val).div
+    (continuous_const.sub
+      (((continuous_apply i).comp
+        (continuous_subtype_val.comp continuous_subtype_val)).comp
+          continuous_subtype_val))
+    (fun w ↦ (standardBoundarySevenFaceNeighborhood_one_sub_pos i w).ne')
+
+/-- The normalized point, reinserted as a point of the ordinary boundary. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodProjection
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    StandardSimplexBoundary 7 :=
+  ⟨stdSimplex.map i.succAbove
+      (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w),
+    ⟨i, stdSimplex_map_succAbove_apply_self i _⟩⟩
+
+/-- The projection varies continuously. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodProjection
+    (i : Fin 8) :
+    Continuous (standardBoundarySevenFaceNeighborhoodProjection i) := by
+  apply Continuous.subtype_mk
+  exact (stdSimplex.continuous_map i.succAbove).comp
+    (continuous_standardBoundarySevenFaceNeighborhoodRetractionCoordinates i)
+
+/-- The projected point still belongs to the same open face neighbourhood. -/
+public theorem standardBoundarySevenFaceNeighborhoodProjection_mem
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhoodProjection i w ∈
+      standardBoundarySevenFaceNeighborhood i := by
+  change (standardBoundarySevenFaceNeighborhoodProjection i w).1 i < (1 : ℝ) / 8
+  rw [standardBoundarySevenFaceNeighborhoodProjection,
+    stdSimplex_map_succAbove_apply_self]
+  norm_num
+
+/-- The projection, as a self-map of the open neighbourhood. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodProjectionSelf
+    (i : Fin 8) :
+    C(standardBoundarySevenFaceNeighborhood i,
+      standardBoundarySevenFaceNeighborhood i) :=
+  ⟨fun w ↦ ⟨standardBoundarySevenFaceNeighborhoodProjection i w,
+      standardBoundarySevenFaceNeighborhoodProjection_mem i w⟩,
+    (continuous_standardBoundarySevenFaceNeighborhoodProjection i).subtype_mk _⟩
+
+/-- Every coordinate which vanishes before projection also vanishes after projection. -/
+public theorem standardBoundarySevenFaceNeighborhoodProjection_apply_eq_zero
+    (i k : Fin 8) (w : standardBoundarySevenFaceNeighborhood i)
+    (hk : w.1.1 k = 0) :
+    (standardBoundarySevenFaceNeighborhoodProjection i w).1 k = 0 := by
+  rcases Fin.eq_self_or_eq_succAbove i k with hik | ⟨j, hj⟩
+  · subst k
+    exact stdSimplex_map_succAbove_apply_self i _
+  · subst k
+    rw [standardBoundarySevenFaceNeighborhoodProjection,
+      stdSimplex_map_apply_of_injective i.succAbove
+        Fin.succAbove_right_injective]
+    change w.1.1 (i.succAbove j) /
+      (1 - w.1.1 i) = 0
+    rw [hk, zero_div]
+
+/-- Linear interpolation from a point of the neighbourhood to its normalized face projection. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodHomotopyPoint
+    (i : Fin 8) (q : unitInterval × standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhood i := by
+  let t : ℝ := q.1
+  let w := q.2
+  let p := standardBoundarySevenFaceNeighborhoodProjection i w
+  let z : Fin 8 → ℝ := fun k ↦ (1 - t) * w.1.1 k + t * p.1 k
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    exact add_nonneg
+      (mul_nonneg (sub_nonneg.mpr q.1.2.2) (w.1.1.2.1 k))
+      (mul_nonneg q.1.2.1 (p.1.2.1 k))
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    have hw_sum : (∑ k : Fin 8, w.1.1 k) = 1 := w.1.1.2.2
+    have hp_sum : (∑ k : Fin 8, p.1 k) = 1 := p.1.2.2
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      hw_sum, hp_sum]
+    ring
+  have hz_boundary : ∃ k, z k = 0 := by
+    obtain ⟨k, hk⟩ := w.1.2
+    refine ⟨k, ?_⟩
+    dsimp [z]
+    rw [hk, standardBoundarySevenFaceNeighborhoodProjection_apply_eq_zero i k w hk]
+    ring
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  let zb : StandardSimplexBoundary 7 := ⟨zs, hz_boundary⟩
+  refine ⟨zb, ?_⟩
+  have hpi : p.1 i = 0 := stdSimplex_map_succAbove_apply_self i _
+  have hwi_nonneg : 0 ≤ w.1.1 i := w.1.1.2.1 i
+  have hwi_lt : w.1.1 i < (1 : ℝ) / 8 := w.2
+  have ht0 : 0 ≤ t := q.1.2.1
+  have ht1 : t ≤ 1 := q.1.2.2
+  change z i < (1 : ℝ) / 8
+  dsimp [z]
+  rw [hpi, mul_zero, add_zero]
+  nlinarith
+
+/-- The affine neighbourhood deformation is continuous. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodHomotopyPoint
+    (i : Fin 8) :
+    Continuous (standardBoundarySevenFaceNeighborhoodHomotopyPoint i) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  change Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦
+        (1 - (q.1 : ℝ)) * q.2.1.1 k +
+          (q.1 : ℝ) *
+            (standardBoundarySevenFaceNeighborhoodProjection i q.2).1 k)
+  have ct : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦ (q.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have cw : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦ q.2.1.1 k) :=
+    ((((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp continuous_subtype_val).comp continuous_snd
+  have cp : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhood i ↦
+        (standardBoundarySevenFaceNeighborhoodProjection i q.2).1 k) :=
+    (((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp
+        ((continuous_standardBoundarySevenFaceNeighborhoodProjection i).comp continuous_snd)
+  exact (continuous_const.sub ct).mul cw |>.add (ct.mul cp)
+
+/-- At time zero the affine deformation is the identity. -/
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodHomotopyPoint_zero
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhoodHomotopyPoint i (0, w) = w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (0 : ℝ)) * w.1.1 k + 0 *
+      (standardBoundarySevenFaceNeighborhoodProjection i w).1 k = w.1.1 k
+  ring
+
+/-- At time one the affine deformation is the normalized face projection. -/
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodHomotopyPoint_one
+    (i : Fin 8) (w : standardBoundarySevenFaceNeighborhood i) :
+    standardBoundarySevenFaceNeighborhoodHomotopyPoint i (1, w) =
+      standardBoundarySevenFaceNeighborhoodProjectionSelf i w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (1 : ℝ)) * w.1.1 k + 1 *
+      (standardBoundarySevenFaceNeighborhoodProjection i w).1 k =
+        (standardBoundarySevenFaceNeighborhoodProjection i w).1 k
+  ring
+
+/-- The explicit deformation from the identity to the face projection. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodHomotopy
+    (i : Fin 8) :
+    ContinuousMap.Homotopy (ContinuousMap.id _)
+      (standardBoundarySevenFaceNeighborhoodProjectionSelf i) where
+  toFun := standardBoundarySevenFaceNeighborhoodHomotopyPoint i
+  continuous_toFun := continuous_standardBoundarySevenFaceNeighborhoodHomotopyPoint i
+  map_zero_left := standardBoundarySevenFaceNeighborhoodHomotopyPoint_zero i
+  map_one_left := standardBoundarySevenFaceNeighborhoodHomotopyPoint_one i
+
+/-! ## The face inclusion is a homotopy equivalence -/
+
+/-- Insert a realized standard six-simplex as the `i`-th affine face, regarded as a point of the
+open face neighbourhood. -/
+public noncomputable def realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood
+    (i : Fin 8) :
+    C((SSet.toTop.obj (Δ[6] : SSet.{0}) : Type),
+      standardBoundarySevenFaceNeighborhood i) := by
+  refine ⟨fun y ↦ ⟨⟨stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y),
+      ⟨i, stdSimplex_map_succAbove_apply_self i _⟩⟩, ?_⟩, ?_⟩
+  · change stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) i < (1 : ℝ) / 8
+    rw [stdSimplex_map_succAbove_apply_self]
+    norm_num
+  · apply Continuous.subtype_mk
+    apply Continuous.subtype_mk
+    exact (stdSimplex.continuous_map i.succAbove).comp
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).continuous
+
+/-- Normalize away the distinguished coordinate and return to the realized standard face. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex
+    (i : Fin 8) :
+    C(standardBoundarySevenFaceNeighborhood i,
+      (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :=
+  ⟨fun w ↦ (SimplexCategory.toTopHomeo
+      (SimplexCategory.mk 6)).symm
+        (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm.continuous.comp
+      (continuous_standardBoundarySevenFaceNeighborhoodRetractionCoordinates i)⟩
+
+/-- Normalizing a point already on the face returns its original face coordinates. -/
+public theorem standardBoundarySevenFaceNeighborhoodRetractionCoordinates_face
+    (i : Fin 8) (y : SSet.toTop.obj (Δ[6] : SSet.{0})) :
+    standardBoundarySevenFaceNeighborhoodRetractionCoordinates i
+        (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i y) =
+      SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y := by
+  apply stdSimplex.ext
+  funext j
+  rw [standardBoundarySevenFaceNeighborhoodRetractionCoordinates]
+  change stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) (i.succAbove j) /
+        (1 - stdSimplex.map i.succAbove
+          (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) i) = _
+  rw [stdSimplex_map_apply_of_injective i.succAbove
+      Fin.succAbove_right_injective,
+    stdSimplex_map_succAbove_apply_self]
+  simp
+
+/-- The retraction is a strict left inverse to the face inclusion. -/
+public theorem standardBoundarySevenFaceNeighborhoodToRealized_comp_inclusion :
+    (standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex i).comp
+        (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i) =
+      ContinuousMap.id _ := by
+  ext y
+  apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+  simp [standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex,
+    standardBoundarySevenFaceNeighborhoodRetractionCoordinates_face]
+
+/-- Inclusion after retraction is exactly the normalized affine face projection. -/
+public theorem realizedStandardSixSimplexToStandardBoundary_comp_retraction :
+    (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i).comp
+        (standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex i) =
+      standardBoundarySevenFaceNeighborhoodProjectionSelf i := by
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)
+        ((SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm
+          (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w))) k =
+    stdSimplex.map i.succAbove
+      (standardBoundarySevenFaceNeighborhoodRetractionCoordinates i w) k
+  rw [Homeomorph.apply_symm_apply]
+
+/-- The affine face inclusion is a homotopy equivalence, with the explicit normalized
+retraction as inverse. -/
+public noncomputable def realizedStandardSixSimplexStandardBoundaryFaceNeighborhoodHomotopyEquiv
+    (i : Fin 8) :
+    (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ≃ₕ
+      standardBoundarySevenFaceNeighborhood i where
+  toFun := realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i
+  invFun := standardBoundarySevenFaceNeighborhoodToRealizedStandardSixSimplex i
+  left_inv := by
+    rw [standardBoundarySevenFaceNeighborhoodToRealized_comp_inclusion]
+  right_inv := by
+    rw [realizedStandardSixSimplexToStandardBoundary_comp_retraction]
+    exact ⟨(standardBoundarySevenFaceNeighborhoodHomotopy i).symm⟩
+
+/-! ## Transport back to the geometric realization -/
+
+/-- The canonical barycentric homeomorphism, now available unconditionally. -/
+public noncomputable def boundarySevenRealizationHomeomorphStandardBoundary :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ StandardSimplexBoundary 7 :=
+  boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+    boundarySevenRealizationToBoundary_injective
+
+@[simp]
+public theorem boundarySevenRealizationHomeomorphStandardBoundary_apply_val
+    (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
+    (boundarySevenRealizationHomeomorphStandardBoundary x :
+        stdSimplex ℝ (Fin 8)) = boundarySevenComparisonToStdSimplex x :=
+  rfl
+
+/-- The actual realization face neighbourhood is homeomorphic to its ordinary barycentric
+counterpart. -/
+public noncomputable def boundarySevenFaceNeighborhoodHomeomorphStandard
+    (i : Fin 8) :
+    boundarySevenComparisonFaceNeighborhood i ≃ₜ
+      standardBoundarySevenFaceNeighborhood i :=
+  boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
+    change boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8 ↔
+      (boundarySevenRealizationHomeomorphStandardBoundary x :
+        stdSimplex ℝ (Fin 8)) i < (1 : ℝ) / 8
+    rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+
+/-- The forward continuous map of the barycentric neighbourhood homeomorphism. -/
+public noncomputable def boundarySevenFaceNeighborhoodToStandardContinuousMap
+    (i : Fin 8) :
+    C(boundarySevenComparisonFaceNeighborhood i,
+      standardBoundarySevenFaceNeighborhood i) :=
+  ⟨boundarySevenFaceNeighborhoodHomeomorphStandard i,
+    (boundarySevenFaceNeighborhoodHomeomorphStandard i).continuous⟩
+
+/-- Under barycentric coordinates, the existing realized-face map is the affine face
+inclusion used above. -/
+public theorem boundarySevenFaceNeighborhoodHomeomorphStandard_comp_face
+    (i : Fin 8) :
+    (boundarySevenFaceNeighborhoodToStandardContinuousMap i).comp
+        (boundarySevenFaceToComparisonFaceNeighborhood i).hom =
+      realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i := by
+  apply ContinuousMap.ext
+  intro y
+  apply Subtype.ext
+  apply Subtype.ext
+  change boundarySevenComparisonToStdSimplex
+      (SSet.toTop.map (SSet.boundary.ι i) y) =
+    stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)
+  exact boundarySevenComparisonToStdSimplex_face i y
+
+/-- Every canonical realized face is a homotopy equivalence onto its open affine
+neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodHomotopyEquiv
+    (i : Fin 8) :
+    (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ≃ₕ
+      boundarySevenComparisonFaceNeighborhood i :=
+  (realizedStandardSixSimplexStandardBoundaryFaceNeighborhoodHomotopyEquiv i).trans
+    (boundarySevenFaceNeighborhoodHomeomorphStandard i).symm.toHomotopyEquiv
+
+/-- The forward function of the preceding homotopy equivalence is the face map already used by
+the comparison construction. -/
+public theorem boundarySevenFaceNeighborhoodHomotopyEquiv_apply
+    (i : Fin 8) (y : SSet.toTop.obj (Δ[6] : SSet.{0})) :
+    boundarySevenFaceNeighborhoodHomotopyEquiv i y =
+      boundarySevenFaceToComparisonFaceNeighborhood i y := by
+  change (boundarySevenFaceNeighborhoodHomeomorphStandard i).symm
+      (realizedStandardSixSimplexToStandardBoundaryFaceNeighborhood i y) =
+    boundarySevenFaceToComparisonFaceNeighborhood i y
+  apply (boundarySevenFaceNeighborhoodHomeomorphStandard i).injective
+  rw [Homeomorph.apply_symm_apply]
+  exact ContinuousMap.congr_fun
+    (boundarySevenFaceNeighborhoodHomeomorphStandard_comp_face i).symm y
+
+/-- The singular-chain map induced by inclusion of a realized face into its neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntegralSingularChainMap
+    (i : Fin 8) :
+    IntegralSingularChainComplexObj
+        (SSet.toTop.obj (Δ[6] : SSet.{0})) ⟶
+      IntegralSingularChainComplexObj
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood i)) :=
+  integralSingularChainMapObj
+    (boundarySevenFaceToComparisonFaceNeighborhood i)
+
+/-- Since the face inclusion is an explicit homotopy equivalence, its integral singular-chain
+map is a quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodIntegralSingularChainMap_quasiIso
+    (i : Fin 8) :
+    QuasiIso (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) := by
+  let e := boundarySevenFaceNeighborhoodHomotopyEquiv i
+  have hmap : TopCat.ofHom e.toFun =
+      boundarySevenFaceToComparisonFaceNeighborhood i := by
+    ext y
+    exact congrArg Subtype.val
+      (boundarySevenFaceNeighborhoodHomotopyEquiv_apply i y)
+  rw [quasiIso_iff]
+  intro k
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  change IsIso (((singularHomologyFunctor AddCommGrpCat k).obj
+    (AddCommGrpCat.of ℤ)).map
+      (boundarySevenFaceToComparisonFaceNeighborhood i))
+  rw [← hmap]
+  change IsIso (singularHomologyIsoOfHomotopyEquiv
+    (AddCommGrpCat.of ℤ) k e).hom
+  infer_instance
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersectionHomology.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersectionHomology.lean
@@ -1,0 +1,50 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodIntersections
+public import SphereSixComplex.Topology.ContractibleSingularMapQuasiIso
+
+/-!
+# Homology of finite face-neighbourhood intersections
+
+The explicit strong deformation retractions of the affine intersections imply their positive-
+degree singular homology vanishes.  More strongly, every specified map from a realized standard
+simplex into such an intersection induces a quasi-isomorphism on singular chains.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+/-- A nonempty proper face-neighbourhood intersection has zero positive-degree singular homology,
+with arbitrary coefficients. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_singularHomology_isZero
+    (R : AddCommGrpCat) (s : Finset (Fin 8)) (hsne : s.Nonempty)
+    (hsproper : s ≠ Finset.univ) (k : ℕ) (hk : k ≠ 0) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj
+      (TopCat.of (boundarySevenFaceNeighborhoodIntersection s))) := by
+  let _ : ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) :=
+    boundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hsproper
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (boundarySevenFaceNeighborhoodIntersection s)
+  have hunit :=
+    AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+      AddCommGrpCat k R (TopCat.of Unit) hk
+  exact hunit.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
+
+/-- Any continuous map from a realized standard simplex to a nonempty proper intersection
+induces a singular-chain quasi-isomorphism. -/
+public theorem standardSimplexToBoundarySevenFaceNeighborhoodIntersection_quasiIso
+    (R : AddCommGrpCat) (n : ℕ) (s : Finset (Fin 8))
+    (hsne : s.Nonempty) (hsproper : s ≠ Finset.univ)
+    (f : C((SSet.toTop.obj (Δ[n] : SSet.{0}) : Type),
+      boundarySevenFaceNeighborhoodIntersection s)) :
+    QuasiIso (standardSimplexToContractibleSingularChainMap R n f) := by
+  let _ : ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) :=
+    boundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hsproper
+  exact standardSimplexToContractibleSingularChainMap_quasiIso R n f
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersections.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersections.lean
@@ -1,0 +1,760 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodDeformation
+
+/-!
+# Intersections of the boundary-seven face neighbourhoods
+
+Every nonempty proper intersection of the affine open sets `x i < 1 / 8` retracts onto
+the face on which all of the indexed coordinates vanish.  The retraction simultaneously
+sets those coordinates to zero and renormalizes the complementary coordinates.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open ContinuousMap Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The barycentric model of an intersection of face neighbourhoods. -/
+public def standardBoundarySevenFaceNeighborhoodIntersection (s : Finset (Fin 8)) :
+    Set (StandardSimplexBoundary 7) :=
+  {w | ∀ i ∈ s, w.1 i < (1 : ℝ) / 8}
+
+/-- The affine face on which every coordinate indexed by `s` vanishes. -/
+public def standardBoundarySevenAffineFace (s : Finset (Fin 8)) :
+    Set (StandardSimplexBoundary 7) :=
+  {w | ∀ i ∈ s, w.1 i = 0}
+
+/-- A proper subset of the eight coordinates contains at most seven coordinates. -/
+public theorem boundarySeven_finset_card_le_seven
+    {s : Finset (Fin 8)} (hs : s ≠ Finset.univ) : s.card ≤ 7 := by
+  have hss : s ⊂ Finset.univ := Finset.ssubset_univ_iff.mpr hs
+  have hc := Finset.card_lt_card hss
+  simp only [Finset.card_univ, Fintype.card_fin] at hc
+  omega
+
+/-- The complementary mass used in simultaneous normalization is positive. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersection_one_sub_sum_pos
+    {s : Finset (Fin 8)} (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    0 < 1 - ∑ i ∈ s, w.1.1 i := by
+  have hlt : (∑ i ∈ s, w.1.1 i) < ∑ _i ∈ s, (1 : ℝ) / 8 := by
+    apply Finset.sum_lt_sum
+    · intro i hi
+      exact (w.2 i hi).le
+    · obtain ⟨i, hi⟩ := hsne
+      exact ⟨i, hi, w.2 i hi⟩
+  have hc : s.card ≤ 7 := boundarySeven_finset_card_le_seven hs
+  have hconst : (∑ _i ∈ s, (1 : ℝ) / 8) ≤ (7 : ℝ) / 8 := by
+    simp only [Finset.sum_const, nsmul_eq_mul]
+    have hc' : (s.card : ℝ) ≤ 7 := by exact_mod_cast hc
+    calc
+      (s.card : ℝ) * ((1 : ℝ) / 8) ≤
+          7 * ((1 : ℝ) / 8) :=
+        mul_le_mul_of_nonneg_right hc' (by norm_num)
+      _ = (7 : ℝ) / 8 := by ring
+  linarith
+
+/-- Simultaneously set the coordinates in `s` to zero and renormalize the complement. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionProjection
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    StandardSimplexBoundary 7 := by
+  let d : ℝ := 1 - ∑ i ∈ s, w.1.1 i
+  have hd : 0 < d :=
+    standardBoundarySevenFaceNeighborhoodIntersection_one_sub_sum_pos hsne hs w
+  let z : Fin 8 → ℝ := fun k ↦ if k ∈ s then 0 else w.1.1 k / d
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    dsimp [z]
+    split_ifs
+    · exact le_rfl
+    · exact div_nonneg (w.1.1.2.1 k) hd.le
+  have hpartition :
+      (∑ k ∈ s, w.1.1 k) + (∑ k ∈ Finset.univ.filter (· ∉ s), w.1.1 k) = 1 := by
+    have hsplit := Finset.sum_filter_add_sum_filter_not Finset.univ
+      (fun k : Fin 8 ↦ k ∈ s) (fun k ↦ w.1.1 k)
+    rw [show Finset.univ.filter (fun k ↦ k ∈ s) = s by ext; simp] at hsplit
+    exact hsplit.trans w.1.1.2.2
+  have hother : (∑ k ∈ Finset.univ.filter (· ∉ s), w.1.1 k) = d := by
+    dsimp [d]
+    linarith
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    rw [Finset.sum_ite]
+    simp only [Finset.sum_const_zero, zero_add, ← Finset.sum_div]
+    rw [hother, div_self hd.ne']
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  refine ⟨zs, ?_⟩
+  obtain ⟨i, hi⟩ := hsne
+  refine ⟨i, ?_⟩
+  change z i = 0
+  simp [z, hi]
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s)
+    {i : Fin 8} (hi : i ∈ s) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 i = 0 := by
+  change (if i ∈ s then 0 else
+    w.1.1 i / (1 - ∑ j ∈ s, w.1.1 j)) = 0
+  rw [if_pos hi]
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_not_mem
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s)
+    {i : Fin 8} (hi : i ∉ s) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 i =
+      w.1.1 i / (1 - ∑ j ∈ s, w.1.1 j) := by
+  change (if i ∈ s then 0 else
+    w.1.1 i / (1 - ∑ j ∈ s, w.1.1 j)) = _
+  rw [if_neg hi]
+
+/-- The simultaneous projection lands in the common affine face. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_mem_face
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w ∈
+      standardBoundarySevenAffineFace s := by
+  intro i hi
+  exact standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+    s hsne hs w hi
+
+/-- The simultaneous projection also remains in the open intersection. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_mem
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w ∈
+      standardBoundarySevenFaceNeighborhoodIntersection s := by
+  intro i hi
+  rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+    s hsne hs w hi]
+  norm_num
+
+/-- The simultaneous normalization varies continuously. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodIntersectionProjection
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  by_cases hk : k ∈ s
+  · simp only [if_pos hk]
+    exact continuous_const
+  · simp only [if_neg hk]
+    have ck : Continuous (fun w : standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        w.1.1 k) :=
+      (((continuous_apply k).comp continuous_subtype_val).comp
+        continuous_subtype_val).comp continuous_subtype_val
+    have csum : Continuous (fun w : standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        ∑ i ∈ s, w.1.1 i) := by
+      apply continuous_finsetSum
+      intro i _hi
+      exact (((continuous_apply i).comp continuous_subtype_val).comp
+        continuous_subtype_val).comp continuous_subtype_val
+    exact ck.div (continuous_const.sub csum) fun w ↦
+      (standardBoundarySevenFaceNeighborhoodIntersection_one_sub_sum_pos
+        hsne hs w).ne'
+
+/-- Simultaneous normalization as a map to the common affine face. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionRetraction
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    C(standardBoundarySevenFaceNeighborhoodIntersection s,
+      standardBoundarySevenAffineFace s) :=
+  ⟨fun w ↦ ⟨standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w,
+      standardBoundarySevenFaceNeighborhoodIntersectionProjection_mem_face s hsne hs w⟩,
+    (continuous_standardBoundarySevenFaceNeighborhoodIntersectionProjection
+      s hsne hs).subtype_mk _⟩
+
+/-- Inclusion of the common affine face into the open intersection. -/
+public noncomputable def standardBoundarySevenAffineFaceInclusion
+    (s : Finset (Fin 8)) :
+    C(standardBoundarySevenAffineFace s,
+      standardBoundarySevenFaceNeighborhoodIntersection s) := by
+  refine ⟨fun w ↦ ⟨w.1, ?_⟩, continuous_subtype_val.subtype_mk _⟩
+  intro i hi
+  rw [w.2 i hi]
+  norm_num
+
+/-- Every zero coordinate remains zero under simultaneous normalization. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_eq_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) (k : Fin 8)
+    (hk : w.1.1 k = 0) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k = 0 := by
+  by_cases hks : k ∈ s
+  · exact standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+      s hsne hs w hks
+  · rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_not_mem
+      s hsne hs w hks, hk, zero_div]
+
+/-- The affine interpolation from a point to its simultaneous normalized projection. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (q : unitInterval × standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersection s := by
+  let t : ℝ := q.1
+  let w := q.2
+  let p := standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w
+  let z : Fin 8 → ℝ := fun k ↦ (1 - t) * w.1.1 k + t * p.1 k
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    exact add_nonneg
+      (mul_nonneg (sub_nonneg.mpr q.1.2.2) (w.1.1.2.1 k))
+      (mul_nonneg q.1.2.1 (p.1.2.1 k))
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    have hw_sum : (∑ k : Fin 8, w.1.1 k) = 1 := w.1.1.2.2
+    have hp_sum : (∑ k : Fin 8, p.1 k) = 1 := p.1.2.2
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      hw_sum, hp_sum]
+    ring
+  have hz_boundary : ∃ k, z k = 0 := by
+    obtain ⟨k, hk⟩ := w.1.2
+    refine ⟨k, ?_⟩
+    dsimp [z]
+    rw [hk, standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_eq_zero
+      s hsne hs w k hk]
+    ring
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  let zb : StandardSimplexBoundary 7 := ⟨zs, hz_boundary⟩
+  refine ⟨zb, ?_⟩
+  intro i hi
+  have hpi : p.1 i = 0 :=
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+      s hsne hs w hi
+  have hwi_nonneg : 0 ≤ w.1.1 i := w.1.1.2.1 i
+  have hwi_lt : w.1.1 i < (1 : ℝ) / 8 := w.2 i hi
+  have ht0 : 0 ≤ t := q.1.2.1
+  have ht1 : t ≤ 1 := q.1.2.2
+  change z i < (1 : ℝ) / 8
+  dsimp [z]
+  rw [hpi, mul_zero, add_zero]
+  nlinarith
+
+/-- The simultaneous affine deformation is continuous. -/
+public theorem continuous_standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  change Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        (1 - (q.1 : ℝ)) * q.2.1.1 k +
+          (q.1 : ℝ) *
+            (standardBoundarySevenFaceNeighborhoodIntersectionProjection
+              s hsne hs q.2).1 k)
+  have ct : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦ (q.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have cw : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦ q.2.1.1 k) :=
+    ((((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp continuous_subtype_val).comp continuous_snd
+  have cp : Continuous (fun q : unitInterval ×
+      standardBoundarySevenFaceNeighborhoodIntersection s ↦
+        (standardBoundarySevenFaceNeighborhoodIntersectionProjection
+          s hsne hs q.2).1 k) :=
+    (((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp
+        ((continuous_standardBoundarySevenFaceNeighborhoodIntersectionProjection
+          s hsne hs).comp continuous_snd)
+  exact (continuous_const.sub ct).mul cw |>.add (ct.mul cp)
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (0, w) = w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (0 : ℝ)) * w.1.1 k + 0 *
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k =
+    w.1.1 k
+  ring
+
+@[simp]
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenFaceNeighborhoodIntersection s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (1, w) =
+      standardBoundarySevenAffineFaceInclusion s
+        (standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs w) := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (1 : ℝ)) * w.1.1 k + 1 *
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k =
+        (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs w).1 k
+  ring
+
+/-- The simultaneous affine deformation, from the identity to inclusion after retraction. -/
+public noncomputable def standardBoundarySevenFaceNeighborhoodIntersectionHomotopy
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContinuousMap.Homotopy (ContinuousMap.id _)
+      ((standardBoundarySevenAffineFaceInclusion s).comp
+        (standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)) where
+  toFun := standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  continuous_toFun :=
+    continuous_standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  map_zero_left :=
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero s hsne hs
+  map_one_left :=
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one s hsne hs
+
+/-- Normalization is the identity on the common affine face. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionProjection_face
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs
+        (standardBoundarySevenAffineFaceInclusion s w) = w.1 := by
+  have hsum :
+      (∑ i ∈ s, (standardBoundarySevenAffineFaceInclusion s w).1.1 i) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    exact w.2 i hi
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  by_cases hk : k ∈ s
+  · rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_mem
+      s hsne hs _ hk, w.2 k hk]
+  · rw [standardBoundarySevenFaceNeighborhoodIntersectionProjection_apply_of_not_mem
+      s hsne hs _ hk, hsum]
+    change w.1.1 k / (1 - 0) = w.1.1 k
+    ring
+
+/-- The normalization map is a strict retraction of the face inclusion. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    (standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs).comp
+        (standardBoundarySevenAffineFaceInclusion s) =
+      ContinuousMap.id _ := by
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  exact standardBoundarySevenFaceNeighborhoodIntersectionProjection_face s hsne hs w
+
+/-- The deformation fixes the affine face pointwise at every time. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_fixed
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (t : unitInterval) (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (t, standardBoundarySevenAffineFaceInclusion s w) =
+      standardBoundarySevenAffineFaceInclusion s w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  have hp := standardBoundarySevenFaceNeighborhoodIntersectionProjection_face
+    s hsne hs w
+  have hpk :
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs
+        (standardBoundarySevenAffineFaceInclusion s w)).1 k = w.1.1 k := by
+    rw [hp]
+  change (1 - (t : ℝ)) * w.1.1 k + (t : ℝ) *
+      (standardBoundarySevenFaceNeighborhoodIntersectionProjection s hsne hs
+        (standardBoundarySevenAffineFaceInclusion s w)).1 k = w.1.1 k
+  rw [hpk]
+  ring
+
+/-- A nonempty proper intersection is homotopy equivalent to its common affine face.  The
+forward map is the literal face inclusion and the inverse is simultaneous normalization. -/
+public noncomputable def standardBoundarySevenAffineFaceIntersectionHomotopyEquiv
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    standardBoundarySevenAffineFace s ≃ₕ
+      standardBoundarySevenFaceNeighborhoodIntersection s where
+  toFun := standardBoundarySevenAffineFaceInclusion s
+  invFun := standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs
+  left_inv := by
+    rw [standardBoundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion]
+  right_inv := ⟨(standardBoundarySevenFaceNeighborhoodIntersectionHomotopy
+    s hsne hs).symm⟩
+
+/-! ## Contractibility of the common affine face -/
+
+/-- A chosen coordinate outside a proper set of coordinates. -/
+public noncomputable def boundarySevenCoordinateOutside
+    (s : Finset (Fin 8)) (hs : s ≠ Finset.univ) : Fin 8 :=
+  Classical.choose (show ∃ i, i ∉ s by
+    by_contra h
+    apply hs
+    apply Finset.eq_univ_of_forall
+    intro i
+    by_contra hi
+    exact h ⟨i, hi⟩)
+
+@[simp]
+public theorem boundarySevenCoordinateOutside_not_mem
+    (s : Finset (Fin 8)) (hs : s ≠ Finset.univ) :
+    boundarySevenCoordinateOutside s hs ∉ s :=
+  Classical.choose_spec (show ∃ i, i ∉ s by
+    by_contra h
+    apply hs
+    apply Finset.eq_univ_of_forall
+    intro i
+    by_contra hi
+    exact h ⟨i, hi⟩)
+
+/-- The complementary vertex used as a contraction point for the common face. -/
+public noncomputable def standardBoundarySevenAffineFaceVertex
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    standardBoundarySevenAffineFace s := by
+  let j := boundarySevenCoordinateOutside s hs
+  let z : Fin 8 → ℝ := fun k ↦ if k = j then 1 else 0
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    dsimp [z]
+    split_ifs <;> norm_num
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    simp
+  let zs : stdSimplex ℝ (Fin 8) := ⟨z, ⟨hz_nonneg, hz_sum⟩⟩
+  have hj : j ∉ s := boundarySevenCoordinateOutside_not_mem s hs
+  have hz_face : ∀ i ∈ s, zs i = 0 := by
+    intro i hi
+    change (if i = j then 1 else 0) = 0
+    rw [if_neg]
+    intro hij
+    subst i
+    exact hj hi
+  have hz_boundary : ∃ i, zs i = 0 := by
+    obtain ⟨i, hi⟩ := hsne
+    exact ⟨i, hz_face i hi⟩
+  exact ⟨⟨zs, hz_boundary⟩, hz_face⟩
+
+/-- Linear contraction of the common affine face to a complementary vertex. -/
+public noncomputable def standardBoundarySevenAffineFaceContractionPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (q : unitInterval × standardBoundarySevenAffineFace s) :
+    standardBoundarySevenAffineFace s := by
+  let t : ℝ := q.1
+  let w := q.2
+  let v := standardBoundarySevenAffineFaceVertex s hsne hs
+  let z : Fin 8 → ℝ := fun k ↦ (1 - t) * w.1.1 k + t * v.1.1 k
+  have hz_nonneg : ∀ k, 0 ≤ z k := by
+    intro k
+    exact add_nonneg
+      (mul_nonneg (sub_nonneg.mpr q.1.2.2) (w.1.1.2.1 k))
+      (mul_nonneg q.1.2.1 (v.1.1.2.1 k))
+  have hz_sum : ∑ k, z k = 1 := by
+    dsimp [z]
+    have hw_sum : (∑ k : Fin 8, w.1.1 k) = 1 := w.1.1.2.2
+    have hv_sum : (∑ k : Fin 8, v.1.1 k) = 1 := v.1.1.2.2
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum,
+      hw_sum, hv_sum]
+    ring
+  have hz_face : ∀ i ∈ s, z i = 0 := by
+    intro i hi
+    dsimp [z]
+    rw [w.2 i hi, v.2 i hi]
+    ring
+  have hz_boundary : ∃ i, z i = 0 := by
+    obtain ⟨i, hi⟩ := hsne
+    exact ⟨i, hz_face i hi⟩
+  exact ⟨⟨⟨z, ⟨hz_nonneg, hz_sum⟩⟩, hz_boundary⟩, hz_face⟩
+
+/-- The explicit contraction of the common face is continuous. -/
+public theorem continuous_standardBoundarySevenAffineFaceContractionPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous (standardBoundarySevenAffineFaceContractionPoint s hsne hs) := by
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply Continuous.subtype_mk
+  apply continuous_pi
+  intro k
+  change Continuous (fun q : unitInterval × standardBoundarySevenAffineFace s ↦
+    (1 - (q.1 : ℝ)) * q.2.1.1 k + (q.1 : ℝ) *
+      (standardBoundarySevenAffineFaceVertex s hsne hs).1.1 k)
+  have ct : Continuous (fun q : unitInterval × standardBoundarySevenAffineFace s ↦
+      (q.1 : ℝ)) := continuous_subtype_val.comp continuous_fst
+  have cw : Continuous (fun q : unitInterval × standardBoundarySevenAffineFace s ↦
+      q.2.1.1 k) :=
+    ((((continuous_apply k).comp continuous_subtype_val).comp
+      continuous_subtype_val).comp continuous_subtype_val).comp continuous_snd
+  exact (continuous_const.sub ct).mul cw |>.add (ct.mul continuous_const)
+
+@[simp]
+public theorem standardBoundarySevenAffineFaceContractionPoint_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenAffineFaceContractionPoint s hsne hs (0, w) = w := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (0 : ℝ)) * w.1.1 k + 0 *
+      (standardBoundarySevenAffineFaceVertex s hsne hs).1.1 k = w.1.1 k
+  ring
+
+@[simp]
+public theorem standardBoundarySevenAffineFaceContractionPoint_one
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (w : standardBoundarySevenAffineFace s) :
+    standardBoundarySevenAffineFaceContractionPoint s hsne hs (1, w) =
+      standardBoundarySevenAffineFaceVertex s hsne hs := by
+  apply Subtype.ext
+  apply Subtype.ext
+  apply stdSimplex.ext
+  funext k
+  change (1 - (1 : ℝ)) * w.1.1 k + 1 *
+      (standardBoundarySevenAffineFaceVertex s hsne hs).1.1 k = _
+  ring
+
+/-- The common affine face is contractible. -/
+public theorem standardBoundarySevenAffineFace_contractibleSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContractibleSpace (standardBoundarySevenAffineFace s) := by
+  rw [contractible_iff_id_nullhomotopic]
+  refine ⟨standardBoundarySevenAffineFaceVertex s hsne hs, ⟨?_⟩⟩
+  exact
+    { toFun := standardBoundarySevenAffineFaceContractionPoint s hsne hs
+      continuous_toFun := continuous_standardBoundarySevenAffineFaceContractionPoint s hsne hs
+      map_zero_left := standardBoundarySevenAffineFaceContractionPoint_zero s hsne hs
+      map_one_left := standardBoundarySevenAffineFaceContractionPoint_one s hsne hs }
+
+/-- Every nonempty proper standard affine neighbourhood intersection is contractible. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersection_contractibleSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContractibleSpace (standardBoundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace (standardBoundarySevenAffineFace s) :=
+    standardBoundarySevenAffineFace_contractibleSpace s hsne hs
+  exact (standardBoundarySevenAffineFaceIntersectionHomotopyEquiv
+    s hsne hs).symm.contractibleSpace
+
+/-- Hence every nonempty proper standard intersection is path connected. -/
+public theorem standardBoundarySevenFaceNeighborhoodIntersection_pathConnectedSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    PathConnectedSpace (standardBoundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace
+      (standardBoundarySevenFaceNeighborhoodIntersection s) :=
+    standardBoundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hs
+  infer_instance
+
+/-! ## Transport to the geometric realization -/
+
+/-- The common affine face inside the geometric realization. -/
+public def boundarySevenAffineFaceIntersection (s : Finset (Fin 8)) :
+    Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
+  {x | ∀ i ∈ s, boundarySevenComparisonToStdSimplex x i = 0}
+
+/-- The canonical barycentric homeomorphism restricted to an intersection of face
+neighbourhoods. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard
+    (s : Finset (Fin 8)) :
+    boundarySevenFaceNeighborhoodIntersection s ≃ₜ
+      standardBoundarySevenFaceNeighborhoodIntersection s :=
+  boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
+    rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+    change (∀ i ∈ s, boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8) ↔
+      ∀ i ∈ s,
+        (boundarySevenRealizationHomeomorphStandardBoundary x :
+          stdSimplex ℝ (Fin 8)) i < (1 : ℝ) / 8
+    rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+
+/-- The canonical barycentric homeomorphism restricted to the common affine face. -/
+public noncomputable def boundarySevenAffineFaceIntersectionHomeomorphStandard
+    (s : Finset (Fin 8)) :
+    boundarySevenAffineFaceIntersection s ≃ₜ standardBoundarySevenAffineFace s :=
+  boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
+    change (∀ i ∈ s, boundarySevenComparisonToStdSimplex x i = 0) ↔
+      ∀ i ∈ s,
+        (boundarySevenRealizationHomeomorphStandardBoundary x :
+          stdSimplex ℝ (Fin 8)) i = 0
+    rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
+
+/-- Every nonempty proper realized intersection is homotopy equivalent to its literal common
+affine face. -/
+public noncomputable def boundarySevenAffineFaceIntersectionHomotopyEquiv
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    boundarySevenAffineFaceIntersection s ≃ₕ
+      boundarySevenFaceNeighborhoodIntersection s :=
+  (boundarySevenAffineFaceIntersectionHomeomorphStandard s).toHomotopyEquiv |>.trans
+    (standardBoundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs) |>.trans
+      (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm.toHomotopyEquiv
+
+/-- The forward map of the transported equivalence is the literal inclusion of the common face
+in the neighbourhood intersection. -/
+public theorem boundarySevenAffineFaceIntersectionHomotopyEquiv_apply
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (x : boundarySevenAffineFaceIntersection s) :
+    (boundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs x).1 = x.1 := by
+  change (boundarySevenRealizationHomeomorphStandardBoundary).symm
+      (boundarySevenRealizationHomeomorphStandardBoundary x.1) = x.1
+  exact Homeomorph.symm_apply_apply _ _
+
+/-- Literal inclusion of the realized common affine face into the neighbourhood intersection. -/
+public noncomputable def boundarySevenAffineFaceIntersectionInclusion
+    (s : Finset (Fin 8)) :
+    C(boundarySevenAffineFaceIntersection s,
+      boundarySevenFaceNeighborhoodIntersection s) := by
+  refine ⟨fun x ↦ ⟨x.1, ?_⟩, continuous_subtype_val.subtype_mk _⟩
+  rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
+  intro i hi
+  rw [x.2 i hi]
+  norm_num
+
+/-- The inverse of the realized face/intersection homotopy equivalence is the simultaneous
+normalization retraction. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionRetraction
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    C(boundarySevenFaceNeighborhoodIntersection s,
+      boundarySevenAffineFaceIntersection s) :=
+  (boundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs).invFun
+
+/-- The forward map used in the realized equivalence is exactly the literal inclusion. -/
+public theorem boundarySevenAffineFaceIntersectionHomotopyEquiv_toFun
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    (boundarySevenAffineFaceIntersectionHomotopyEquiv s hsne hs).toFun =
+      boundarySevenAffineFaceIntersectionInclusion s := by
+  apply ContinuousMap.ext
+  intro x
+  apply Subtype.ext
+  exact boundarySevenAffineFaceIntersectionHomotopyEquiv_apply s hsne hs x
+
+/-- The realized simultaneous normalization is a strict left inverse to face inclusion. -/
+public theorem boundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs).comp
+        (boundarySevenAffineFaceIntersectionInclusion s) =
+      ContinuousMap.id _ := by
+  apply ContinuousMap.ext
+  intro x
+  change (boundarySevenAffineFaceIntersectionHomeomorphStandard s).symm
+      ((standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)
+        ((boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s)
+          (boundarySevenAffineFaceIntersectionInclusion s x))) = x
+  apply (boundarySevenAffineFaceIntersectionHomeomorphStandard s).injective
+  rw [Homeomorph.apply_symm_apply]
+  exact ContinuousMap.congr_fun
+    (standardBoundarySevenFaceNeighborhoodIntersectionRetraction_comp_inclusion
+      s hsne hs) ((boundarySevenAffineFaceIntersectionHomeomorphStandard s) x)
+
+/-- The affine homotopy transported explicitly to the geometric realization. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (q : unitInterval × boundarySevenFaceNeighborhoodIntersection s) :
+    boundarySevenFaceNeighborhoodIntersection s :=
+  (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+    (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+      (q.1, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s q.2))
+
+/-- The transported affine homotopy is continuous. -/
+public theorem continuous_boundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    Continuous (boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs) := by
+  exact (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm.continuous.comp
+    ((continuous_standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint
+      s hsne hs).comp
+        (continuous_fst.prodMk
+          ((boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).continuous.comp
+            continuous_snd)))
+
+@[simp]
+public theorem boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (x : boundarySevenFaceNeighborhoodIntersection s) :
+    boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (0, x) = x := by
+  change (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (0, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s x)) = x
+  rw [standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero,
+    Homeomorph.symm_apply_apply]
+
+@[simp]
+public theorem boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (x : boundarySevenFaceNeighborhoodIntersection s) :
+    boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs (1, x) =
+      boundarySevenAffineFaceIntersectionInclusion s
+        (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs x) := by
+  change (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (1, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s x)) =
+    boundarySevenAffineFaceIntersectionInclusion s
+      (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs x)
+  apply (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).injective
+  rw [Homeomorph.apply_symm_apply]
+  rw [standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one]
+  apply Subtype.ext
+  have hr := Homeomorph.apply_symm_apply
+    (boundarySevenAffineFaceIntersectionHomeomorphStandard s)
+    ((standardBoundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)
+      (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s x))
+  exact (congrArg Subtype.val hr).symm
+
+/-- The transported homotopy from the identity to inclusion after normalization. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomotopy
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContinuousMap.Homotopy (ContinuousMap.id _)
+      ((boundarySevenAffineFaceIntersectionInclusion s).comp
+        (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs)) where
+  toFun := boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  continuous_toFun :=
+    continuous_boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+  map_zero_left := boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_zero s hsne hs
+  map_one_left := boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_one s hsne hs
+
+/-- The transported deformation fixes the common affine face pointwise. -/
+public theorem boundarySevenFaceNeighborhoodIntersectionHomotopyPoint_fixed
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ)
+    (t : unitInterval) (x : boundarySevenAffineFaceIntersection s) :
+    boundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (t, boundarySevenAffineFaceIntersectionInclusion s x) =
+      boundarySevenAffineFaceIntersectionInclusion s x := by
+  change (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).symm
+      (standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+        (t, boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s
+          (boundarySevenAffineFaceIntersectionInclusion s x))) =
+    boundarySevenAffineFaceIntersectionInclusion s x
+  apply (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).injective
+  rw [Homeomorph.apply_symm_apply]
+  change standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint s hsne hs
+      (t, standardBoundarySevenAffineFaceInclusion s
+        (boundarySevenAffineFaceIntersectionHomeomorphStandard s x)) =
+    standardBoundarySevenAffineFaceInclusion s
+      (boundarySevenAffineFaceIntersectionHomeomorphStandard s x)
+  exact standardBoundarySevenFaceNeighborhoodIntersectionHomotopyPoint_fixed
+    s hsne hs t _
+
+/-- The reverse affine homotopy is the deformation from inclusion after simultaneous
+normalization to the identity on the realized intersection. -/
+public noncomputable def boundarySevenFaceNeighborhoodIntersectionDeformation
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContinuousMap.Homotopy
+      ((boundarySevenAffineFaceIntersectionInclusion s).comp
+        (boundarySevenFaceNeighborhoodIntersectionRetraction s hsne hs))
+      (ContinuousMap.id _) :=
+  (boundarySevenFaceNeighborhoodIntersectionHomotopy s hsne hs).symm
+
+/-- Every nonempty proper intersection of the actual face-neighbourhood cover is contractible. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_contractibleSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace
+      (standardBoundarySevenFaceNeighborhoodIntersection s) :=
+    standardBoundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hs
+  exact (boundarySevenFaceNeighborhoodIntersectionHomeomorphStandard s).contractibleSpace
+
+/-- Every nonempty proper intersection of the actual cover is path connected. -/
+public theorem boundarySevenFaceNeighborhoodIntersection_pathConnectedSpace
+    (s : Finset (Fin 8)) (hsne : s.Nonempty) (hs : s ≠ Finset.univ) :
+    PathConnectedSpace (boundarySevenFaceNeighborhoodIntersection s) := by
+  let _ : ContractibleSpace (boundarySevenFaceNeighborhoodIntersection s) :=
+    boundarySevenFaceNeighborhoodIntersection_contractibleSpace s hsne hs
+  infer_instance
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodLocalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodLocalComparison.lean
@@ -1,0 +1,80 @@
+module
+
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparison
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodDeformation
+
+/-!
+# The local simplicial--singular comparison on a boundary face
+
+The canonical adjunction unit on the standard six-simplex, followed by the singular-set map of
+the inclusion into its affine face neighbourhood, induces a quasi-isomorphism on integral
+chains.  The proof factors this exact canonical map into the standard-simplex comparison and the
+singular-chain map of the explicit face-neighbourhood homotopy equivalence.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical simplicial map from the standard six-simplex to singular simplices in its
+`i`-th affine face neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodLocalComparisonSSetMap
+    (i : Fin 8) :
+    (Δ[6] : SSet.{0}) ⟶
+      TopCat.toSSet.obj (TopCat.of (boundarySevenComparisonFaceNeighborhood i)) :=
+  sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+    TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i)
+
+/-- The exact canonical integral chain map on one standard face and its affine neighbourhood. -/
+public noncomputable def boundarySevenFaceNeighborhoodLocalIntegralComparison
+    (i : Fin 8) :
+    (Δ[6] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      IntegralSingularChainComplexObj
+        (TopCat.of (boundarySevenComparisonFaceNeighborhood i)) :=
+  SSet.chainComplexMap (boundarySevenFaceNeighborhoodLocalComparisonSSetMap i)
+    (AddCommGrpCat.of ℤ)
+
+/-- Functoriality identifies the canonical local comparison with the standard-simplex
+simplicial--singular comparison followed by the singular chain map of face inclusion. -/
+public theorem boundarySevenFaceNeighborhoodLocalIntegralComparison_eq
+    (i : Fin 8) :
+    boundarySevenFaceNeighborhoodLocalIntegralComparison i =
+      simplicialToRealizationSingularChainMap
+          (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ) ≫
+        boundarySevenFaceNeighborhoodIntegralSingularChainMap i := by
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+        (sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+          TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i)) =
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (sSetTopAdj.unit.app (Δ[6] : SSet.{0})) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i))
+  exact Functor.map_comp _ _ _
+
+/-- The canonical local integral comparison is a quasi-isomorphism. -/
+public theorem boundarySevenFaceNeighborhoodLocalIntegralComparison_quasiIso
+    (i : Fin 8) :
+    QuasiIso (boundarySevenFaceNeighborhoodLocalIntegralComparison i) := by
+  rw [boundarySevenFaceNeighborhoodLocalIntegralComparison_eq]
+  let hstandard : QuasiIso
+      (simplicialToRealizationSingularChainMap
+        (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ)) :=
+    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso 6
+  let hneighborhood : QuasiIso
+      (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) :=
+    boundarySevenFaceNeighborhoodIntegralSingularChainMap_quasiIso i
+  rw [quasiIso_iff]
+  intro k
+  exact quasiIsoAt_comp
+    (simplicialToRealizationSingularChainMap
+      (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) k
+    (hφ := hstandard.quasiIsoAt k)
+    (hφ' := hneighborhood.quasiIsoAt k)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenRealization.lean
+++ b/SphereSixComplex/Topology/BoundarySevenRealization.lean
@@ -1,0 +1,498 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits
+public import Mathlib.Analysis.Convex.GaugeRescale
+public import Mathlib.Analysis.Normed.Affine.AddTorsorBases
+
+/-!
+# The geometric realization of the boundary of the seven-simplex
+
+This file isolates the canonical map from `|∂Δ[7]|` to the ordinary topological seven-simplex
+and its compatibility with all eight codimension-one faces.  It also uses gauge rescaling to
+identify the ordinary affine boundary with the project's unit six-sphere.  Thus the only missing
+geometric-realization input is that realization of the simplicial subcomplex carries the expected
+subspace topology and underlying boundary points.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The ordinary boundary of a standard simplex: at least one barycentric coordinate vanishes. -/
+public abbrev StandardSimplexBoundary (n : ℕ) :=
+  {w : stdSimplex ℝ (Fin (n + 1)) // ∃ i, w i = 0}
+
+/-- The canonical map from realization of the simplicial boundary into the ordinary standard
+seven-simplex. -/
+public noncomputable def boundarySevenRealizationToStdSimplex :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
+  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι x),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
+      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
+
+/-- On each simplicial face, the canonical realization map is the usual affine face inclusion. -/
+public theorem boundarySevenRealizationToStdSimplex_face
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenRealizationToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
+  unfold boundarySevenRealizationToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
+  rw [← ConcreteCategory.comp_apply]
+  rw [← SSet.toTop.map_comp]
+  rw [SSet.boundary.ι_ι]
+  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
+
+/-- The ordinary affine inclusion of a codimension-one face lands in the topological boundary. -/
+public noncomputable def standardSimplexFaceToBoundary
+    (n : ℕ) (i : Fin (n + 2)) :
+    C(stdSimplex ℝ (Fin (n + 1)), StandardSimplexBoundary (n + 1)) := by
+  let f : C(stdSimplex ℝ (Fin (n + 1)), stdSimplex ℝ (Fin (n + 2))) :=
+    ⟨stdSimplex.map i.succAbove, stdSimplex.continuous_map i.succAbove⟩
+  refine ⟨fun w ↦ ⟨f w, ⟨i, ?_⟩⟩, f.continuous.subtype_mk _⟩
+  classical
+  change stdSimplex.map i.succAbove w i = 0
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  apply Finset.sum_eq_zero
+  intro j hj
+  exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+
+/-- The realization map restricted to every face agrees with the corresponding map to the
+ordinary topological boundary, after forgetting the boundary witness. -/
+public theorem boundarySevenRealizationToStdSimplex_face_eq_val
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenRealizationToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      (standardSimplexFaceToBoundary 6 i
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) :
+          stdSimplex ℝ (Fin 8)) := by
+  change boundarySevenRealizationToStdSimplex
+      (SSet.toTop.map (SSet.boundary.ι i) x) =
+    stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x)
+  exact boundarySevenRealizationToStdSimplex_face i x
+
+/-- A chosen affine basis with eight vertices in seven-dimensional Euclidean space. -/
+public noncomputable def boundarySevenAffineBasis :
+    AffineBasis (Fin 8) ℝ (EuclideanSpace ℝ (Fin 7)) :=
+  Classical.choice (AffineBasis.exists_affineBasis_of_finiteDimensional
+    (k := ℝ) (V := EuclideanSpace ℝ (Fin 7))
+    (P := EuclideanSpace ℝ (Fin 7)) (ι := Fin 8) (by simp))
+
+/-- The compact convex body spanned by the chosen affine basis. -/
+public def boundarySevenAffineBody : Set (EuclideanSpace ℝ (Fin 7)) :=
+  convexHull ℝ (Set.range boundarySevenAffineBasis)
+
+public theorem boundarySevenAffineBody_convex : Convex ℝ boundarySevenAffineBody :=
+  convex_convexHull ℝ _
+
+public theorem boundarySevenAffineBody_bounded : Bornology.IsBounded boundarySevenAffineBody := by
+  unfold boundarySevenAffineBody
+  rw [isBounded_convexHull]
+  exact (Set.finite_range boundarySevenAffineBasis).isBounded
+
+public theorem boundarySevenAffineBody_interior_nonempty :
+    (interior boundarySevenAffineBody).Nonempty := by
+  exact ⟨_, boundarySevenAffineBasis.centroid_mem_interior_convexHull⟩
+
+/-- Barycentric coordinates identify the standard seven-simplex with the convex hull of the
+chosen affine basis. -/
+public noncomputable def stdSimplexHomeomorphBoundarySevenAffineBody :
+    stdSimplex ℝ (Fin 8) ≃ₜ boundarySevenAffineBody where
+  toFun w := ⟨Finset.univ.affineCombination ℝ boundarySevenAffineBasis w,
+    affineCombination_mem_convexHull (fun i _ ↦ w.2.1 i) w.2.2⟩
+  invFun x := ⟨fun i ↦ boundarySevenAffineBasis.coord i x,
+    ⟨fun i ↦ by
+        have hx : x.1 ∈ convexHull ℝ (Set.range boundarySevenAffineBasis) := by
+          simpa only [boundarySevenAffineBody] using x.2
+        rw [boundarySevenAffineBasis.convexHull_eq_nonneg_coord] at hx
+        exact hx i,
+      boundarySevenAffineBasis.sum_coord_apply_eq_one x⟩⟩
+  left_inv w := by
+    apply Subtype.ext
+    ext i
+    exact boundarySevenAffineBasis.coord_apply_combination_of_mem
+      (Finset.mem_univ i) w.2.2
+  right_inv x := by
+    apply Subtype.ext
+    exact boundarySevenAffineBasis.affineCombination_coord_eq_self x
+  continuous_toFun := by
+    apply Continuous.subtype_mk
+    have h : Continuous (fun w : stdSimplex ℝ (Fin 8) ↦
+        ∑ i, w i • boundarySevenAffineBasis i) := by
+      apply continuous_finsetSum
+      intro i hi
+      exact ((continuous_apply i).comp continuous_subtype_val).smul continuous_const
+    exact h.congr fun w ↦
+      (Finset.univ.affineCombination_eq_linear_combination
+        boundarySevenAffineBasis w w.2.2).symm
+  continuous_invFun := by
+    have h : Continuous (fun x : boundarySevenAffineBody ↦
+        fun i ↦ boundarySevenAffineBasis.coord i x) := by
+      apply continuous_pi
+      intro i
+      exact (continuous_barycentric_coord boundarySevenAffineBasis i).comp
+        continuous_subtype_val
+    exact h.subtype_mk _
+
+/-- Gauge rescaling supplies an ambient homeomorphism carrying the affine-simplex frontier to the
+unit sphere in seven-dimensional Euclidean space. -/
+public noncomputable def boundarySevenAffineBodyGaugeHomeomorph :
+    EuclideanSpace ℝ (Fin 7) ≃ₜ EuclideanSpace ℝ (Fin 7) :=
+  Classical.choose (exists_homeomorph_image_interior_closure_frontier_eq_unitBall
+    boundarySevenAffineBody_convex boundarySevenAffineBody_interior_nonempty
+      boundarySevenAffineBody_bounded)
+
+public theorem boundarySevenAffineBodyGaugeHomeomorph_frontier :
+    boundarySevenAffineBodyGaugeHomeomorph '' frontier boundarySevenAffineBody =
+      Metric.sphere (0 : EuclideanSpace ℝ (Fin 7)) 1 :=
+  (Classical.choose_spec (exists_homeomorph_image_interior_closure_frontier_eq_unitBall
+    boundarySevenAffineBody_convex boundarySevenAffineBody_interior_nonempty
+      boundarySevenAffineBody_bounded)).2.2
+
+public theorem boundarySevenAffineBody_closed : IsClosed boundarySevenAffineBody := by
+  unfold boundarySevenAffineBody
+  exact ((Set.finite_range boundarySevenAffineBasis).isCompact_convexHull ℝ).isClosed
+
+/-- Under barycentric coordinates, belonging to the frontier is exactly the vanishing of at least
+one standard-simplex coordinate. -/
+public theorem stdSimplexHomeomorphBoundarySevenAffineBody_mem_frontier_iff
+    (w : stdSimplex ℝ (Fin 8)) :
+    (stdSimplexHomeomorphBoundarySevenAffineBody w :
+        EuclideanSpace ℝ (Fin 7)) ∈
+        frontier boundarySevenAffineBody ↔
+      ∃ i, w i = 0 := by
+  classical
+  have hcoord (i : Fin 8) :
+      boundarySevenAffineBasis.coord i
+          (stdSimplexHomeomorphBoundarySevenAffineBody w) = w i :=
+    boundarySevenAffineBasis.coord_apply_combination_of_mem
+      (Finset.mem_univ i) w.2.2
+  have hinter :
+      (stdSimplexHomeomorphBoundarySevenAffineBody w :
+          EuclideanSpace ℝ (Fin 7)) ∈
+          interior boundarySevenAffineBody ↔
+        ∀ i, 0 < w i := by
+    have hset : interior boundarySevenAffineBody =
+        {x | ∀ i, 0 < boundarySevenAffineBasis.coord i x} := by
+      simpa only [boundarySevenAffineBody] using
+        boundarySevenAffineBasis.interior_convexHull
+    rw [hset]
+    constructor
+    · intro h i
+      exact (hcoord i) ▸ h i
+    · intro h i
+      exact (hcoord i).symm ▸ h i
+  rw [boundarySevenAffineBody_closed.frontier_eq]
+  simp only [Set.mem_sdiff, (stdSimplexHomeomorphBoundarySevenAffineBody w).2,
+    true_and, hinter]
+  constructor
+  · rw [not_forall]
+    rintro ⟨i, hi⟩
+    exact ⟨i, le_antisymm (le_of_not_gt hi) (w.2.1 i)⟩
+  · rintro ⟨i, hi⟩ hall
+    exact (ne_of_gt (hall i)) hi
+
+/-- Flatten the frontier regarded as a subspace of the affine body to the same frontier regarded
+as a subspace of the ambient Euclidean space. -/
+public noncomputable def boundarySevenFrontierInBodyHomeomorphFrontier :
+    {y : boundarySevenAffineBody //
+      (y : EuclideanSpace ℝ (Fin 7)) ∈ frontier boundarySevenAffineBody} ≃ₜ
+      frontier boundarySevenAffineBody where
+  toFun y := ⟨y.1.1, y.2⟩
+  invFun x := ⟨⟨x.1, by
+      simpa only [boundarySevenAffineBody_closed.closure_eq] using
+        (frontier_subset_closure x.2)⟩, x.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  continuous_toFun :=
+    (continuous_subtype_val.comp continuous_subtype_val).subtype_mk _
+  continuous_invFun := by
+    apply Continuous.subtype_mk
+    exact continuous_subtype_val.subtype_mk fun x ↦ by
+      simpa only [boundarySevenAffineBody_closed.closure_eq] using
+        (frontier_subset_closure x.2)
+
+/-- The ordinary barycentric boundary of the standard seven-simplex is homeomorphic to the
+frontier of a full-dimensional affine simplex in seven-dimensional Euclidean space. -/
+public noncomputable def standardSimplexBoundarySevenHomeomorphAffineFrontier :
+    StandardSimplexBoundary 7 ≃ₜ frontier boundarySevenAffineBody := by
+  let e : StandardSimplexBoundary 7 ≃ₜ
+      {y : boundarySevenAffineBody //
+        (y : EuclideanSpace ℝ (Fin 7)) ∈ frontier boundarySevenAffineBody} :=
+    stdSimplexHomeomorphBoundarySevenAffineBody.subtype
+      (p := fun w : stdSimplex ℝ (Fin 8) ↦ ∃ i, w i = 0)
+      (q := fun y : boundarySevenAffineBody ↦
+        (y : EuclideanSpace ℝ (Fin 7)) ∈
+        frontier boundarySevenAffineBody)
+      (fun w ↦ (stdSimplexHomeomorphBoundarySevenAffineBody_mem_frontier_iff w).symm)
+  exact e.trans boundarySevenFrontierInBodyHomeomorphFrontier
+
+/-- Gauge rescaling restricts to a homeomorphism from the affine-simplex frontier to the unit
+six-sphere. -/
+public noncomputable def boundarySevenAffineFrontierHomeomorphSixSphere :
+    frontier boundarySevenAffineBody ≃ₜ SixSphere :=
+  boundarySevenAffineBodyGaugeHomeomorph.subtype fun x ↦ by
+    constructor
+    · intro hx
+      rw [← boundarySevenAffineBodyGaugeHomeomorph_frontier]
+      exact ⟨x, hx, rfl⟩
+    · intro hx
+      rw [← boundarySevenAffineBodyGaugeHomeomorph_frontier] at hx
+      obtain ⟨y, hy, heq⟩ := hx
+      have hxy : y = x := boundarySevenAffineBodyGaugeHomeomorph.injective heq
+      simpa [hxy] using hy
+
+/-- The ordinary topological boundary of the seven-simplex is the project's standard unit
+six-sphere. -/
+public noncomputable def standardSimplexBoundarySevenHomeomorphSixSphere :
+    StandardSimplexBoundary 7 ≃ₜ SixSphere :=
+  standardSimplexBoundarySevenHomeomorphAffineFrontier.trans
+    boundarySevenAffineFrontierHomeomorphSixSphere
+
+/-! ## The exact realization/subspace gap -/
+
+/-- The boundary is categorically the multicoequalizer of its eight faces and their pairwise
+intersections. -/
+public theorem boundarySevenFaceMulticoequalizerDiagram :
+    SSet.Subcomplex.MulticoequalizerDiagram (SSet.boundary 7)
+      (fun i : Fin 8 ↦ SSet.stdSimplex.face {i}ᶜ)
+      (fun i j : Fin 8 ↦ SSet.stdSimplex.face {i}ᶜ ⊓
+        SSet.stdSimplex.face {j}ᶜ) where
+  iSup_eq := (SSet.boundary_eq_iSup 7).symm
+  eq_inf _ _ := rfl
+
+/-- Since geometric realization is a left adjoint, realization of the boundary is the same
+multicoequalizer of realized faces. -/
+public noncomputable def boundarySevenRealizationIsColimitOfFaces :
+    IsColimit
+      (SSet.toTop.mapCocone
+        (boundarySevenFaceMulticoequalizerDiagram.multicofork.map
+          SSet.Subcomplex.toSSetFunctor)) :=
+  isColimitOfPreserves SSet.toTop
+    boundarySevenFaceMulticoequalizerDiagram.isColimit
+
+/-- Every point of the realized boundary is represented by a point of one of its eight
+codimension-one simplicial faces.  This is the point-set surjectivity part of the realized
+multicoequalizer, extracted after forgetting the topology. -/
+public theorem boundarySevenRealization_faceCovered
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    ∃ (i : Fin 8)
+      (y : (SSet.toTop.obj
+        (SSet.stdSimplex.face {i}ᶜ : SSet.Subcomplex (Δ[7] : SSet.{0})) : Type)),
+      SSet.toTop.map (SSet.boundary.faceι i) y = x := by
+  have h := isColimitOfPreserves (forget TopCat)
+    boundarySevenRealizationIsColimitOfFaces
+  obtain ⟨j, y, hy⟩ := Types.jointly_surjective_of_isColimit h x
+  rcases j with l | i
+  · let f := WalkingMultispan.Hom.fst
+      (J := MultispanShape.prod (Fin 8)) l
+    let y' := (((boundarySevenFaceMulticoequalizerDiagram.multispanIndex.map
+      SSet.Subcomplex.toSSetFunctor).multispan ⋙ SSet.toTop) ⋙
+        forget TopCat).map f y
+    refine ⟨l.1, y', ?_⟩
+    have hw := ((forget TopCat).mapCocone
+      (SSet.toTop.mapCocone
+        (boundarySevenFaceMulticoequalizerDiagram.multicofork.map
+          SSet.Subcomplex.toSSetFunctor))).w f
+    exact (ConcreteCategory.congr_hom hw y).trans hy
+  · exact ⟨i, y, hy⟩
+
+/-- Equivalently, every realized boundary point comes from an ordinary standard six-simplex via
+one of the eight standard boundary maps. -/
+public theorem boundarySevenRealization_standardFaceCovered
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    ∃ (i : Fin 8) (y : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)),
+      SSet.toTop.map (SSet.boundary.ι i) y = x := by
+  obtain ⟨i, y, hy⟩ := boundarySevenRealization_faceCovered x
+  refine ⟨i, SSet.toTop.map (SSet.stdSimplex.faceSingletonComplIso i).inv y, ?_⟩
+  rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,
+    SSet.boundary.faceSingletonComplIso_inv_ι]
+  exact hy
+
+public theorem boundarySevenRealizationToStdSimplex_mem_boundary
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    ∃ i, boundarySevenRealizationToStdSimplex x i = 0 := by
+  obtain ⟨i, y, rfl⟩ := boundarySevenRealization_standardFaceCovered x
+  rw [boundarySevenRealizationToStdSimplex_face_eq_val]
+  exact (standardSimplexFaceToBoundary 6 i
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)).2
+
+/-- The canonical realization map, now lifted to the ordinary zero-coordinate boundary.  The
+landing condition follows from the face cover, so it requires no choice of a preferred face. -/
+public noncomputable def boundarySevenRealizationToBoundary :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), StandardSimplexBoundary 7) :=
+  ⟨fun x ↦ ⟨boundarySevenRealizationToStdSimplex x,
+      boundarySevenRealizationToStdSimplex_mem_boundary x⟩,
+    boundarySevenRealizationToStdSimplex.continuous.subtype_mk _⟩
+
+@[simp]
+public theorem boundarySevenRealizationToBoundary_val
+    (x : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) :
+    (boundarySevenRealizationToBoundary x : stdSimplex ℝ (Fin 8)) =
+      boundarySevenRealizationToStdSimplex x := rfl
+
+/-- Every point of the ordinary barycentric boundary belongs to one of the standard affine
+faces. -/
+public theorem standardSimplexBoundarySeven_standardFaceCovered
+    (w : StandardSimplexBoundary 7) :
+    ∃ (i : Fin 8) (z : stdSimplex ℝ (Fin 7)),
+      stdSimplex.map i.succAbove z = w.1 := by
+  classical
+  obtain ⟨i, hi⟩ := w.2
+  let z : stdSimplex ℝ (Fin 7) := ⟨fun j ↦ w.1 (i.succAbove j),
+    ⟨fun j ↦ w.1.2.1 (i.succAbove j), by
+      have hsum := w.1.2.2
+      change ∑ k, w.1 k = 1 at hsum
+      rw [Fin.sum_univ_succAbove (fun k ↦ w.1 k) i, hi, zero_add] at hsum
+      exact hsum⟩⟩
+  refine ⟨i, z, ?_⟩
+  apply stdSimplex.ext
+  funext k
+  obtain rfl | ⟨j, rfl⟩ := Fin.eq_self_or_eq_succAbove i k
+  · simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_zero]
+    · exact hi.symm
+    · intro j hj
+      exact (Fin.succAbove_ne k j (Finset.mem_filter.mp hj).2).elim
+  · simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_single j]
+    · rfl
+    · intro b hb hbj
+      exact (hbj (Fin.succAbove_right_inj.mp (Finset.mem_filter.mp hb).2)).elim
+    · simp
+
+/-- The canonical map from the realized simplicial boundary onto the ordinary barycentric
+boundary is surjective. -/
+public theorem boundarySevenRealizationToBoundary_surjective :
+    Function.Surjective boundarySevenRealizationToBoundary := by
+  intro w
+  obtain ⟨i, z, hz⟩ := standardSimplexBoundarySeven_standardFaceCovered w
+  let y := (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm z
+  refine ⟨SSet.toTop.map (SSet.boundary.ι i) y, ?_⟩
+  apply Subtype.ext
+  rw [boundarySevenRealizationToBoundary_val,
+    boundarySevenRealizationToStdSimplex_face]
+  change stdSimplex.map i.succAbove
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y) = w.1
+  rw [Homeomorph.apply_symm_apply]
+  exact hz
+
+/-- The realized simplicial boundary is compact: it is a finite union of the continuous images of
+the eight compact realized standard six-simplices. -/
+public theorem boundarySevenRealization_isCompact_univ :
+    IsCompact (Set.univ : Set (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type)) := by
+  have hsource : IsCompact
+      (Set.univ : Set (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) := by
+    simpa only [Set.image_univ,
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm.surjective.range_eq]
+      using (isCompact_univ.image
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm.continuous)
+  have hface (i : Fin 8) : IsCompact
+      (Set.range fun y : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ↦
+        SSet.toTop.map (SSet.boundary.ι i) y) :=
+    by simpa only [Set.image_univ] using
+      hsource.image (SSet.toTop.map (SSet.boundary.ι i)).hom.continuous
+  have hcover : (⋃ i : Fin 8, Set.range fun y :
+      (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type) ↦
+        SSet.toTop.map (SSet.boundary.ι i) y) = Set.univ := by
+    apply Set.eq_univ_of_forall
+    intro x
+    obtain ⟨i, y, hy⟩ := boundarySevenRealization_standardFaceCovered x
+    exact Set.mem_iUnion.2 ⟨i, ⟨y, hy⟩⟩
+  rw [← hcover]
+  exact isCompact_iUnion hface
+
+/-- Injectivity is the only remaining point-set condition needed to turn the canonical continuous
+surjection into a homeomorphism. -/
+public noncomputable def boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+    (hinj : Function.Injective boundarySevenRealizationToBoundary) :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ StandardSimplexBoundary 7 := by
+  letI : CompactSpace (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) :=
+    isCompact_univ_iff.mp boundarySevenRealization_isCompact_univ
+  exact (Equiv.ofBijective boundarySevenRealizationToBoundary
+    ⟨hinj, boundarySevenRealizationToBoundary_surjective⟩).toHomeomorphOfContinuousClosed
+      boundarySevenRealizationToBoundary.continuous
+      boundarySevenRealizationToBoundary.continuous.isClosedMap
+
+/-- The one missing topological realization theorem: the canonical map identifies realization of
+the simplicial boundary with the ordinary zero-coordinate boundary, not merely face by face. -/
+public def BoundarySevenRealizationIdentifiesStandardSimplexBoundary : Prop :=
+  ∃ e : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ StandardSimplexBoundary 7,
+    ∀ x, (e x : stdSimplex ℝ (Fin 8)) = boundarySevenRealizationToStdSimplex x
+
+/-- The exact remaining content of the realization/subspace comparison is injectivity of the
+canonical map.  Surjectivity, continuity, compactness of the source, and Hausdorffness of the
+target have all been proved above. -/
+public theorem boundarySevenRealizationIdentifiesStandardSimplexBoundary_iff_injective :
+    BoundarySevenRealizationIdentifiesStandardSimplexBoundary ↔
+      Function.Injective boundarySevenRealizationToBoundary := by
+  constructor
+  · rintro ⟨e, he⟩ x y hxy
+    apply e.injective
+    apply Subtype.ext
+    rw [he x, he y]
+    exact congr_arg Subtype.val hxy
+  · intro hinj
+    refine ⟨boundarySevenRealizationHomeomorphStandardBoundary_of_injective hinj, ?_⟩
+    intro x
+    rfl
+
+/-- Equivalently, the remaining injectivity assertion says that geometric realization sends the
+monomorphism from the simplicial boundary into the representable seven-simplex to an injective
+continuous map. -/
+public theorem boundarySevenRealizationToBoundary_injective_iff_realizedInclusion :
+    Function.Injective boundarySevenRealizationToBoundary ↔
+      Function.Injective (SSet.toTop.map
+        (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι) := by
+  constructor
+  · intro h x y hxy
+    apply h
+    apply Subtype.ext
+    rw [boundarySevenRealizationToBoundary_val,
+      boundarySevenRealizationToBoundary_val]
+    exact congr_arg (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)) hxy
+  · intro h x y hxy
+    apply h
+    apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).injective
+    change boundarySevenRealizationToStdSimplex x =
+      boundarySevenRealizationToStdSimplex y
+    exact congr_arg Subtype.val hxy
+
+/-- Once the realization functor's face-colimit is identified with the ordinary closed face
+cover, the desired realization/sphere homeomorphism follows from the concrete affine geometry
+proved above. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere_of_identifiesBoundary
+    (h : BoundarySevenRealizationIdentifiesStandardSimplexBoundary) :
+    BoundarySevenRealizationHomeomorphSixSphere := by
+  obtain ⟨e, he⟩ := h
+  exact ⟨e.trans standardSimplexBoundarySevenHomeomorphSixSphere⟩
+
+/-- A final reduction of the desired homeomorphism to the sole missing face-gluing statement:
+different face representatives with the same ordinary barycentric point represent the same point
+of geometric realization. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere_of_injective
+    (hinj : Function.Injective boundarySevenRealizationToBoundary) :
+    BoundarySevenRealizationHomeomorphSixSphere :=
+  boundarySevenRealizationHomeomorphSixSphere_of_identifiesBoundary
+    (boundarySevenRealizationIdentifiesStandardSimplexBoundary_iff_injective.mpr hinj)
+
+/-- Therefore it is enough to supply the currently absent theorem that realization preserves
+injectivity for this simplicial subcomplex inclusion. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere_of_realizedInclusion_injective
+    (hinj : Function.Injective (SSet.toTop.map
+      (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι)) :
+    BoundarySevenRealizationHomeomorphSixSphere :=
+  boundarySevenRealizationHomeomorphSixSphere_of_injective
+    (boundarySevenRealizationToBoundary_injective_iff_realizedInclusion.mpr hinj)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenRealizationInjective.lean
+++ b/SphereSixComplex/Topology/BoundarySevenRealizationInjective.lean
@@ -1,0 +1,253 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenRealization
+
+/-!
+# Injectivity of the realized boundary inclusion
+
+This file proves the remaining point-set assertion face by face.  Two points of the realized
+boundary are represented by codimension-one faces.  If their ordinary barycentric coordinates
+agree, either the faces coincide or both representatives factor through their common
+codimension-two face.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Set Simplicial
+
+namespace SphereSixComplex
+
+public theorem stdSimplex_map_apply_of_injective
+    {m n : ℕ} (f : Fin m → Fin n) (hf : Function.Injective f)
+    (w : stdSimplex ℝ (Fin m)) (i : Fin m) :
+    stdSimplex.map f w (f i) = w i := by
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply, hf.eq_iff]
+  rw [Finset.sum_eq_single i]
+  · simp
+  · simp
+
+public theorem stdSimplex_map_injective
+    {m n : ℕ} (f : Fin m → Fin n) (hf : Function.Injective f) :
+    Function.Injective (stdSimplex.map (S := ℝ) f) := by
+  intro x y h
+  apply stdSimplex.ext
+  funext i
+  have hi := congrArg (fun w : stdSimplex ℝ (Fin n) ↦ w (f i)) h
+  simpa only [stdSimplex_map_apply_of_injective f hf] using hi
+
+public theorem stdSimplex_map_succAbove_apply_self
+    {n : ℕ} (i : Fin (n + 2)) (w : stdSimplex ℝ (Fin (n + 1))) :
+    stdSimplex.map i.succAbove w i = 0 := by
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  apply Finset.sum_eq_zero
+  intro j hj
+  exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+
+/-- Removing a zero coordinate gives the unique point of the corresponding affine face. -/
+public noncomputable def stdSimplexDeleteZeroCoordinate
+    {n : ℕ} (i : Fin (n + 2)) (w : stdSimplex ℝ (Fin (n + 2)))
+    (hi : w i = 0) : stdSimplex ℝ (Fin (n + 1)) :=
+  ⟨fun j ↦ w (i.succAbove j),
+    ⟨fun j ↦ w.2.1 _, by
+      have hsum := w.2.2
+      change (∑ k : Fin (n + 2), w k) = 1 at hsum
+      change (∑ j : Fin (n + 1), w (i.succAbove j)) = 1
+      rw [Fin.sum_univ_succAbove (fun k ↦ w k) i, hi, zero_add] at hsum
+      exact hsum⟩⟩
+
+public theorem stdSimplex_map_deleteZeroCoordinate
+    {n : ℕ} (i : Fin (n + 2)) (w : stdSimplex ℝ (Fin (n + 2)))
+    (hi : w i = 0) :
+    stdSimplex.map i.succAbove (stdSimplexDeleteZeroCoordinate i w hi) = w := by
+  apply stdSimplex.ext
+  funext k
+  obtain rfl | ⟨j, rfl⟩ := Fin.eq_self_or_eq_succAbove i k
+  · simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_zero]
+    · exact hi.symm
+    · intro j hj
+      exact (Fin.succAbove_ne k j (Finset.mem_filter.mp hj).2).elim
+  · exact stdSimplex_map_apply_of_injective i.succAbove
+      Fin.succAbove_right_injective _ j
+
+/-- Each individual realized face embeds in the realized boundary. -/
+public theorem boundarySevenRealizedFace_injective (i : Fin 8) :
+    Function.Injective (SSet.toTop.map (SSet.boundary.ι.{0} i)) := by
+  intro x y h
+  apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+  apply stdSimplex_map_injective i.succAbove Fin.succAbove_right_injective
+  simpa only [boundarySevenRealizationToStdSimplex_face] using
+    congrArg (fun z : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ↦
+      boundarySevenRealizationToStdSimplex z) h
+
+/-- The two standard parametrizations of a codimension-two face use the same ordered embedding
+of its six vertices. -/
+public theorem finPairFaceEmbedding_eq
+    (i j : Fin 8) (hij : i < j) :
+    (fun k : Fin 6 ↦
+        i.succAbove ((j.pred (Fin.ne_zero_of_lt hij)).succAbove k)) =
+      (fun k : Fin 6 ↦
+        j.succAbove ((i.castPred (Fin.ne_last_of_lt hij)).succAbove k)) := by
+  funext k
+  let ki := j.pred (Fin.ne_zero_of_lt hij)
+  let kj := i.castPred (Fin.ne_last_of_lt hij)
+  have hkj : Fin.castSucc kj < j := by
+    simpa [kj] using hij
+  have hcat : SimplexCategory.δ kj ≫ SimplexCategory.δ j =
+      SimplexCategory.δ ki ≫ SimplexCategory.δ i := by
+    simpa [ki, kj] using SimplexCategory.δ_comp_δ' hkj
+  exact congrArg (fun f : SimplexCategory.mk 5 ⟶ SimplexCategory.mk 7 ↦
+    f.toOrderHom k) hcat.symm
+
+/-- Representatives lying in two different facets with the same barycentric point are identified
+through their common codimension-two simplicial face. -/
+public theorem boundarySevenRealizedFaces_eq_of_lt
+    (i j : Fin 8) (hij : i < j)
+    (x y : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type))
+    (hxy : stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) =
+      stdSimplex.map j.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)) :
+    SSet.toTop.map (SSet.boundary.ι.{0} i) x =
+      SSet.toTop.map (SSet.boundary.ι.{0} j) y := by
+  let xi := SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x
+  let yj := SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y
+  let ki : Fin 7 := j.pred (Fin.ne_zero_of_lt hij)
+  let kj : Fin 7 := i.castPred (Fin.ne_last_of_lt hij)
+  have hiki : i.succAbove ki = j := by
+    exact Fin.succAbove_pred_of_lt i j hij
+  have hjkj : j.succAbove kj = i := by
+    exact Fin.succAbove_castPred_of_lt j i hij
+  have hxi : xi ki = 0 := by
+    calc
+      xi ki = stdSimplex.map i.succAbove xi (i.succAbove ki) :=
+        (stdSimplex_map_apply_of_injective i.succAbove
+          Fin.succAbove_right_injective xi ki).symm
+      _ = stdSimplex.map j.succAbove yj (i.succAbove ki) :=
+        congrArg (fun w : stdSimplex ℝ (Fin 8) ↦ w (i.succAbove ki)) hxy
+      _ = stdSimplex.map j.succAbove yj j := by rw [hiki]
+      _ = 0 := stdSimplex_map_succAbove_apply_self j yj
+  have hyj : yj kj = 0 := by
+    calc
+      yj kj = stdSimplex.map j.succAbove yj (j.succAbove kj) :=
+        (stdSimplex_map_apply_of_injective j.succAbove
+          Fin.succAbove_right_injective yj kj).symm
+      _ = stdSimplex.map i.succAbove xi (j.succAbove kj) :=
+        congrArg (fun w : stdSimplex ℝ (Fin 8) ↦ w (j.succAbove kj)) hxy.symm
+      _ = stdSimplex.map i.succAbove xi i := by rw [hjkj]
+      _ = 0 := stdSimplex_map_succAbove_apply_self i xi
+  let zx := stdSimplexDeleteZeroCoordinate ki xi hxi
+  let zy := stdSimplexDeleteZeroCoordinate kj yj hyj
+  have hz : zx = zy := by
+    apply stdSimplex_map_injective
+      (fun k : Fin 6 ↦ i.succAbove (ki.succAbove k))
+      (Fin.succAbove_right_injective.comp Fin.succAbove_right_injective)
+    calc
+      stdSimplex.map (fun k : Fin 6 ↦ i.succAbove (ki.succAbove k)) zx =
+          stdSimplex.map i.succAbove (stdSimplex.map ki.succAbove zx) := by
+            exact (stdSimplex.map_comp_apply ki.succAbove i.succAbove zx).symm
+      _ = stdSimplex.map i.succAbove xi := by
+        rw [stdSimplex_map_deleteZeroCoordinate]
+      _ = stdSimplex.map j.succAbove yj := hxy
+      _ = stdSimplex.map j.succAbove (stdSimplex.map kj.succAbove zy) := by
+        rw [stdSimplex_map_deleteZeroCoordinate]
+      _ = stdSimplex.map (fun k : Fin 6 ↦ j.succAbove (kj.succAbove k)) zy := by
+        exact stdSimplex.map_comp_apply kj.succAbove j.succAbove zy
+      _ = stdSimplex.map (fun k : Fin 6 ↦ i.succAbove (ki.succAbove k)) zy := by
+        rw [finPairFaceEmbedding_eq i j hij]
+  let z : (SSet.toTop.obj (Δ[5] : SSet.{0}) : Type) :=
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 5)).symm zx
+  have hx : SSet.toTop.map (SSet.stdSimplex.δ ki) z = x := by
+    apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+    calc
+      SimplexCategory.toTopHomeo (SimplexCategory.mk 6)
+          (SSet.toTop.map (SSet.stdSimplex.δ ki) z) =
+          stdSimplex.map ki.succAbove
+            (SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z) :=
+        SimplexCategory.toTopHomeo_naturality_apply
+          (SimplexCategory.δ ki) z
+      _ = stdSimplex.map ki.succAbove zx := by
+        rw [show SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z = zx by
+          simp [z]]
+      _ = xi := stdSimplex_map_deleteZeroCoordinate ki xi hxi
+      _ = SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x := rfl
+  have hy : SSet.toTop.map (SSet.stdSimplex.δ kj) z = y := by
+    apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+    calc
+      SimplexCategory.toTopHomeo (SimplexCategory.mk 6)
+          (SSet.toTop.map (SSet.stdSimplex.δ kj) z) =
+          stdSimplex.map kj.succAbove
+            (SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z) :=
+        SimplexCategory.toTopHomeo_naturality_apply
+          (SimplexCategory.δ kj) z
+      _ = stdSimplex.map kj.succAbove zx := by
+        rw [show SimplexCategory.toTopHomeo (SimplexCategory.mk 5) z = zx by
+          simp [z]]
+      _ = stdSimplex.map kj.succAbove zy := by rw [hz]
+      _ = yj := stdSimplex_map_deleteZeroCoordinate kj yj hyj
+      _ = SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y := rfl
+  have hfaces : SSet.stdSimplex.δ ki ≫ SSet.boundary.ι.{0} i =
+      SSet.stdSimplex.δ kj ≫ SSet.boundary.ι.{0} j := by
+    rw [← cancel_mono (SSet.boundary 7).ι]
+    simp only [Category.assoc, SSet.boundary.ι_ι]
+    let hpair := SSet.stdSimplex.facePairComplIso_hom_ι
+      (n := 5) i j hij
+    let hpair' := SSet.stdSimplex.facePairComplIso_hom_ι'
+      (n := 5) i j hij
+    simpa [ki, kj] using hpair'.symm.trans hpair
+  rw [← hx, ← hy]
+  change (SSet.toTop.map (SSet.stdSimplex.δ ki) ≫
+      SSet.toTop.map (SSet.boundary.ι.{0} i)) z =
+    (SSet.toTop.map (SSet.stdSimplex.δ kj) ≫
+      SSet.toTop.map (SSet.boundary.ι.{0} j)) z
+  rw [← Functor.map_comp, ← Functor.map_comp, hfaces]
+
+/-- The canonical map from realization of the simplicial boundary to the ordinary barycentric
+boundary is injective.  Equal barycentric points either lie in the same standard facet or factor
+through the common codimension-two face of two distinct facets. -/
+public theorem boundarySevenRealizationToBoundary_injective :
+    Function.Injective boundarySevenRealizationToBoundary := by
+  intro x y hxy
+  obtain ⟨i, xi, hxi⟩ := boundarySevenRealization_standardFaceCovered x
+  obtain ⟨j, yj, hyj⟩ := boundarySevenRealization_standardFaceCovered y
+  rw [← hxi, ← hyj]
+  have hcoord : stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) xi) =
+      stdSimplex.map j.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) yj) := by
+    have hv := congrArg Subtype.val hxy
+    rw [← hxi, ← hyj] at hv
+    simpa only [boundarySevenRealizationToBoundary_val,
+      boundarySevenRealizationToStdSimplex_face] using hv
+  rcases lt_trichotomy i j with hij | hij | hij
+  · exact boundarySevenRealizedFaces_eq_of_lt i j hij xi yj hcoord
+  · subst j
+    have hface : xi = yj := by
+      apply (SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).injective
+      apply stdSimplex_map_injective i.succAbove Fin.succAbove_right_injective
+      exact hcoord
+    subst yj
+    rfl
+  · exact (boundarySevenRealizedFaces_eq_of_lt j i hij yj xi hcoord.symm).symm
+
+/-- The geometric realization of the boundary of the seven-simplex is homeomorphic to the
+project's standard six-sphere. -/
+public theorem boundarySevenRealizationHomeomorphSixSphere :
+    BoundarySevenRealizationHomeomorphSixSphere :=
+  boundarySevenRealizationHomeomorphSixSphere_of_injective
+    boundarySevenRealizationToBoundary_injective
+
+/-- Consequently the boundary comparison package now requires only the chain-level
+simplicial-to-singular quasi-isomorphism. -/
+public theorem boundarySevenComparisonInputs_of_quasiIsomorphism
+    (R : AddCommGrpCat)
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) R) :
+    BoundarySevenComparisonInputs R :=
+  ⟨hcomparison, boundarySevenRealizationHomeomorphSixSphere⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/ContractibleSingularMapQuasiIso.lean
+++ b/SphereSixComplex/Topology/ContractibleSingularMapQuasiIso.lean
@@ -1,0 +1,98 @@
+module
+
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparisonGeneral
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Singular chains of maps between contractible spaces
+
+Every specified continuous map between two contractible spaces is itself a homotopy equivalence.
+Consequently its singular-chain map is a quasi-isomorphism, with arbitrary coefficients.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+variable {X Y : Type}
+variable [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- Replacing the forward map of a homotopy equivalence by a homotopic map preserves the bundled
+homotopy equivalence. -/
+public noncomputable def homotopyEquivOfHomotopicTo
+    (f : C(X, Y)) (e : X ≃ₕ Y) (h : f.Homotopic e.toFun) : X ≃ₕ Y where
+  toFun := f
+  invFun := e.invFun
+  left_inv := (ContinuousMap.Homotopic.comp (.refl e.invFun) h).trans e.left_inv
+  right_inv := (ContinuousMap.Homotopic.comp h (.refl e.invFun)).trans e.right_inv
+
+/-- Any specified continuous map between contractible spaces carries a homotopy equivalence. -/
+public noncomputable def homotopyEquivOfMapBetweenContractibleSpaces
+    [ContractibleSpace X] [ContractibleSpace Y] (f : C(X, Y)) : X ≃ₕ Y := by
+  let e := Classical.choice (ContractibleSpace.hequiv X Y)
+  let hnull := id_nullhomotopic Y
+  let y := Classical.choose hnull
+  let hy := Classical.choose_spec hnull
+  have hf : f.Homotopic (ContinuousMap.const X y) := by
+    simpa only [ContinuousMap.id_comp, ContinuousMap.const_comp] using
+      ContinuousMap.Homotopic.comp hy (.refl f)
+  have he : e.toFun.Homotopic (ContinuousMap.const X y) := by
+    simpa only [ContinuousMap.id_comp, ContinuousMap.const_comp] using
+      ContinuousMap.Homotopic.comp hy (.refl e.toFun)
+  exact homotopyEquivOfHomotopicTo f e (hf.trans he.symm)
+
+/-- Applying singular chains with arbitrary coefficients to the forward map of a homotopy
+equivalence gives a quasi-isomorphism. -/
+public theorem singularChainMap_quasiIso_of_homotopyEquiv
+    (R : AddCommGrpCat) (e : X ≃ₕ Y) :
+    QuasiIso (SSet.chainComplexMap
+      (TopCat.toSSet.map (TopCat.ofHom e.toFun)) R) := by
+  rw [quasiIso_iff]
+  intro k
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  change IsIso (singularHomologyIsoOfHomotopyEquiv R k e).hom
+  infer_instance
+
+/-- The singular-chain map of any continuous map between contractible spaces is a
+quasi-isomorphism. -/
+public theorem singularChainMap_quasiIso_of_contractibleSpaces
+    [ContractibleSpace X] [ContractibleSpace Y]
+    (R : AddCommGrpCat) (f : C(X, Y)) :
+    QuasiIso (SSet.chainComplexMap
+      (TopCat.toSSet.map (TopCat.ofHom f)) R) := by
+  exact singularChainMap_quasiIso_of_homotopyEquiv R
+    (homotopyEquivOfMapBetweenContractibleSpaces f)
+
+/-- The canonical standard-simplex comparison followed by any continuous map to a contractible
+space. -/
+public noncomputable def standardSimplexToContractibleSingularChainMap
+    {Z : Type} [TopologicalSpace Z] (R : AddCommGrpCat) (n : ℕ)
+    (f : C((SSet.toTop.obj (Δ[n] : SSet.{0}) : Type), Z)) :
+    (Δ[n] : SSet.{0}).chainComplex R ⟶
+      (TopCat.toSSet.obj (TopCat.of Z)).chainComplex R :=
+  simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R ≫
+    SSet.chainComplexMap (TopCat.toSSet.map (TopCat.ofHom f)) R
+
+/-- Every such standard-simplex-to-contractible-space comparison is a quasi-isomorphism, with
+arbitrary coefficients. -/
+public theorem standardSimplexToContractibleSingularChainMap_quasiIso
+    {Z : Type} [TopologicalSpace Z] [ContractibleSpace Z]
+    (R : AddCommGrpCat) (n : ℕ)
+    (f : C((SSet.toTop.obj (Δ[n] : SSet.{0}) : Type), Z)) :
+    QuasiIso (standardSimplexToContractibleSingularChainMap R n f) := by
+  let _ : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    standardSimplexRealization_contractibleSpace n
+  let hstandard : QuasiIso
+      (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) :=
+    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso_general R n
+  let htarget : QuasiIso
+      (SSet.chainComplexMap (TopCat.toSSet.map (TopCat.ofHom f)) R) :=
+    singularChainMap_quasiIso_of_contractibleSpaces R f
+  unfold standardSimplexToContractibleSingularChainMap
+  infer_instance
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenCoverGeometry.lean
+++ b/SphereSixComplex/Topology/DiskSevenCoverGeometry.lean
@@ -1,0 +1,616 @@
+module
+
+public import SphereSixComplex.Topology.SingularExcision
+public import SphereSixComplex.Topology.CollarHomotopyExtension
+public import Mathlib.Analysis.Normed.Module.Connected
+
+/-!
+# Geometry of the concrete two-member cover of the seven-disk
+
+This file records explicit radial geometry for `diskSevenExcisionCover`.  The true member is the
+open disk.  The false member is the disk with its centre removed, and radially deformation
+retracts onto the boundary.  Their intersection is the punctured open disk.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory ContinuousMap Function Metric Set Topology
+
+namespace SphereSixComplex
+
+/-- The true member is definitionally the complement of the disk boundary, hence is homeomorphic
+to the standard open seven-ball. -/
+public noncomputable def diskSevenCoverTrueHomeomorphBall :
+    (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7)) ≃ₜ
+      (TopCat.ball.{0} 7 : Type) := by
+  change CollapseComplement (TopCat.diskBoundaryInclusion.{0} 7) ≃ₜ _
+  exact diskSevenComplementBoundaryHomeomorphBall
+
+set_option linter.style.haveILetI false in
+/-- The true cover member is contractible. -/
+public theorem diskSevenCoverTrue_contractibleSpace :
+    ContractibleSpace (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7)) := by
+  letI : ContractibleSpace
+      (Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1) :=
+    Metric.contractibleSpace_ball (by norm_num)
+  letI : ContractibleSpace (TopCat.ball.{0} 7 : Type) := by
+    change ContractibleSpace
+      (ULift (Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1))
+    exact (Homeomorph.ulift :
+      ULift (Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1) ≃ₜ
+        Metric.ball (0 : EuclideanSpace ℝ (Fin 7)) 1).contractibleSpace
+  exact diskSevenCoverTrueHomeomorphBall.contractibleSpace
+
+/-- The ambient Euclidean vector underlying a point of the seven-disk. -/
+public def diskSevenVector (x : TopCat.disk.{0} 7) :
+    EuclideanSpace ℝ (Fin 7) :=
+  x.down.1
+
+@[simp]
+public theorem diskSevenVector_center :
+    diskSevenVector diskSevenCenter = 0 := by
+  rfl
+
+/-- A point in the false cover member has a nonzero underlying vector. -/
+public theorem diskSevenVector_ne_zero_of_mem_false
+    (x : diskSevenExcisionCover false) : diskSevenVector x.1 ≠ 0 := by
+  intro hx
+  have hxc : x.1 = diskSevenCenter := by
+    apply ULift.ext
+    apply Subtype.ext
+    exact hx
+  have hxmem : x.1 ≠ diskSevenCenter := by
+    simpa [diskSevenExcisionCover] using x.2
+  exact hxmem hxc
+
+/-- A point in the false member has strictly positive radius. -/
+public theorem diskSevenNorm_pos_of_mem_false
+    (x : diskSevenExcisionCover false) : 0 < ‖diskSevenVector x.1‖ :=
+  norm_pos_iff.mpr (diskSevenVector_ne_zero_of_mem_false x)
+
+/-- Radial normalization from the punctured disk to its boundary sphere. -/
+public def diskSevenFalseRadialRetractionFunction
+    (x : diskSevenExcisionCover false) : TopCat.sphere.{0} 6 :=
+  ULift.up ⟨‖diskSevenVector x.1‖⁻¹ • diskSevenVector x.1, by
+    have hn := diskSevenNorm_pos_of_mem_false x
+    simp only [Metric.mem_sphere, dist_zero_right, norm_smul, Real.norm_eq_abs,
+      abs_inv, abs_norm]
+    exact inv_mul_cancel₀ hn.ne'⟩
+
+/-- Radial normalization is continuous on the disk with its centre removed. -/
+public theorem continuous_diskSevenFalseRadialRetractionFunction :
+    Continuous diskSevenFalseRadialRetractionFunction := by
+  unfold diskSevenFalseRadialRetractionFunction
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have hv : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  exact (hv.norm.inv₀ (fun x ↦
+    (diskSevenNorm_pos_of_mem_false x).ne')).smul hv
+
+/-- Radial normalization as a morphism of topological spaces. -/
+public noncomputable def diskSevenFalseRadialRetraction :
+    TopCat.of (diskSevenExcisionCover false) ⟶ TopCat.sphere.{0} 6 :=
+  TopCat.ofHom
+    ⟨diskSevenFalseRadialRetractionFunction,
+      continuous_diskSevenFalseRadialRetractionFunction⟩
+
+@[simp]
+public theorem diskSevenFalseRadialRetraction_down (x : diskSevenExcisionCover false) :
+    (diskSevenFalseRadialRetraction x).down.1 =
+      ‖diskSevenVector x.1‖⁻¹ • diskSevenVector x.1 :=
+  rfl
+
+@[simp]
+public theorem diskBoundaryToDiskSevenExcisionCoverFalse_vector
+    (x : TopCat.sphere.{0} 6) :
+    diskSevenVector (diskBoundaryToDiskSevenExcisionCoverFalse x).1 = x.down.1 :=
+  rfl
+
+/-- Radial normalization is a left inverse to the boundary inclusion into the false member. -/
+public theorem diskBoundaryToDiskSevenExcisionCoverFalse_comp_radialRetraction :
+    diskBoundaryToDiskSevenExcisionCoverFalse ≫
+        diskSevenFalseRadialRetraction =
+      𝟙 (TopCat.sphere.{0} 6) := by
+  ext x
+  apply ULift.ext
+  apply Subtype.ext
+  change ‖x.down.1‖⁻¹ • x.down.1 = x.down.1
+  have hx : ‖x.down.1‖ = 1 := by
+    simpa only [Metric.mem_sphere, dist_zero_right] using x.down.2
+  simp [hx]
+
+/-- Every disk point has radius at most one. -/
+public theorem diskSevenNorm_le_one (x : TopCat.disk.{0} 7) :
+    ‖diskSevenVector x‖ ≤ 1 := by
+  simpa only [diskSevenVector, Metric.mem_closedBall, dist_zero_right] using x.down.2
+
+/-- The radial homotopy interpolates between normalization and the original radius. -/
+public def diskSevenFalseRadialScale (t : unitInterval)
+    (x : diskSevenExcisionCover false) : ℝ :=
+  (t : ℝ) + (1 - (t : ℝ)) * ‖diskSevenVector x.1‖⁻¹
+
+/-- The radial scaling factor is always positive. -/
+public theorem diskSevenFalseRadialScale_pos (t : unitInterval)
+    (x : diskSevenExcisionCover false) :
+    0 < diskSevenFalseRadialScale t x := by
+  have hinv : 0 < ‖diskSevenVector x.1‖⁻¹ :=
+    inv_pos.mpr (diskSevenNorm_pos_of_mem_false x)
+  by_cases ht : (t : ℝ) = 0
+  · simp [diskSevenFalseRadialScale, ht, hinv]
+  · exact add_pos_of_pos_of_nonneg
+      (lt_of_le_of_ne t.2.1 (Ne.symm ht))
+      (mul_nonneg (sub_nonneg.mpr t.2.2) hinv.le)
+
+/-- Radial interpolation stays in the closed unit disk. -/
+public theorem norm_diskSevenFalseRadialScale_smul_le_one
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    ‖diskSevenFalseRadialScale t x • diskSevenVector x.1‖ ≤ 1 := by
+  have hn := diskSevenNorm_pos_of_mem_false x
+  rw [norm_smul, Real.norm_eq_abs,
+    abs_of_pos (diskSevenFalseRadialScale_pos t x)]
+  change (((t : ℝ) + (1 - (t : ℝ)) * ‖diskSevenVector x.1‖⁻¹) *
+    ‖diskSevenVector x.1‖) ≤ 1
+  rw [add_mul, mul_assoc, inv_mul_cancel₀ hn.ne', mul_one]
+  calc
+    (t : ℝ) * ‖diskSevenVector x.1‖ + (1 - (t : ℝ)) ≤
+        (t : ℝ) * 1 + (1 - (t : ℝ)) :=
+      add_le_add
+        (mul_le_mul_of_nonneg_left (diskSevenNorm_le_one x.1) t.2.1) le_rfl
+    _ = 1 := by ring
+
+/-- The explicit radial homotopy on the disk with its centre removed. -/
+public def diskSevenFalseRadialHomotopyFunction
+    (p : unitInterval × diskSevenExcisionCover false) :
+    diskSevenExcisionCover false :=
+  ⟨ULift.up ⟨diskSevenFalseRadialScale p.1 p.2 • diskSevenVector p.2.1,
+      by simpa only [Metric.mem_closedBall, dist_zero_right] using
+        norm_diskSevenFalseRadialScale_smul_le_one p.1 p.2⟩, by
+    change (ULift.up ⟨diskSevenFalseRadialScale p.1 p.2 •
+      diskSevenVector p.2.1, _⟩ : TopCat.disk.{0} 7) ≠ diskSevenCenter
+    intro h
+    have hv := congrArg diskSevenVector h
+    change diskSevenFalseRadialScale p.1 p.2 •
+      diskSevenVector p.2.1 = diskSevenVector diskSevenCenter at hv
+    rw [diskSevenVector_center] at hv
+    exact (smul_ne_zero (ne_of_gt (diskSevenFalseRadialScale_pos p.1 p.2))
+      (diskSevenVector_ne_zero_of_mem_false p.2)) hv⟩
+
+/-- The radial homotopy is jointly continuous in time and the punctured-disk point. -/
+public theorem continuous_diskSevenFalseRadialHomotopyFunction :
+    Continuous diskSevenFalseRadialHomotopyFunction := by
+  unfold diskSevenFalseRadialHomotopyFunction
+  apply Continuous.subtype_mk
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have hv₀ : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  have hv : Continuous (fun p : unitInterval × diskSevenExcisionCover false ↦
+      diskSevenVector p.2.1) := hv₀.comp continuous_snd
+  have ht : Continuous (fun p : unitInterval ×
+      diskSevenExcisionCover false ↦ (p.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have hninv : Continuous (fun p : unitInterval ×
+      diskSevenExcisionCover false ↦ ‖diskSevenVector p.2.1‖⁻¹) :=
+    hv.norm.inv₀ (fun p ↦ (diskSevenNorm_pos_of_mem_false p.2).ne')
+  exact (ht.add ((continuous_const.sub ht).mul hninv)).smul hv
+
+@[simp]
+public theorem diskSevenFalseRadialHomotopyFunction_vector
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseRadialHomotopyFunction (t, x)).1 =
+      diskSevenFalseRadialScale t x • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- At time zero the radial homotopy is radial normalization. -/
+@[simp]
+public theorem diskSevenFalseRadialHomotopyFunction_zero
+    (x : diskSevenExcisionCover false) :
+    diskSevenFalseRadialHomotopyFunction (0, x) =
+      diskBoundaryToDiskSevenExcisionCoverFalse
+        (diskSevenFalseRadialRetraction x) := by
+  apply Subtype.ext
+  apply ULift.ext
+  apply Subtype.ext
+  change diskSevenVector (diskSevenFalseRadialHomotopyFunction (0, x)).1 =
+    diskSevenVector (diskBoundaryToDiskSevenExcisionCoverFalse
+      (diskSevenFalseRadialRetraction x)).1
+  rw [diskSevenFalseRadialHomotopyFunction_vector,
+    diskBoundaryToDiskSevenExcisionCoverFalse_vector,
+    diskSevenFalseRadialRetraction_down]
+  simp [diskSevenFalseRadialScale]
+
+/-- At time one the radial homotopy is the identity. -/
+@[simp]
+public theorem diskSevenFalseRadialHomotopyFunction_one
+    (x : diskSevenExcisionCover false) :
+    diskSevenFalseRadialHomotopyFunction (1, x) = x := by
+  apply Subtype.ext
+  apply ULift.ext
+  apply Subtype.ext
+  simp [diskSevenFalseRadialHomotopyFunction, diskSevenFalseRadialScale,
+    diskSevenVector]
+
+/-- The radial homotopy from boundary normalization to the identity of the false member. -/
+public noncomputable def diskSevenFalseRadialHomotopy :
+    TopCat.Homotopy
+      (diskSevenFalseRadialRetraction ≫
+        diskBoundaryToDiskSevenExcisionCoverFalse)
+      (𝟙 (TopCat.of (diskSevenExcisionCover false))) where
+  toFun := diskSevenFalseRadialHomotopyFunction
+  continuous_toFun := continuous_diskSevenFalseRadialHomotopyFunction
+  map_zero_left := diskSevenFalseRadialHomotopyFunction_zero
+  map_one_left := diskSevenFalseRadialHomotopyFunction_one
+
+@[simp]
+public theorem diskSevenFalseRadialHomotopy_vector
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseRadialHomotopy (t, x)).1 =
+      diskSevenFalseRadialScale t x • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The radial homotopy fixes boundary points pointwise. -/
+public theorem diskSevenFalseRadialHomotopy_fixed
+    (t : unitInterval) (x : TopCat.sphere.{0} 6) :
+    diskSevenFalseRadialHomotopy
+      (t, diskBoundaryToDiskSevenExcisionCoverFalse x) =
+      diskBoundaryToDiskSevenExcisionCoverFalse x := by
+  apply Subtype.ext
+  apply ULift.ext
+  apply Subtype.ext
+  have hx : ‖x.down.1‖ = 1 := by
+    simpa only [Metric.mem_sphere, dist_zero_right] using x.down.2
+  change diskSevenVector
+      (diskSevenFalseRadialHomotopy
+        (t, diskBoundaryToDiskSevenExcisionCoverFalse x)).1 =
+    diskSevenVector (diskBoundaryToDiskSevenExcisionCoverFalse x).1
+  rw [diskSevenFalseRadialHomotopy_vector,
+    diskBoundaryToDiskSevenExcisionCoverFalse_vector]
+  have hnorm : ‖diskSevenVector
+      (diskBoundaryToDiskSevenExcisionCoverFalse x).1‖ = 1 := by
+    rw [diskBoundaryToDiskSevenExcisionCoverFalse_vector]
+    exact hx
+  simp [diskSevenFalseRadialScale, hnorm]
+
+/-- The boundary is a strong deformation retract of the false cover member. -/
+public noncomputable def diskSevenFalseStrongDeformationRetract :
+    TopCat.StrongDeformationRetractData
+      diskBoundaryToDiskSevenExcisionCoverFalse where
+  retraction := diskSevenFalseRadialRetraction
+  retract := diskBoundaryToDiskSevenExcisionCoverFalse_comp_radialRetraction
+  homotopy := diskSevenFalseRadialHomotopy
+  fixed := diskSevenFalseRadialHomotopy_fixed
+
+/-- The boundary inclusion into the false member is an explicit homotopy equivalence. -/
+public noncomputable def diskBoundaryToDiskSevenExcisionCoverFalseHomotopyEquiv :
+    (TopCat.sphere.{0} 6 : Type) ≃ₕ
+      (diskSevenExcisionCover false : Set (TopCat.disk.{0} 7)) :=
+  strongDeformationRetractHomotopyEquiv
+    diskSevenFalseStrongDeformationRetract
+
+/-- The intersection of the two concrete cover members. -/
+public abbrev DiskSevenCoverIntersection : Type :=
+  (diskSevenExcisionCover true ∩ diskSevenExcisionCover false :
+    Set (TopCat.disk.{0} 7))
+
+/-- Radius strictly below one characterizes membership in the true cover member. -/
+public theorem mem_diskSevenExcisionCover_true_of_norm_lt_one
+    (x : TopCat.disk.{0} 7) (hx : ‖diskSevenVector x‖ < 1) :
+    x ∈ diskSevenExcisionCover true := by
+  change x ∉ Set.range (TopCat.diskBoundaryInclusion.{0} 7)
+  rintro ⟨y, rfl⟩
+  have hy : ‖y.down.1‖ = 1 := by
+    simpa only [Metric.mem_sphere, dist_zero_right] using y.down.2
+  apply hx.ne
+  change ‖y.down.1‖ = 1
+  exact hy
+
+/-- Intersection points, being in the open disk, have radius strictly below one. -/
+public theorem diskSevenNorm_lt_one_of_mem_intersection
+    (x : DiskSevenCoverIntersection) : ‖diskSevenVector x.1‖ < 1 := by
+  have hx := x.2.1
+  change x.1 ∉ Set.range (TopCat.diskBoundaryInclusion.{0} 7) at hx
+  exact lt_of_le_of_ne (diskSevenNorm_le_one x.1) (fun h ↦ hx
+    ⟨ULift.up ⟨diskSevenVector x.1, by
+      simpa only [Metric.mem_sphere, dist_zero_right] using h⟩, by
+        apply ULift.ext
+        apply Subtype.ext
+        rfl⟩)
+
+/-- Forgetting the true-member condition, as a function to the false member. -/
+public def diskSevenIntersectionToFalseFunction
+    (x : DiskSevenCoverIntersection) : diskSevenExcisionCover false :=
+  ⟨x.1, x.2.2⟩
+
+/-- Forgetting the true-member condition includes the intersection in the false member. -/
+public noncomputable def diskSevenIntersectionToFalse :
+    TopCat.of DiskSevenCoverIntersection ⟶
+      TopCat.of (diskSevenExcisionCover false) :=
+  TopCat.ofHom ⟨diskSevenIntersectionToFalseFunction,
+    continuous_subtype_val.subtype_mk _⟩
+
+@[simp]
+public theorem diskSevenIntersectionToFalseFunction_vector
+    (x : DiskSevenCoverIntersection) :
+    diskSevenVector (diskSevenIntersectionToFalseFunction x).1 =
+      diskSevenVector x.1 :=
+  rfl
+
+/-- Halving the vector of a false-member point keeps it in the closed disk. -/
+public theorem norm_half_diskSevenVector_le_one
+    (x : diskSevenExcisionCover false) :
+    ‖(2 : ℝ)⁻¹ • diskSevenVector x.1‖ ≤ 1 := by
+  rw [norm_smul, Real.norm_eq_abs]
+  have habs : |(2 : ℝ)⁻¹| = (2 : ℝ)⁻¹ := abs_of_pos (by positivity)
+  rw [habs]
+  calc
+    (2 : ℝ)⁻¹ * ‖diskSevenVector x.1‖ ≤ (2 : ℝ)⁻¹ * 1 :=
+      mul_le_mul_of_nonneg_left (diskSevenNorm_le_one x.1) (by positivity)
+    _ ≤ 1 := by norm_num
+
+/-- Halving the vector of a false-member point puts it strictly inside the disk. -/
+public theorem norm_half_diskSevenVector_lt_one
+    (x : diskSevenExcisionCover false) :
+    ‖(2 : ℝ)⁻¹ • diskSevenVector x.1‖ < 1 := by
+  rw [norm_smul, Real.norm_eq_abs]
+  have habs : |(2 : ℝ)⁻¹| = (2 : ℝ)⁻¹ := abs_of_pos (by positivity)
+  rw [habs]
+  calc
+    (2 : ℝ)⁻¹ * ‖diskSevenVector x.1‖ ≤ (2 : ℝ)⁻¹ * 1 :=
+      mul_le_mul_of_nonneg_left (diskSevenNorm_le_one x.1) (by positivity)
+    _ < 1 := by norm_num
+
+/-- The closed-disk point obtained by radially halving a false-member point. -/
+public def diskSevenFalseHalfDiskPoint
+    (x : diskSevenExcisionCover false) : TopCat.disk.{0} 7 :=
+  ULift.up ⟨(2 : ℝ)⁻¹ • diskSevenVector x.1, by
+    simpa only [Metric.mem_closedBall, dist_zero_right] using
+      norm_half_diskSevenVector_le_one x⟩
+
+@[simp]
+public theorem diskSevenFalseHalfDiskPoint_vector
+    (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseHalfDiskPoint x) =
+      (2 : ℝ)⁻¹ • diskSevenVector x.1 :=
+  rfl
+
+/-- Radially halve a false-member point; the result lies in the punctured open disk. -/
+public def diskSevenFalseToIntersectionHalfFunction
+    (x : diskSevenExcisionCover false) : DiskSevenCoverIntersection :=
+  ⟨diskSevenFalseHalfDiskPoint x, ⟨by
+    apply mem_diskSevenExcisionCover_true_of_norm_lt_one
+    rw [diskSevenFalseHalfDiskPoint_vector]
+    exact norm_half_diskSevenVector_lt_one x
+  , by
+    change diskSevenFalseHalfDiskPoint x ≠ diskSevenCenter
+    intro h
+    have hv := congrArg diskSevenVector h
+    rw [diskSevenFalseHalfDiskPoint_vector, diskSevenVector_center] at hv
+    exact (smul_ne_zero (by norm_num) (diskSevenVector_ne_zero_of_mem_false x)) hv⟩⟩
+
+/-- Radial halving is continuous. -/
+public theorem continuous_diskSevenFalseToIntersectionHalfFunction :
+    Continuous diskSevenFalseToIntersectionHalfFunction := by
+  unfold diskSevenFalseToIntersectionHalfFunction diskSevenFalseHalfDiskPoint
+  apply Continuous.subtype_mk
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have hv : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  have hc : Continuous (fun _ : diskSevenExcisionCover false ↦ (2 : ℝ)⁻¹) :=
+    continuous_const
+  exact hc.smul hv
+
+/-- Radial halving as a topological map from the false member to the intersection. -/
+public noncomputable def diskSevenFalseToIntersectionHalf :
+    TopCat.of (diskSevenExcisionCover false) ⟶
+      TopCat.of DiskSevenCoverIntersection :=
+  TopCat.ofHom ⟨diskSevenFalseToIntersectionHalfFunction,
+    continuous_diskSevenFalseToIntersectionHalfFunction⟩
+
+/-- Scaling coefficient from one half at time zero to one at time one. -/
+public def diskSevenHalfToIdentityScale (t : unitInterval) : ℝ :=
+  (1 + (t : ℝ)) / 2
+
+public theorem diskSevenHalfToIdentityScale_pos (t : unitInterval) :
+    0 < diskSevenHalfToIdentityScale t := by
+  dsimp [diskSevenHalfToIdentityScale]
+  linarith [t.2.1]
+
+public theorem diskSevenHalfToIdentityScale_le_one (t : unitInterval) :
+    diskSevenHalfToIdentityScale t ≤ 1 := by
+  dsimp [diskSevenHalfToIdentityScale]
+  linarith [t.2.2]
+
+/-- The half-radius-to-identity homotopy on the false member. -/
+public def diskSevenFalseHalfHomotopyFunction
+    (p : unitInterval × diskSevenExcisionCover false) :
+    diskSevenExcisionCover false :=
+  ⟨ULift.up ⟨diskSevenHalfToIdentityScale p.1 • diskSevenVector p.2.1, by
+      have hnorm : ‖diskSevenHalfToIdentityScale p.1 • diskSevenVector p.2.1‖ ≤ 1 := by
+        rw [norm_smul, Real.norm_eq_abs,
+          abs_of_pos (diskSevenHalfToIdentityScale_pos p.1)]
+        exact (mul_le_mul_of_nonneg_right
+          (diskSevenHalfToIdentityScale_le_one p.1)
+          (norm_nonneg _)).trans (by simpa using diskSevenNorm_le_one p.2.1)
+      simpa only [Metric.mem_closedBall, dist_zero_right] using hnorm⟩, by
+    change (ULift.up ⟨diskSevenHalfToIdentityScale p.1 •
+      diskSevenVector p.2.1, _⟩ : TopCat.disk.{0} 7) ≠ diskSevenCenter
+    intro h
+    have hv := congrArg diskSevenVector h
+    change diskSevenHalfToIdentityScale p.1 • diskSevenVector p.2.1 =
+      diskSevenVector diskSevenCenter at hv
+    rw [diskSevenVector_center] at hv
+    exact (smul_ne_zero (ne_of_gt (diskSevenHalfToIdentityScale_pos p.1))
+      (diskSevenVector_ne_zero_of_mem_false p.2)) hv⟩
+
+public theorem continuous_diskSevenFalseHalfHomotopyFunction :
+    Continuous diskSevenFalseHalfHomotopyFunction := by
+  unfold diskSevenFalseHalfHomotopyFunction
+  apply Continuous.subtype_mk
+  apply continuous_uliftUp.comp
+  apply Continuous.subtype_mk
+  have ht : Continuous (fun p : unitInterval × diskSevenExcisionCover false ↦
+      diskSevenHalfToIdentityScale p.1) := by
+    unfold diskSevenHalfToIdentityScale
+    fun_prop
+  have hv₀ : Continuous (fun x : diskSevenExcisionCover false ↦
+      diskSevenVector x.1) :=
+    (continuous_subtype_val.comp continuous_uliftDown).comp
+      continuous_subtype_val
+  exact ht.smul (hv₀.comp continuous_snd)
+
+@[simp]
+public theorem diskSevenFalseHalfHomotopyFunction_vector
+    (t : unitInterval) (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseHalfHomotopyFunction (t, x)).1 =
+      diskSevenHalfToIdentityScale t • diskSevenVector x.1 :=
+  rfl
+
+@[simp]
+public theorem diskSevenFalseToIntersectionHalfFunction_vector
+    (x : diskSevenExcisionCover false) :
+    diskSevenVector (diskSevenFalseToIntersectionHalfFunction x).1 =
+      (2 : ℝ)⁻¹ • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- On the false member, halving followed by inclusion is homotopic to the identity. -/
+public noncomputable def diskSevenFalseHalfHomotopy :
+    TopCat.Homotopy
+      (diskSevenFalseToIntersectionHalf ≫ diskSevenIntersectionToFalse)
+      (𝟙 (TopCat.of (diskSevenExcisionCover false))) where
+  toFun := diskSevenFalseHalfHomotopyFunction
+  continuous_toFun := continuous_diskSevenFalseHalfHomotopyFunction
+  map_zero_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    change diskSevenVector (diskSevenFalseHalfHomotopyFunction (0, x)).1 =
+      diskSevenVector (diskSevenIntersectionToFalseFunction
+        (diskSevenFalseToIntersectionHalfFunction x)).1
+    rw [diskSevenFalseHalfHomotopyFunction_vector,
+      diskSevenIntersectionToFalseFunction_vector,
+      diskSevenFalseToIntersectionHalfFunction_vector]
+    simp [diskSevenHalfToIdentityScale]
+  map_one_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    simp [diskSevenFalseHalfHomotopyFunction,
+      diskSevenHalfToIdentityScale, diskSevenVector]
+
+/-- Restrict the same radial homotopy to the punctured open disk. -/
+public def diskSevenIntersectionHalfHomotopyFunction
+    (p : unitInterval × DiskSevenCoverIntersection) :
+    DiskSevenCoverIntersection :=
+  ⟨(diskSevenFalseHalfHomotopyFunction
+      (p.1, diskSevenIntersectionToFalseFunction p.2)).1, ⟨by
+    apply mem_diskSevenExcisionCover_true_of_norm_lt_one
+    rw [diskSevenFalseHalfHomotopyFunction_vector,
+      diskSevenIntersectionToFalseFunction_vector, norm_smul, Real.norm_eq_abs,
+      abs_of_pos (diskSevenHalfToIdentityScale_pos p.1)]
+    calc
+      diskSevenHalfToIdentityScale p.1 * ‖diskSevenVector p.2.1‖ ≤
+          1 * ‖diskSevenVector p.2.1‖ :=
+        mul_le_mul_of_nonneg_right (diskSevenHalfToIdentityScale_le_one p.1)
+          (norm_nonneg _)
+      _ < 1 := by simpa using diskSevenNorm_lt_one_of_mem_intersection p.2
+  , by
+    exact (diskSevenFalseHalfHomotopyFunction
+      (p.1, diskSevenIntersectionToFalseFunction p.2)).2⟩⟩
+
+public theorem continuous_diskSevenIntersectionHalfHomotopyFunction :
+    Continuous diskSevenIntersectionHalfHomotopyFunction := by
+  unfold diskSevenIntersectionHalfHomotopyFunction
+  apply Continuous.subtype_mk
+  apply continuous_subtype_val.comp
+  apply continuous_diskSevenFalseHalfHomotopyFunction.comp
+  have hi : Continuous diskSevenIntersectionToFalseFunction :=
+    continuous_subtype_val.subtype_mk _
+  exact continuous_fst.prodMk (hi.comp continuous_snd)
+
+@[simp]
+public theorem diskSevenIntersectionHalfHomotopyFunction_vector
+    (t : unitInterval) (x : DiskSevenCoverIntersection) :
+    diskSevenVector (diskSevenIntersectionHalfHomotopyFunction (t, x)).1 =
+      diskSevenHalfToIdentityScale t • diskSevenVector x.1 :=
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- On the intersection, inclusion followed by radial halving is homotopic to the identity. -/
+public noncomputable def diskSevenIntersectionHalfHomotopy :
+    TopCat.Homotopy
+      (diskSevenIntersectionToFalse ≫ diskSevenFalseToIntersectionHalf)
+      (𝟙 (TopCat.of DiskSevenCoverIntersection)) where
+  toFun := diskSevenIntersectionHalfHomotopyFunction
+  continuous_toFun := continuous_diskSevenIntersectionHalfHomotopyFunction
+  map_zero_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    change diskSevenVector
+        (diskSevenIntersectionHalfHomotopyFunction (0, x)).1 =
+      diskSevenVector (diskSevenFalseToIntersectionHalfFunction
+        (diskSevenIntersectionToFalseFunction x)).1
+    rw [diskSevenIntersectionHalfHomotopyFunction_vector,
+      diskSevenFalseToIntersectionHalfFunction_vector,
+      diskSevenIntersectionToFalseFunction_vector]
+    simp [diskSevenHalfToIdentityScale]
+  map_one_left x := by
+    apply Subtype.ext
+    apply ULift.ext
+    apply Subtype.ext
+    change diskSevenVector
+        (diskSevenIntersectionHalfHomotopyFunction (1, x)).1 =
+      diskSevenVector x.1
+    rw [diskSevenIntersectionHalfHomotopyFunction_vector]
+    simp [diskSevenHalfToIdentityScale]
+
+/-- Radial halving and inclusion give a homotopy equivalence between the punctured closed and
+punctured open disks. -/
+public noncomputable def diskSevenFalseIntersectionHomotopyEquiv :
+    (diskSevenExcisionCover false : Set (TopCat.disk.{0} 7)) ≃ₕ
+      DiskSevenCoverIntersection where
+  toFun := diskSevenFalseToIntersectionHalf.hom
+  invFun := diskSevenIntersectionToFalse.hom
+  left_inv := ⟨diskSevenFalseHalfHomotopy⟩
+  right_inv := ⟨diskSevenIntersectionHalfHomotopy⟩
+
+/-- The punctured open disk, i.e. the cover intersection, is homotopy equivalent to the standard
+six-sphere. -/
+public noncomputable def diskSevenCoverIntersectionHomotopyEquivSphereSix :
+    DiskSevenCoverIntersection ≃ₕ (TopCat.sphere.{0} 6 : Type) :=
+  (diskBoundaryToDiskSevenExcisionCoverFalseHomotopyEquiv.trans
+    diskSevenFalseIntersectionHomotopyEquiv).symm
+
+/-- The forward map of the intersection-sphere equivalence is exactly radial normalization after
+forgetting the open-disk condition. -/
+@[simp]
+public theorem diskSevenCoverIntersectionHomotopyEquivSphereSix_apply
+    (x : DiskSevenCoverIntersection) :
+    diskSevenCoverIntersectionHomotopyEquivSphereSix x =
+      diskSevenFalseRadialRetraction (diskSevenIntersectionToFalse x) :=
+  rfl
+
+/-- The inverse map first includes the boundary in the punctured closed disk and then halves its
+radius, landing in the punctured interior. -/
+@[simp]
+public theorem diskSevenCoverIntersectionHomotopyEquivSphereSix_symm_apply
+    (x : TopCat.sphere.{0} 6) :
+    diskSevenCoverIntersectionHomotopyEquivSphereSix.symm x =
+      diskSevenFalseToIntersectionHalf
+        (diskBoundaryToDiskSevenExcisionCoverFalse x) :=
+  rfl
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenCoverRangeGeometryChains.lean
+++ b/SphereSixComplex/Topology/DiskSevenCoverRangeGeometryChains.lean
@@ -1,0 +1,459 @@
+module
+
+public import SphereSixComplex.Topology.DiskSevenCoverGeometry
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLowAcyclic
+public import Mathlib.Algebra.Homology.HomologicalComplexBiprod
+public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Geometric identifications of the seven-disk cover range complexes
+
+This file transfers the explicit topology of `diskSevenExcisionCover` to the range subcomplexes
+used by the local relative Mayer--Vietoris calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap Set
+
+namespace SphereSixComplex
+
+/-- Inclusion of either cover member into the disk is a monomorphism. -/
+public instance diskSevenCoverSubsetInclusion_mono (b : Bool) :
+    Mono (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b)) := by
+  rw [TopCat.mono_iff_injective]
+  exact Subtype.val_injective
+
+/-- The induced map of singular simplicial sets is a monomorphism. -/
+public instance diskSevenCoverSubsetSingularSetInclusion_mono (b : Bool) :
+    Mono (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b))) := by
+  apply Functor.map_mono
+
+/-- Because subspace inclusion is injective, its singular simplicial set is isomorphic to its
+range subcomplex. -/
+public instance diskSevenCoverMemberToRangeSingularSet_isIso (b : Bool) :
+    IsIso (diskSevenCoverMemberToRangeSingularSet b) := by
+  change IsIso (SSet.Subcomplex.toRange
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b))))
+  infer_instance
+
+/-- The singular simplicial set of a cover member, identified with its range in the disk. -/
+public noncomputable def diskSevenCoverMemberRangeSingularSetIso (b : Bool) :
+    TopCat.toSSet.obj (TopCat.of (diskSevenExcisionCover b)) ≅
+      (diskSevenCoverRangeSubcomplex b : SSet) :=
+  asIso (diskSevenCoverMemberToRangeSingularSet b)
+
+/-- The chain map from a cover member to its range complex. -/
+public noncomputable def diskSevenCoverMemberToRangeChains (b : Bool) :
+    IntegralSingularChainComplexObj (TopCat.of (diskSevenExcisionCover b)) ⟶
+      DiskSevenCoverRangeChainComplex b :=
+  SSet.chainComplexMap (diskSevenCoverMemberToRangeSingularSet b)
+    (AddCommGrpCat.of ℤ)
+
+/-- Integral singular chains of a cover member are isomorphic to chains on the corresponding
+range subcomplex. -/
+public noncomputable def diskSevenCoverMemberRangeChainsIso (b : Bool) :
+    IntegralSingularChainComplexObj (TopCat.of (diskSevenExcisionCover b)) ≅
+      DiskSevenCoverRangeChainComplex b :=
+  ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).mapIso
+    (diskSevenCoverMemberRangeSingularSetIso b)
+
+@[simp]
+public theorem diskSevenCoverMemberRangeChainsIso_hom (b : Bool) :
+    (diskSevenCoverMemberRangeChainsIso b).hom =
+      diskSevenCoverMemberToRangeChains b :=
+  rfl
+
+/-- The induced degreewise homology identification for a cover member and its range. -/
+public noncomputable def diskSevenCoverMemberRangeHomologyIso (b : Bool) (k : ℕ) :
+    (IntegralSingularChainComplexObj
+        (TopCat.of (diskSevenExcisionCover b))).homology k ≅
+      (DiskSevenCoverRangeChainComplex b).homology k :=
+  (HomologicalComplex.homologyFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) k).mapIso (diskSevenCoverMemberRangeChainsIso b)
+
+/-- Singular homology objects are invariant under a specified topological homotopy equivalence. -/
+public noncomputable def integralSingularHomologyIsoOfHomotopyEquiv
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (k : ℕ) (e : X ≃ₕ Y) :
+    (((singularHomologyFunctor AddCommGrpCat k).obj
+        (AddCommGrpCat.of ℤ)).obj (TopCat.of X)) ≅
+      (((singularHomologyFunctor AddCommGrpCat k).obj
+        (AddCommGrpCat.of ℤ)).obj (TopCat.of Y)) := by
+  let F := (singularHomologyFunctor AddCommGrpCat k).obj (AddCommGrpCat.of ℤ)
+  let f : TopCat.of X ⟶ TopCat.of Y := TopCat.ofHom e.toFun
+  let g : TopCat.of Y ⟶ TopCat.of X := TopCat.ofHom e.invFun
+  exact CategoryTheory.Iso.mk (F.map f) (F.map g) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.left_inv.some (AddCommGrpCat.of ℤ) k) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.right_inv.some (AddCommGrpCat.of ℤ) k)
+
+/-- Every positive-degree integral homology object of the true range vanishes. -/
+public theorem diskSevenCoverTrueRange_homology_isZero
+    (k : ℕ) (hk : k ≠ 0) :
+    IsZero ((DiskSevenCoverRangeChainComplex true).homology k) := by
+  let _ : ContractibleSpace
+      (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7)) :=
+    diskSevenCoverTrue_contractibleSpace
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (diskSevenExcisionCover true : Set (TopCat.disk.{0} 7))
+  have hunit :=
+    AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+      AddCommGrpCat k (AddCommGrpCat.of ℤ) (TopCat.of Unit) hk
+  have hmember : IsZero
+      ((IntegralSingularChainComplexObj
+        (TopCat.of (diskSevenExcisionCover true))).homology k) :=
+    by
+      change IsZero (((singularHomologyFunctor AddCommGrpCat k).obj
+        (AddCommGrpCat.of ℤ)).obj
+          (TopCat.of (diskSevenExcisionCover true)))
+      exact hunit.of_iso (integralSingularHomologyIsoOfHomotopyEquiv k e)
+  exact hmember.of_iso (diskSevenCoverMemberRangeHomologyIso true k).symm
+
+/-- The boundary inclusion into the false member is a chain-homotopy equivalence. -/
+public noncomputable def diskBoundaryToDiskSevenFalseMemberChainsHomotopyEquiv :
+    HomotopyEquiv
+      (IntegralSingularChainComplexObj (TopCat.sphere.{0} 6))
+      (IntegralSingularChainComplexObj
+        (TopCat.of (diskSevenExcisionCover false))) where
+  hom := integralSingularChainMapObj
+    diskBoundaryToDiskSevenExcisionCoverFalse
+  inv := integralSingularChainMapObj diskSevenFalseRadialRetraction
+  homotopyHomInvId := by
+    let F := (singularChainComplexFunctor AddCommGrpCat).obj
+      (AddCommGrpCat.of ℤ)
+    let h₁ : Homotopy
+        (F.map diskBoundaryToDiskSevenExcisionCoverFalse ≫
+          F.map diskSevenFalseRadialRetraction)
+        (F.map (𝟙 (TopCat.sphere.{0} 6))) :=
+      Homotopy.ofEq (by
+        rw [← F.map_comp,
+          diskBoundaryToDiskSevenExcisionCoverFalse_comp_radialRetraction])
+    let h₂ : Homotopy (F.map (𝟙 (TopCat.sphere.{0} 6))) (𝟙 _) :=
+      Homotopy.ofEq (F.map_id _)
+    simpa only [integralSingularChainMapObj] using h₁.trans h₂
+  homotopyInvHomId := by
+    let F := (singularChainComplexFunctor AddCommGrpCat).obj
+      (AddCommGrpCat.of ℤ)
+    let h₀ : Homotopy
+        (F.map diskSevenFalseRadialRetraction ≫
+          F.map diskBoundaryToDiskSevenExcisionCoverFalse)
+        (F.map (diskSevenFalseRadialRetraction ≫
+          diskBoundaryToDiskSevenExcisionCoverFalse)) :=
+      Homotopy.ofEq (F.map_comp _ _).symm
+    let h₁ := diskSevenFalseRadialHomotopy.singularChainComplexFunctorObjMap
+      (AddCommGrpCat.of ℤ)
+    let h₂ : Homotopy
+        (F.map (𝟙 (TopCat.of (diskSevenExcisionCover false)))) (𝟙 _) :=
+      Homotopy.ofEq (F.map_id _)
+    simpa only [integralSingularChainMapObj] using h₀.trans (h₁.trans h₂)
+
+/-- Composing the preceding equivalence with the member-range chain isomorphism gives the exact
+boundary-to-false-range chain map used by the relative complex. -/
+public noncomputable def diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv :
+    HomotopyEquiv
+      (IntegralSingularChainComplexObj (TopCat.sphere.{0} 6))
+      (DiskSevenCoverRangeChainComplex false) :=
+  diskBoundaryToDiskSevenFalseMemberChainsHomotopyEquiv.trans
+    (HomotopyEquiv.ofIso (diskSevenCoverMemberRangeChainsIso false))
+
+@[simp]
+public theorem diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv_hom :
+    diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv.hom =
+      diskBoundaryToDiskSevenFalseRangeChains :=
+  rfl
+
+/-- The boundary-to-false-range map is a quasi-isomorphism. -/
+public theorem diskBoundaryToDiskSevenFalseRangeChains_quasiIso :
+    QuasiIso diskBoundaryToDiskSevenFalseRangeChains := by
+  rw [← diskBoundaryToDiskSevenFalseRangeChainsHomotopyEquiv_hom]
+  infer_instance
+
+/-- The boundary-to-false-member map is a monomorphism. -/
+public instance diskBoundaryToDiskSevenExcisionCoverFalse_mono :
+    Mono diskBoundaryToDiskSevenExcisionCoverFalse := by
+  rw [TopCat.mono_iff_injective]
+  intro x y h
+  apply ULift.ext
+  apply Subtype.ext
+  exact congrArg (fun z ↦ z.1.down.1) h
+
+/-- The boundary-to-false-range chain map is degreewise injective. -/
+public instance diskBoundaryToDiskSevenFalseRangeChains_mono :
+    Mono diskBoundaryToDiskSevenFalseRangeChains := by
+  let _ : Mono (integralSingularChainMapObj
+      diskBoundaryToDiskSevenExcisionCoverFalse) := by
+    dsimp [integralSingularChainMapObj]
+    apply Functor.map_mono
+  let _ : Mono (diskSevenCoverMemberToRangeChains false) := by
+    rw [← diskSevenCoverMemberRangeChainsIso_hom]
+    infer_instance
+  change Mono
+    (integralSingularChainMapObj diskBoundaryToDiskSevenExcisionCoverFalse ≫
+      diskSevenCoverMemberToRangeChains false)
+  infer_instance
+
+/-- The standard cokernel sequence defining the false relative range complex. -/
+public noncomputable def diskSevenFalseRangeRelativeShortComplex :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  ShortComplex.mk diskBoundaryToDiskSevenFalseRangeChains
+    diskSevenFalseRangeRelativeProjection
+    (cokernel.condition diskBoundaryToDiskSevenFalseRangeChains)
+
+/-- That cokernel sequence is short exact. -/
+public theorem diskSevenFalseRangeRelativeShortComplex_shortExact :
+    diskSevenFalseRangeRelativeShortComplex.ShortExact :=
+  { exact := ShortComplex.exact_cokernel
+      diskBoundaryToDiskSevenFalseRangeChains
+    mono_f := by
+      dsimp [diskSevenFalseRangeRelativeShortComplex]
+      infer_instance
+    epi_g := by
+      dsimp [diskSevenFalseRangeRelativeShortComplex,
+        diskSevenFalseRangeRelativeProjection]
+      constructor
+      intro Z g h w
+      exact Cofork.IsColimit.hom_ext
+        (cokernelIsCokernel diskBoundaryToDiskSevenFalseRangeChains) w }
+
+/-- The false-range relative chain complex is acyclic in every degree. -/
+public theorem diskSevenFalseRangeRelativeChainComplex_acyclic :
+    DiskSevenFalseRangeRelativeChainComplex.Acyclic := by
+  have hq : QuasiIso diskSevenFalseRangeRelativeShortComplex.f := by
+    exact diskBoundaryToDiskSevenFalseRangeChains_quasiIso
+  exact diskSevenFalseRangeRelativeShortComplex_shortExact.acyclic_X₃ hq
+
+/-- Consequently every homology object of the false-range relative complex vanishes. -/
+public theorem diskSevenFalseRangeRelativeChainComplex_homology_isZero (k : ℕ) :
+    IsZero (DiskSevenFalseRangeRelativeChainComplex.homology k) := by
+  rw [← HomologicalComplex.exactAt_iff_isZero_homology]
+  exact diskSevenFalseRangeRelativeChainComplex_acyclic k
+
+/-- Homology of the local relative middle complex is the biproduct of the homologies of its two
+summands. -/
+public noncomputable def diskSevenCoverLocalRelativeMiddleHomologyIso (k : ℕ) :
+    DiskSevenCoverLocalRelativeMiddleChainComplex.homology k ≅
+      (DiskSevenCoverRangeChainComplex true).homology k ⊞
+        DiskSevenFalseRangeRelativeChainComplex.homology k :=
+  by
+    let F := HomologicalComplex.homologyFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) k
+    letI : F.Additive := inferInstance
+    letI : PreservesFiniteBiproducts F := inferInstance
+    letI : PreservesBinaryBiproducts F :=
+      preservesBinaryBiproducts_of_preservesBiproducts F
+    exact F.mapBiprod _ _
+
+/-- The local relative middle homology vanishes in every positive degree. -/
+public theorem diskSevenCoverLocalRelativeMiddle_homology_isZero
+    (k : ℕ) (hk : k ≠ 0) :
+    IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology k) := by
+  have hsum : IsZero
+      ((DiskSevenCoverRangeChainComplex true).homology k ⊞
+        DiskSevenFalseRangeRelativeChainComplex.homology k) :=
+    (biprod_isZero_iff _ _).2
+      ⟨diskSevenCoverTrueRange_homology_isZero k hk,
+        diskSevenFalseRangeRelativeChainComplex_homology_isZero k⟩
+  exact hsum.of_iso (diskSevenCoverLocalRelativeMiddleHomologyIso k)
+
+/-- The two middle homology objects needed by local relative Mayer--Vietoris vanish. -/
+public theorem diskSevenCoverLocalRelativeMiddle_low_isZero :
+    IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 3) ∧
+      IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 4) :=
+  ⟨diskSevenCoverLocalRelativeMiddle_homology_isZero 3 (by omega),
+    diskSevenCoverLocalRelativeMiddle_homology_isZero 4 (by omega)⟩
+
+/-! ## The range intersection -/
+
+/-- Forgetting the false-member condition includes the punctured interior in the true member. -/
+public noncomputable def diskSevenIntersectionToTrue :
+    TopCat.of DiskSevenCoverIntersection ⟶
+      TopCat.of (diskSevenExcisionCover true) :=
+  TopCat.ofHom ⟨fun x ↦ ⟨x.1, x.2.1⟩,
+    continuous_subtype_val.subtype_mk _⟩
+
+/-- Direct inclusion of the punctured interior in the ambient disk. -/
+public noncomputable def diskSevenCoverIntersectionToDisk :
+    TopCat.of DiskSevenCoverIntersection ⟶ TopCat.disk.{0} 7 :=
+  topologicalSubsetInclusion (TopCat.disk.{0} 7)
+    (diskSevenExcisionCover true ∩ diskSevenExcisionCover false)
+
+@[reassoc (attr := simp)]
+public theorem diskSevenIntersectionToTrue_comp_disk :
+    diskSevenIntersectionToTrue ≫
+        topologicalSubsetInclusion (TopCat.disk.{0} 7)
+          (diskSevenExcisionCover true) =
+      diskSevenCoverIntersectionToDisk := by
+  rfl
+
+@[reassoc (attr := simp)]
+public theorem diskSevenIntersectionToFalse_comp_disk :
+    diskSevenIntersectionToFalse ≫
+        topologicalSubsetInclusion (TopCat.disk.{0} 7)
+          (diskSevenExcisionCover false) =
+      diskSevenCoverIntersectionToDisk := by
+  rfl
+
+/-- Singular simplices of the punctured interior land in both member ranges. -/
+public theorem diskSevenCoverIntersection_range_le_rangeIntersection :
+    SSet.Subcomplex.range
+        (TopCat.toSSet.map diskSevenCoverIntersectionToDisk) ≤
+      diskSevenCoverRangeIntersectionSubcomplex := by
+  apply le_inf
+  · rw [← diskSevenIntersectionToTrue_comp_disk,
+      Functor.map_comp]
+    exact Subfunctor.range_comp_le _ _
+  · rw [← diskSevenIntersectionToFalse_comp_disk,
+      Functor.map_comp]
+    exact Subfunctor.range_comp_le _ _
+
+/-- The singular simplicial set of the punctured interior, lifted to the intersection of the two
+member ranges. -/
+public noncomputable def diskSevenCoverIntersectionToRangeIntersectionSingularSet :
+    TopCat.toSSet.obj (TopCat.of DiskSevenCoverIntersection) ⟶
+      (diskSevenCoverRangeIntersectionSubcomplex : SSet) :=
+  SSet.Subcomplex.lift (TopCat.toSSet.map diskSevenCoverIntersectionToDisk)
+    diskSevenCoverIntersection_range_le_rangeIntersection
+
+/-- Direct inclusion of the punctured interior is a monomorphism. -/
+public instance diskSevenCoverIntersectionToDisk_mono :
+    Mono diskSevenCoverIntersectionToDisk := by
+  rw [TopCat.mono_iff_injective]
+  exact Subtype.val_injective
+
+/-- Its lift to the intersection range remains a monomorphism. -/
+public instance diskSevenCoverIntersectionToRangeIntersectionSingularSet_mono :
+    Mono diskSevenCoverIntersectionToRangeIntersectionSingularSet := by
+  apply mono_of_mono_fac
+    (SSet.Subcomplex.lift_ι
+      (TopCat.toSSet.map diskSevenCoverIntersectionToDisk)
+      diskSevenCoverIntersection_range_le_rangeIntersection)
+
+/-- Every simplex in both member ranges has a unique lift to the punctured interior. -/
+public theorem diskSevenCoverIntersectionToRangeIntersection_app_surjective
+    (n : SimplexCategoryᵒᵖ) :
+    Function.Surjective
+      (diskSevenCoverIntersectionToRangeIntersectionSingularSet.app n) := by
+  intro z
+  have hz := z.2
+  change
+    z.1 ∈ (diskSevenCoverRangeSubcomplex true).obj n ∧
+      z.1 ∈ (diskSevenCoverRangeSubcomplex false).obj n at hz
+  rcases hz with ⟨hzTrue, hzFalse⟩
+  change z.1 ∈ (SSet.Subcomplex.range
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover true)))).obj n at hzTrue
+  change z.1 ∈ (SSet.Subcomplex.range
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover false)))).obj n at hzFalse
+  rw [Subfunctor.range_obj] at hzTrue hzFalse
+  obtain ⟨yTrue, hyTrue⟩ := hzTrue
+  obtain ⟨yFalse, hyFalse⟩ := hzFalse
+  let fTrue := (TopCat.of (diskSevenExcisionCover true)).toSSetObjEquiv n yTrue
+  let fFalse := (TopCat.of (diskSevenExcisionCover false)).toSSetObjEquiv n yFalse
+  have hpoint (p : stdSimplex ℝ (Fin (n.unop.len + 1))) :
+      (fTrue p).1 = (fFalse p).1 := by
+    have h := congrArg (fun q ↦
+      (TopCat.disk.{0} 7).toSSetObjEquiv n q p)
+        (hyTrue.trans hyFalse.symm)
+    exact h
+  let f : C(stdSimplex ℝ (Fin (n.unop.len + 1)),
+      DiskSevenCoverIntersection) :=
+    ⟨fun p ↦ ⟨(fTrue p).1, ⟨(fTrue p).2, by
+        rw [hpoint p]
+        exact (fFalse p).2⟩⟩,
+      (continuous_subtype_val.comp fTrue.continuous).subtype_mk _⟩
+  let y := (TopCat.of DiskSevenCoverIntersection).toSSetObjEquiv n |>.symm f
+  refine ⟨y, ?_⟩
+  apply Subtype.ext
+  change (TopCat.toSSet.map diskSevenCoverIntersectionToDisk).app n y = z.1
+  rw [← hyTrue]
+  apply (TopCat.disk.{0} 7).toSSetObjEquiv n |>.injective
+  ext p
+  rfl
+
+/-- The lift from punctured-interior singular simplices onto the range intersection is epi. -/
+public instance diskSevenCoverIntersectionToRangeIntersectionSingularSet_epi :
+    Epi diskSevenCoverIntersectionToRangeIntersectionSingularSet := by
+  rw [NatTrans.epi_iff_epi_app]
+  intro n
+  rw [CategoryTheory.epi_iff_surjective]
+  exact diskSevenCoverIntersectionToRangeIntersection_app_surjective n
+
+/-- Hence the lift is an isomorphism of simplicial sets. -/
+public instance diskSevenCoverIntersectionToRangeIntersectionSingularSet_isIso :
+    IsIso diskSevenCoverIntersectionToRangeIntersectionSingularSet :=
+  isIso_of_mono_of_epi _
+
+/-- The singular simplicial set of the punctured interior is exactly the infimum of the two
+member ranges. -/
+public noncomputable def diskSevenCoverIntersectionRangeSingularSetIso :
+    TopCat.toSSet.obj (TopCat.of DiskSevenCoverIntersection) ≅
+      (diskSevenCoverRangeIntersectionSubcomplex : SSet) :=
+  asIso diskSevenCoverIntersectionToRangeIntersectionSingularSet
+
+/-- The resulting integral singular-chain isomorphism. -/
+public noncomputable def diskSevenCoverIntersectionRangeChainsIso :
+    IntegralSingularChainComplexObj (TopCat.of DiskSevenCoverIntersection) ≅
+      DiskSevenCoverRangeIntersectionChainComplex :=
+  ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).mapIso
+    diskSevenCoverIntersectionRangeSingularSetIso
+
+/-- Homology of the range intersection is homology of the actual punctured interior. -/
+public noncomputable def diskSevenCoverIntersectionRangeHomologyIso (k : ℕ) :
+    (IntegralSingularChainComplexObj
+        (TopCat.of DiskSevenCoverIntersection)).homology k ≅
+      DiskSevenCoverRangeIntersectionChainComplex.homology k :=
+  (HomologicalComplex.homologyFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) k).mapIso diskSevenCoverIntersectionRangeChainsIso
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Combining the range identification with radial normalization identifies intersection-range
+homology with the integral singular homology of the standard six-sphere. -/
+public noncomputable def diskSevenCoverRangeIntersectionHomologyIsoSphereSix (k : ℕ) :
+    DiskSevenCoverRangeIntersectionChainComplex.homology k ≅
+      (IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology k :=
+  (diskSevenCoverIntersectionRangeHomologyIso k).symm ≪≫
+    integralSingularHomologyIsoOfHomotopyEquiv k
+      diskSevenCoverIntersectionHomotopyEquivSphereSix
+
+/-- Vanishing of range-intersection homology is exactly vanishing of standard-sphere homology. -/
+public theorem diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix
+    (k : ℕ) :
+    IsZero (DiskSevenCoverRangeIntersectionChainComplex.homology k) ↔
+      IsZero ((IntegralSingularChainComplexObj
+        (TopCat.sphere.{0} 6)).homology k) :=
+  (diskSevenCoverRangeIntersectionHomologyIsoSphereSix k).isZero_iff
+
+/-- The entire local acyclicity obligation now consists precisely of the two standard-sphere
+homology groups in degrees two and three: the local middle terms have vanished unconditionally. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_iff_sphereSix_low_isZero :
+    DiskSevenCoverLocalRelativeLowAcyclic ↔
+      IsZero ((IntegralSingularChainComplexObj
+        (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj
+        (TopCat.sphere.{0} 6)).homology 3) := by
+  constructor
+  · intro h
+    exact
+      ⟨(diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 2).mp
+          h.2.2.1,
+        (diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 3).mp
+          h.2.2.2⟩
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨diskSevenCoverLocalRelativeMiddle_low_isZero.1,
+        diskSevenCoverLocalRelativeMiddle_low_isZero.2,
+        (diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 2).mpr h₂,
+        (diskSevenCoverRangeIntersection_homology_isZero_iff_sphereSix 3).mpr h₃⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyLow.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyLow.lean
@@ -1,0 +1,251 @@
+module
+
+public import SphereSixComplex.Topology.SingularExcisionOpenCover
+public import Mathlib.Algebra.Homology.HomologySequenceLemmas
+
+/-!
+# Low-degree relative homology of the seven-disk
+
+This file replaces the full singular chains of the seven-disk by chains subordinate to the
+concrete two-set excision cover.  The replacement remains valid after quotienting by the boundary
+chains: this follows formally from the unconditional small-chain approximation and the long
+exact homology sequences of the two cokernel complexes.
+
+The remaining geometric calculation is thereby isolated as acyclicity in degrees three and four
+of one explicit cover-small relative chain complex.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- The literal identification `S⁶ = ∂D⁷`, transported to integral singular chains. -/
+public noncomputable def sphereSixChainsIsoDiskBoundarySevenChains :
+    IntegralSingularChainComplexObj (TopCat.sphere 6) ≅
+      IntegralSingularChainComplexObj (TopCat.diskBoundary 7) := by
+  let F := (singularChainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  exact F.mapIso (eqToIso topCatSphereSix_eq_diskBoundarySeven)
+
+public theorem sphereSixChainsIsoDiskBoundarySevenChains_hom_comp_boundary :
+    sphereSixChainsIsoDiskBoundarySevenChains.hom ≫
+        integralSingularChainMapObj (TopCat.diskBoundaryInclusion 7) =
+      diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+        diskSevenCoverSmallIntegralSingularChainInclusion := by
+  rw [diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_comp_inclusion]
+  dsimp [sphereSixChainsIsoDiskBoundarySevenChains,
+    integralSingularChainMapObj]
+  rw [← Functor.map_comp]
+  apply Functor.congr_map
+  ext x
+  rfl
+
+public theorem sphereSixChainsIsoDiskBoundarySevenChains_hom_quasiIso :
+    QuasiIso sphereSixChainsIsoDiskBoundarySevenChains.hom := by
+  rw [quasiIso_iff]
+  intro n
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  infer_instance
+
+/-- Cover-small disk chains modulo the boundary chains. -/
+public noncomputable def DiskSevenCoverSmallRelativeIntegralSingularChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  cokernel diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+
+/-- The quotient map from cover-small disk chains to the cover-small relative complex. -/
+public noncomputable def diskSevenCoverSmallRelativeChainProjection :
+    DiskSevenCoverSmallIntegralSingularChainComplex ⟶
+      DiskSevenCoverSmallRelativeIntegralSingularChainComplex :=
+  cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+
+/-- The boundary-to-small-chain map is mono, since its composite with the small-chain inclusion
+is the ordinary boundary inclusion on singular chains. -/
+public instance diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_mono :
+    Mono diskBoundaryToDiskSevenCoverSmallIntegralSingularChains := by
+  let _ : Mono (diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+      diskSevenCoverSmallIntegralSingularChainInclusion) := by
+    rw [diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_comp_inclusion]
+    exact diskSevenSphereSix_relativeIntegralSingularShortComplex_shortExact.mono_f
+  exact mono_of_mono diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+    diskSevenCoverSmallIntegralSingularChainInclusion
+
+/-- The short exact sequence defining cover-small relative chains. -/
+public noncomputable def diskSevenCoverSmallRelativeShortComplex :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  ShortComplex.mk diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+    diskSevenCoverSmallRelativeChainProjection
+    (cokernel.condition diskBoundaryToDiskSevenCoverSmallIntegralSingularChains)
+
+public theorem diskSevenCoverSmallRelativeShortComplex_shortExact :
+    diskSevenCoverSmallRelativeShortComplex.ShortExact := by
+  dsimp [diskSevenCoverSmallRelativeShortComplex,
+    diskSevenCoverSmallRelativeChainProjection]
+  exact
+    { exact := ShortComplex.exact_cokernel
+        diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+      mono_f := by
+        change Mono diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+        infer_instance
+      epi_g := by
+        change Epi (cokernel.π
+          diskBoundaryToDiskSevenCoverSmallIntegralSingularChains)
+        infer_instance }
+
+/-- The inclusion of cover-small disk chains induces the canonical map from the cover-small
+relative complex to the ordinary relative complex of `(D⁷,S⁶)`. -/
+public noncomputable def diskSevenCoverSmallRelativeChainComparison :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex ⟶
+      DiskSevenSphereSixRelativeIntegralSingularChainComplex :=
+  cokernel.map diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+    (integralSingularChainMapObj (TopCat.diskBoundaryInclusion 7))
+    sphereSixChainsIsoDiskBoundarySevenChains.hom
+      diskSevenCoverSmallIntegralSingularChainInclusion
+      sphereSixChainsIsoDiskBoundarySevenChains_hom_comp_boundary.symm
+
+@[reassoc (attr := simp)]
+public theorem diskSevenCoverSmallRelativeChainProjection_comp_comparison :
+    diskSevenCoverSmallRelativeChainProjection ≫
+        diskSevenCoverSmallRelativeChainComparison =
+      diskSevenCoverSmallIntegralSingularChainInclusion ≫
+        relativeIntegralSingularChainProjection
+          (TopCat.diskBoundaryInclusion 7) := by
+  change cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+      cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+        (diskSevenCoverSmallIntegralSingularChainInclusion ≫
+          cokernel.π (integralSingularChainMapObj
+            (TopCat.diskBoundaryInclusion 7))) _ =
+    diskSevenCoverSmallIntegralSingularChainInclusion ≫
+      cokernel.π (integralSingularChainMapObj
+        (TopCat.diskBoundaryInclusion 7))
+  exact cokernel.π_desc _ _ _
+
+/-- The defining short exact sequence for cover-small relative chains maps to the usual relative
+singular-chain short exact sequence. -/
+public noncomputable def diskSevenCoverSmallRelativeShortComplexComparison :
+    diskSevenCoverSmallRelativeShortComplex ⟶
+      relativeIntegralSingularShortComplex (TopCat.diskBoundaryInclusion 7) where
+  τ₁ := sphereSixChainsIsoDiskBoundarySevenChains.hom
+  τ₂ := diskSevenCoverSmallIntegralSingularChainInclusion
+  τ₃ := diskSevenCoverSmallRelativeChainComparison
+  comm₁₂ := by
+    exact sphereSixChainsIsoDiskBoundarySevenChains_hom_comp_boundary
+  comm₂₃ := diskSevenCoverSmallRelativeChainProjection_comp_comparison.symm
+
+/-- The unconditional small-chain approximation makes the inclusion of cover-small disk chains
+a quasi-isomorphism. -/
+public theorem diskSevenCoverSmallIntegralSingularChainInclusion_quasiIso :
+    QuasiIso diskSevenCoverSmallIntegralSingularChainInclusion := by
+  change QuasiIso (coverSmallIntegralSingularChainInclusion
+    (TopCat.disk.{0} 7) diskSevenExcisionCover)
+  rw [← coverSmallChainHomotopyEquiv_hom
+    (TopCat.disk.{0} 7) diskSevenExcisionCover diskSevenSmallChainApproximation]
+  infer_instance
+
+/-- Quotienting by the unchanged boundary complex preserves the small-chain quasi-isomorphism.
+This is the formal excision reduction supplied by the two long exact homology sequences. -/
+public theorem diskSevenCoverSmallRelativeChainComparison_quasiIso :
+    QuasiIso diskSevenCoverSmallRelativeChainComparison := by
+  apply HomologicalComplex.HomologySequence.quasiIso_τ₃
+    diskSevenCoverSmallRelativeShortComplexComparison
+    diskSevenCoverSmallRelativeShortComplex_shortExact
+    diskSevenSphereSix_relativeIntegralSingularShortComplex_shortExact
+  · dsimp [diskSevenCoverSmallRelativeShortComplexComparison]
+    exact sphereSixChainsIsoDiskBoundarySevenChains_hom_quasiIso
+  · dsimp [diskSevenCoverSmallRelativeShortComplexComparison]
+    exact diskSevenCoverSmallIntegralSingularChainInclusion_quasiIso
+
+/-- Cover-small relative homology computes the usual relative homology of `(D⁷,S⁶)`. -/
+public noncomputable def diskSevenCoverSmallRelativeHomologyIso (n : ℕ) :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology n ≅
+      DiskSevenSphereSixRelativeIntegralSingularChainComplex.homology n := by
+  let _ : QuasiIso diskSevenCoverSmallRelativeChainComparison :=
+    diskSevenCoverSmallRelativeChainComparison_quasiIso
+  exact isoOfQuasiIsoAt diskSevenCoverSmallRelativeChainComparison n
+
+/-- In every positive sphere degree, cover-small relative homology in the next degree is the
+integral singular homology of the standard sphere. -/
+public noncomputable def diskSevenCoverSmallRelativeBoundaryIso
+    (n : ℕ) (hn : n ≠ 0) :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology (n + 1) ≅
+      (IntegralSingularChainComplexObj (TopCat.diskBoundary 7)).homology n :=
+  diskSevenCoverSmallRelativeHomologyIso (n + 1) ≪≫
+    diskSevenSphereSix_relativeBoundaryIso n hn
+
+/-- The same boundary isomorphism, with the target written as the standard categorical sphere
+rather than the definitionally identified disk boundary. -/
+public noncomputable def diskSevenCoverSmallRelativeStandardSphereBoundaryIso
+    (n : ℕ) (hn : n ≠ 0) :
+    DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology (n + 1) ≅
+      (IntegralSingularChainComplexObj (TopCat.sphere 6)).homology n :=
+  diskSevenCoverSmallRelativeBoundaryIso n hn ≪≫
+    (HomologicalComplex.homologyMapIso
+      sphereSixChainsIsoDiskBoundarySevenChains n).symm
+
+/-- The exact remaining low-degree chain calculation. -/
+public def DiskSevenCoverSmallRelativeLowAcyclic : Prop :=
+  IsZero (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 3) ∧
+    IsZero (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 4)
+
+/-- Acyclicity of the explicit cover-small relative complex in degree three gives `H₂(S⁶;ℤ)=0`.
+-/
+public theorem topCatSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 3)) :
+    IsZero ((IntegralSingularChainComplexObj
+      (TopCat.diskBoundary 7)).homology 2) :=
+  h.of_iso (diskSevenCoverSmallRelativeBoundaryIso 2 (by omega)).symm
+
+/-- Acyclicity of the explicit cover-small relative complex in degree four gives `H₃(S⁶;ℤ)=0`.
+-/
+public theorem topCatSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 4)) :
+    IsZero ((IntegralSingularChainComplexObj
+      (TopCat.diskBoundary 7)).homology 3) :=
+  h.of_iso (diskSevenCoverSmallRelativeBoundaryIso 3 (by omega)).symm
+
+/-- The two concrete cover-small calculations imply both required low-degree vanishings. -/
+public theorem topCatSphereSix_integralSingularHomology_low_isZero_of_coverSmallRelative
+    (h : DiskSevenCoverSmallRelativeLowAcyclic) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.diskBoundary 7)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.diskBoundary 7)).homology 3) :=
+  ⟨topCatSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative h.1,
+    topCatSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative h.2⟩
+
+/-- Degree-two vanishing, stated directly for `TopCat.sphere 6`. -/
+public theorem standardSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 3)) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) :=
+  h.of_iso
+    (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 2 (by omega)).symm
+
+/-- Degree-three vanishing, stated directly for `TopCat.sphere 6`. -/
+public theorem standardSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative
+    (h : IsZero
+      (DiskSevenCoverSmallRelativeIntegralSingularChainComplex.homology 4)) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) :=
+  h.of_iso
+    (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 3 (by omega)).symm
+
+/-- Thus the two remaining cover-small relative calculations are exactly equivalent to the two
+desired standard-sphere vanishings; the small-chain and long-exact-sequence reductions lose no
+information. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_iff_standardSphereSix_low_isZero :
+    DiskSevenCoverSmallRelativeLowAcyclic ↔
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+        IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) := by
+  constructor
+  · intro h
+    exact
+      ⟨standardSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative h.1,
+        standardSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative h.2⟩
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨h₂.of_iso (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 2 (by omega)),
+        h₃.of_iso (diskSevenCoverSmallRelativeStandardSphereBoundaryIso 3 (by omega))⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
@@ -1,0 +1,680 @@
+module
+
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLow
+public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits
+public import Mathlib.CategoryTheory.Abelian.CommSq
+public import Mathlib.CategoryTheory.Adjunction.Limits
+public import Mathlib.CategoryTheory.Limits.Preserves.SigmaConst
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Pasting
+
+/-!
+# A local Mayer--Vietoris reduction for the seven-disk pair
+
+This file decomposes the concrete cover-small relative complex into the two range subcomplexes of
+the disk cover.  It proves the resulting relative Mayer--Vietoris sequence short exact from
+pushout squares, leaving only acyclicity of explicit local and intersection complexes in the
+low-degree calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set
+
+namespace SphereSixComplex
+
+/-- A concrete chain-contraction identity at one positive degree. -/
+public structure ChainContractionAt
+    (K : ChainComplex AddCommGrpCat ℕ) (n : ℕ) where
+  upper : K.X n ⟶ K.X (n + 1)
+  lower : K.X (n - 1) ⟶ K.X n
+  identity : upper ≫ K.d (n + 1) n + K.d n (n - 1) ≫ lower = 𝟙 _
+
+/-- A contraction identity makes every cycle in that degree an explicit boundary. -/
+public theorem ChainContractionAt.exactAt
+    {K : ChainComplex AddCommGrpCat ℕ} {n : ℕ} (h : ChainContractionAt K n)
+    (hn : n ≠ 0) : K.ExactAt n := by
+  rw [K.exactAt_iff' (i := n + 1) (j := n) (k := n - 1)
+    (ChainComplex.prev ℕ n)
+    ((ComplexShape.down ℕ).next_eq'
+      (ComplexShape.down_mk n (n - 1) (by omega)))]
+  rw [ShortComplex.ab_exact_iff_function_exact]
+  change Function.Exact (K.d (n + 1) n).hom (K.d n (n - 1)).hom
+  intro x
+  constructor
+  · intro hx
+    refine ⟨h.upper x, ?_⟩
+    have hid := ConcreteCategory.congr_hom h.identity x
+    simp only [AddCommGrpCat.hom_add_apply, ConcreteCategory.comp_apply, hx,
+      map_zero, add_zero, CategoryTheory.ConcreteCategory.id_apply] at hid
+    exact hid
+  · rintro ⟨y, rfl⟩
+    exact ConcreteCategory.congr_hom (K.d_comp_d (n + 1) n (n - 1)) y
+
+/-- A contraction identity implies vanishing of homology in that degree. -/
+public theorem ChainContractionAt.isZero_homology
+    {K : ChainComplex AddCommGrpCat ℕ} {n : ℕ} (h : ChainContractionAt K n)
+    (hn : n ≠ 0) : IsZero (K.homology n) :=
+  (h.exactAt hn).isZero_homology
+
+/-- The singular subcomplex consisting of simplices coming from one member of the concrete disk
+cover. -/
+public noncomputable def diskSevenCoverRangeSubcomplex (b : Bool) :
+    (TopCat.toSSet.obj (TopCat.disk.{0} 7)).Subcomplex :=
+  SSet.Subcomplex.range (TopCat.toSSet.map
+    (topologicalSubsetInclusion (TopCat.disk.{0} 7) (diskSevenExcisionCover b)))
+
+/-- The intersection of the two range subcomplexes. -/
+public noncomputable def diskSevenCoverRangeIntersectionSubcomplex :
+    (TopCat.toSSet.obj (TopCat.disk.{0} 7)).Subcomplex :=
+  diskSevenCoverRangeSubcomplex true ⊓ diskSevenCoverRangeSubcomplex false
+
+/-- The intersection, the two cover-member ranges, and the cover-small subcomplex form the
+tautological bicartesian square in the lattice of subcomplexes. -/
+public theorem diskSevenCoverRangeSubcomplex_bicartSq :
+    SSet.Subcomplex.BicartSq
+      diskSevenCoverRangeIntersectionSubcomplex
+      (diskSevenCoverRangeSubcomplex true)
+      (diskSevenCoverRangeSubcomplex false)
+      (coverSmallSingularSubcomplex (TopCat.disk.{0} 7)
+        diskSevenExcisionCover) := by
+  constructor
+  · simpa [diskSevenCoverRangeSubcomplex,
+      coverSmallSingularSubcomplex] using
+      (iSup_bool_eq (f := fun b ↦ SSet.Subcomplex.range (TopCat.toSSet.map
+        (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+          (diskSevenExcisionCover b))))).symm
+  · rfl
+
+/-- Integral chains on one range subcomplex. -/
+public noncomputable abbrev DiskSevenCoverRangeChainComplex (b : Bool) :
+    ChainComplex AddCommGrpCat ℕ :=
+  (diskSevenCoverRangeSubcomplex b : SSet).chainComplex (AddCommGrpCat.of ℤ)
+
+/-- Integral chains on the intersection of the two range subcomplexes. -/
+public noncomputable abbrev DiskSevenCoverRangeIntersectionChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  (diskSevenCoverRangeIntersectionSubcomplex : SSet).chainComplex
+    (AddCommGrpCat.of ℤ)
+
+/-- A member range is contained in the cover-small singular subcomplex. -/
+public theorem diskSevenCoverRangeSubcomplex_le_coverSmall (b : Bool) :
+    diskSevenCoverRangeSubcomplex b ≤
+      coverSmallSingularSubcomplex (TopCat.disk.{0} 7) diskSevenExcisionCover := by
+  exact le_iSup (fun c ↦ SSet.Subcomplex.range (TopCat.toSSet.map
+    (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover c)))) b
+
+/-- Inclusion of one member range into cover-small simplices. -/
+public noncomputable def diskSevenCoverRangeToSmallSingularSet (b : Bool) :
+    (diskSevenCoverRangeSubcomplex b : SSet) ⟶
+      coverSmallSingularSubcomplex (TopCat.disk.{0} 7) diskSevenExcisionCover :=
+  SSet.Subcomplex.homOfLE (diskSevenCoverRangeSubcomplex_le_coverSmall b)
+
+/-- The induced inclusion on chains. -/
+public noncomputable def diskSevenCoverRangeToSmallChains (b : Bool) :
+    DiskSevenCoverRangeChainComplex b ⟶
+      DiskSevenCoverSmallIntegralSingularChainComplex :=
+  SSet.chainComplexMap (diskSevenCoverRangeToSmallSingularSet b)
+    (AddCommGrpCat.of ℤ)
+
+/-- The intersection includes into either member range. -/
+public noncomputable def diskSevenCoverRangeIntersectionToRangeSingularSet (b : Bool) :
+    (diskSevenCoverRangeIntersectionSubcomplex : SSet) ⟶
+      (diskSevenCoverRangeSubcomplex b : SSet) :=
+  match b with
+  | true => SSet.Subcomplex.homOfLE inf_le_left
+  | false => SSet.Subcomplex.homOfLE inf_le_right
+
+/-- The intersection inclusion on chains. -/
+public noncomputable def diskSevenCoverRangeIntersectionToRangeChains (b : Bool) :
+    DiskSevenCoverRangeIntersectionChainComplex ⟶
+      DiskSevenCoverRangeChainComplex b :=
+  SSet.chainComplexMap (diskSevenCoverRangeIntersectionToRangeSingularSet b)
+    (AddCommGrpCat.of ℤ)
+
+/-- The two range inclusions form a pushout square of simplicial sets. -/
+public theorem diskSevenCoverRangeSingularSet_isPushout :
+    IsPushout
+      (diskSevenCoverRangeIntersectionToRangeSingularSet true)
+      (diskSevenCoverRangeIntersectionToRangeSingularSet false)
+      (diskSevenCoverRangeToSmallSingularSet true)
+      (diskSevenCoverRangeToSmallSingularSet false) := by
+  simpa [diskSevenCoverRangeIntersectionToRangeSingularSet,
+    diskSevenCoverRangeToSmallSingularSet] using
+    diskSevenCoverRangeSubcomplex_bicartSq.isPushout
+
+/-- Both routes from the intersection to cover-small chains agree. -/
+public theorem diskSevenCoverRangeIntersectionToSmallChains_eq :
+    diskSevenCoverRangeIntersectionToRangeChains true ≫
+        diskSevenCoverRangeToSmallChains true =
+      diskSevenCoverRangeIntersectionToRangeChains false ≫
+        diskSevenCoverRangeToSmallChains false := by
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeIntersectionToRangeSingularSet true) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeToSmallSingularSet true) =
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeIntersectionToRangeSingularSet false) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeToSmallSingularSet false)
+  rw [← Functor.map_comp, ← Functor.map_comp]
+  apply Functor.congr_map
+  ext n x
+  apply Subtype.ext
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Integral simplicial chains preserve the preceding pushout square. -/
+public theorem diskSevenCoverRangeChains_isPushout :
+    IsPushout
+      (diskSevenCoverRangeIntersectionToRangeChains true)
+      (diskSevenCoverRangeIntersectionToRangeChains false)
+      (diskSevenCoverRangeToSmallChains true)
+      (diskSevenCoverRangeToSmallChains false) := by
+  have hdegree (n : ℕ) : IsPushout
+      ((diskSevenCoverRangeIntersectionToRangeChains true).f n)
+      ((diskSevenCoverRangeIntersectionToRangeChains false).f n)
+      ((diskSevenCoverRangeToSmallChains true).f n)
+      ((diskSevenCoverRangeToSmallChains false).f n) := by
+    have hType := diskSevenCoverRangeSingularSet_isPushout.map
+      ((evaluation SimplexCategoryᵒᵖ Type).obj (Opposite.op (SimplexCategory.mk n)))
+    have hAb := hType.map (sigmaConst.obj (AddCommGrpCat.of ℤ))
+    simpa [diskSevenCoverRangeIntersectionToRangeChains,
+      diskSevenCoverRangeToSmallChains, SSet.chainComplexMap,
+      SSet.chainComplexFunctor, SimplicialObject.whiskering,
+      AlgebraicTopology.alternatingFaceMapComplex,
+      AlgebraicTopology.AlternatingFaceMapComplex.map] using hAb
+  refine ⟨⟨diskSevenCoverRangeIntersectionToSmallChains_eq⟩,
+    ⟨PushoutCocone.IsColimit.mk _ ?_ ?_ ?_ ?_⟩⟩
+  · intro s
+    exact
+      { f := fun n ↦ (hdegree n).desc (s.inl.f n) (s.inr.f n)
+          (HomologicalComplex.congr_hom s.condition n)
+        comm' := by
+          intro i j _
+          apply (hdegree i).hom_ext
+          · simp
+          · simp }
+  · intro s
+    apply HomologicalComplex.Hom.ext
+    funext n
+    exact (hdegree n).inl_desc _ _ _
+  · intro s
+    apply HomologicalComplex.Hom.ext
+    funext n
+    exact (hdegree n).inr_desc _ _ _
+  · intro s m hm₁ hm₂
+    apply HomologicalComplex.Hom.ext
+    funext n
+    apply (hdegree n).hom_ext
+    · rw [(hdegree n).inl_desc]
+      exact HomologicalComplex.congr_hom hm₁ n
+    · rw [(hdegree n).inr_desc]
+      exact HomologicalComplex.congr_hom hm₂ n
+
+/-- The singular set of a cover member, lifted to its range subcomplex. -/
+public noncomputable def diskSevenCoverMemberToRangeSingularSet (b : Bool) :
+    TopCat.toSSet.obj (TopCat.of (diskSevenExcisionCover b)) ⟶
+      (diskSevenCoverRangeSubcomplex b : SSet) :=
+  SSet.Subcomplex.lift
+    (TopCat.toSSet.map (topologicalSubsetInclusion (TopCat.disk.{0} 7)
+      (diskSevenExcisionCover b))) le_rfl
+
+/-- Lifting a cover member first to its range and then to the cover-small subcomplex is the
+canonical cover-member lift. -/
+public theorem diskSevenCoverMemberToRange_comp_small (b : Bool) :
+    diskSevenCoverMemberToRangeSingularSet b ≫
+        diskSevenCoverRangeToSmallSingularSet b =
+      coverMemberToSmallSingularSet
+        (TopCat.disk.{0} 7) diskSevenExcisionCover b := by
+  ext n x
+  apply Subtype.ext
+  rfl
+
+/-- The boundary chain map lifted specifically to the `false` member range. -/
+public noncomputable def diskBoundaryToDiskSevenFalseRangeChains :
+    IntegralSingularChainComplexObj (TopCat.sphere.{0} 6) ⟶
+      DiskSevenCoverRangeChainComplex false :=
+  SSet.chainComplexMap
+      (TopCat.toSSet.map diskBoundaryToDiskSevenExcisionCoverFalse)
+      (AddCommGrpCat.of ℤ) ≫
+    SSet.chainComplexMap (diskSevenCoverMemberToRangeSingularSet false)
+      (AddCommGrpCat.of ℤ)
+
+set_option backward.isDefEq.respectTransparency false
+/-- The boundary-to-small map factors through the false member range. -/
+public theorem diskBoundaryToDiskSevenFalseRangeChains_comp_small :
+    diskBoundaryToDiskSevenFalseRangeChains ≫
+        diskSevenCoverRangeToSmallChains false =
+      diskBoundaryToDiskSevenCoverSmallIntegralSingularChains := by
+  rw [diskBoundaryToDiskSevenFalseRangeChains,
+    diskBoundaryToDiskSevenCoverSmallIntegralSingularChains,
+    diskSevenCoverRangeToSmallChains,
+    coverMemberToSmallIntegralSingularChains,
+    integralSingularChainMapObj,
+    Category.assoc]
+  congr 1
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverMemberToRangeSingularSet false) ≫
+        ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (diskSevenCoverRangeToSmallSingularSet false) =
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+        (coverMemberToSmallSingularSet
+          (TopCat.disk.{0} 7) diskSevenExcisionCover false)
+  rw [← Functor.map_comp, diskSevenCoverMemberToRange_comp_small]
+set_option backward.isDefEq.respectTransparency true
+
+/-- The false range modulo boundary chains. -/
+public noncomputable def DiskSevenFalseRangeRelativeChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  cokernel diskBoundaryToDiskSevenFalseRangeChains
+
+/-- Projection to the false-range relative complex. -/
+public noncomputable def diskSevenFalseRangeRelativeProjection :
+    DiskSevenCoverRangeChainComplex false ⟶
+      DiskSevenFalseRangeRelativeChainComplex :=
+  cokernel.π diskBoundaryToDiskSevenFalseRangeChains
+
+/-- The false-range relative complex maps canonically to the cover-small relative complex. -/
+public noncomputable def diskSevenFalseRangeRelativeToCoverSmallRelative :
+    DiskSevenFalseRangeRelativeChainComplex ⟶
+      DiskSevenCoverSmallRelativeIntegralSingularChainComplex :=
+  cokernel.map diskBoundaryToDiskSevenFalseRangeChains
+    diskBoundaryToDiskSevenCoverSmallIntegralSingularChains (𝟙 _)
+      (diskSevenCoverRangeToSmallChains false) (by
+        rw [Category.id_comp]
+        exact diskBoundaryToDiskSevenFalseRangeChains_comp_small)
+
+@[reassoc (attr := simp)]
+public theorem diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative :
+    diskSevenFalseRangeRelativeProjection ≫
+        diskSevenFalseRangeRelativeToCoverSmallRelative =
+      diskSevenCoverRangeToSmallChains false ≫
+        diskSevenCoverSmallRelativeChainProjection := by
+  change cokernel.π diskBoundaryToDiskSevenFalseRangeChains ≫
+      cokernel.desc diskBoundaryToDiskSevenFalseRangeChains
+        (diskSevenCoverRangeToSmallChains false ≫
+          cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains) _ = _
+  exact cokernel.π_desc _ _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Quotienting the false range and the total cover-small complex by the same boundary chains
+is a pushout square. -/
+public theorem diskSevenFalseRangeRelativeSquare_isPushout :
+    IsPushout
+      (diskSevenCoverRangeToSmallChains false)
+      diskSevenFalseRangeRelativeProjection
+      diskSevenCoverSmallRelativeChainProjection
+      diskSevenFalseRangeRelativeToCoverSmallRelative := by
+  let _ : Epi diskSevenFalseRangeRelativeProjection := by
+    dsimp [diskSevenFalseRangeRelativeProjection]
+    infer_instance
+  let _ : Epi diskSevenCoverSmallRelativeChainProjection := by
+    dsimp [diskSevenCoverSmallRelativeChainProjection]
+    infer_instance
+  refine ⟨⟨diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative.symm⟩,
+    ⟨PushoutCocone.IsColimit.mk _ ?_ ?_ ?_ ?_⟩⟩
+  · intro s
+    exact cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+      s.inl (by
+        rw [← diskBoundaryToDiskSevenFalseRangeChains_comp_small,
+          Category.assoc, s.condition]
+        simp [diskSevenFalseRangeRelativeProjection])
+  · intro s
+    exact cokernel.π_desc _ _ _
+  · intro s
+    apply (cancel_epi diskSevenFalseRangeRelativeProjection).1
+    rw [← Category.assoc,
+      diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative,
+      Category.assoc]
+    change diskSevenCoverRangeToSmallChains false ≫
+        (cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+          cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+            s.inl _) =
+      diskSevenFalseRangeRelativeProjection ≫ s.inr
+    rw [cokernel.π_desc]
+    exact s.condition
+  · intro s m hm₁ _
+    apply (cancel_epi diskSevenCoverSmallRelativeChainProjection).1
+    rw [hm₁]
+    change s.inl =
+      cokernel.π diskBoundaryToDiskSevenCoverSmallIntegralSingularChains ≫
+        cokernel.desc diskBoundaryToDiskSevenCoverSmallIntegralSingularChains
+          s.inl _
+    exact (cokernel.π_desc _ _ _).symm
+
+/-- The local middle term: true-range chains together with false-range chains modulo boundary. -/
+public noncomputable abbrev DiskSevenCoverLocalRelativeMiddleChainComplex :
+    ChainComplex AddCommGrpCat ℕ :=
+  DiskSevenCoverRangeChainComplex true ⊞
+    DiskSevenFalseRangeRelativeChainComplex
+
+/-- Before quotienting the false range by boundary chains, the two range complexes sum onto the
+cover-small chain complex. -/
+public noncomputable def diskSevenCoverRangeSum :
+    (DiskSevenCoverRangeChainComplex true ⊞
+      DiskSevenCoverRangeChainComplex false) ⟶
+      DiskSevenCoverSmallIntegralSingularChainComplex :=
+  biprod.desc (diskSevenCoverRangeToSmallChains true)
+    (diskSevenCoverRangeToSmallChains false)
+
+set_option backward.isDefEq.respectTransparency false
+/-- Every cover-small simplex belongs to one of the two range subcomplexes, so the range-sum map
+is an epimorphism. -/
+public theorem diskSevenCoverRangeSum_epi : Epi diskSevenCoverRangeSum := by
+  constructor
+  intro Z g h heq
+  apply HomologicalComplex.Hom.ext
+  funext n
+  apply (coverSmallSingularSubcomplex
+    (TopCat.disk.{0} 7) diskSevenExcisionCover : SSet).chainComplex_hom_ext
+  intro x
+  obtain ⟨b, hb⟩ :=
+    (mem_coverSmallSingularSubcomplex_iff
+      (TopCat.disk.{0} 7) diskSevenExcisionCover x.1).mp x.2
+  let xb : (diskSevenCoverRangeSubcomplex b).obj
+      (Opposite.op (SimplexCategory.mk n)) := ⟨x.1, hb⟩
+  have heqn : (diskSevenCoverRangeSum.f n) ≫ g.f n =
+      (diskSevenCoverRangeSum.f n) ≫ h.f n := by
+    exact congrArg (fun q ↦ q.f n) heq
+  cases b with
+  | false =>
+      have hx := congrArg
+        (fun q ↦ ((diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+          (biprod.inr : DiskSevenCoverRangeChainComplex false ⟶
+            (DiskSevenCoverRangeChainComplex true ⊞
+              DiskSevenCoverRangeChainComplex false)).f n) ≫ q) heqn
+      have hx' :
+          ((diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains false).f n) ≫ g.f n =
+            ((diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains false).f n) ≫ h.f n := by
+        simpa [diskSevenCoverRangeSum, Category.assoc] using hx
+      have hι :
+          (diskSevenCoverRangeSubcomplex false : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains false).f n =
+            (coverSmallSingularSubcomplex (TopCat.disk.{0} 7)
+              diskSevenExcisionCover : SSet).ιChainComplex x := by
+        rw [diskSevenCoverRangeToSmallChains, SSet.ι_chainComplexMap_f]
+        congr 1
+      rw [hι] at hx'
+      exact hx'
+  | true =>
+      have hx := congrArg
+        (fun q ↦ ((diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+          (biprod.inl : DiskSevenCoverRangeChainComplex true ⟶
+            (DiskSevenCoverRangeChainComplex true ⊞
+              DiskSevenCoverRangeChainComplex false)).f n) ≫ q) heqn
+      have hx' :
+          ((diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains true).f n) ≫ g.f n =
+            ((diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains true).f n) ≫ h.f n := by
+        simpa [diskSevenCoverRangeSum, Category.assoc] using hx
+      have hι :
+          (diskSevenCoverRangeSubcomplex true : SSet).ιChainComplex xb ≫
+              (diskSevenCoverRangeToSmallChains true).f n =
+            (coverSmallSingularSubcomplex (TopCat.disk.{0} 7)
+              diskSevenExcisionCover : SSet).ιChainComplex x := by
+        rw [diskSevenCoverRangeToSmallChains, SSet.ι_chainComplexMap_f]
+        congr 1
+      rw [hι] at hx'
+      exact hx'
+set_option backward.isDefEq.respectTransparency true
+
+/-- Quotienting the false summand sends the absolute two-range middle term to the relative
+middle term. -/
+public noncomputable def diskSevenCoverRangeSumToLocalRelativeMiddle :
+    (DiskSevenCoverRangeChainComplex true ⊞
+      DiskSevenCoverRangeChainComplex false) ⟶
+      DiskSevenCoverLocalRelativeMiddleChainComplex :=
+  biprod.map (𝟙 _) diskSevenFalseRangeRelativeProjection
+
+/-- Difference map from intersection chains to the local relative middle term. -/
+public noncomputable def diskSevenCoverLocalRelativeDifference :
+    DiskSevenCoverRangeIntersectionChainComplex ⟶
+      DiskSevenCoverLocalRelativeMiddleChainComplex :=
+  biprod.lift
+    (diskSevenCoverRangeIntersectionToRangeChains true)
+    (-(diskSevenCoverRangeIntersectionToRangeChains false ≫
+      diskSevenFalseRangeRelativeProjection))
+
+/-- The local difference map is mono: its true-range component is the inclusion of the
+intersection subcomplex. -/
+public theorem diskSevenCoverLocalRelativeDifference_mono :
+    Mono diskSevenCoverLocalRelativeDifference := by
+  have hinter : Mono (diskSevenCoverRangeIntersectionToRangeChains true) := by
+    let _ : Mono (diskSevenCoverRangeIntersectionToRangeSingularSet true) := by
+      dsimp [diskSevenCoverRangeIntersectionToRangeSingularSet]
+      exact SSet.Subcomplex.mono_homOfLE inf_le_left
+    dsimp [diskSevenCoverRangeIntersectionToRangeChains, SSet.chainComplexMap,
+      SSet.chainComplexFunctor]
+    apply +allowSynthFailures Functor.map_mono
+    apply +allowSynthFailures Functor.map_mono
+    dsimp [SSet, SimplicialObject.whiskering, SimplicialObject]
+    infer_instance
+  let _ : Mono (diskSevenCoverLocalRelativeDifference ≫
+      (biprod.fst : DiskSevenCoverLocalRelativeMiddleChainComplex ⟶
+        DiskSevenCoverRangeChainComplex true)) := by
+    rw [diskSevenCoverLocalRelativeDifference, biprod.lift_fst]
+    exact hinter
+  exact mono_of_mono diskSevenCoverLocalRelativeDifference biprod.fst
+
+/-- Sum map from the local relative middle term to cover-small relative chains. -/
+public noncomputable def diskSevenCoverLocalRelativeSum :
+    DiskSevenCoverLocalRelativeMiddleChainComplex ⟶
+      DiskSevenCoverSmallRelativeIntegralSingularChainComplex :=
+  biprod.desc
+    (diskSevenCoverRangeToSmallChains true ≫
+      diskSevenCoverSmallRelativeChainProjection)
+    diskSevenFalseRangeRelativeToCoverSmallRelative
+
+/-- The relative local sum is the quotient of the absolute range-sum decomposition. -/
+public theorem diskSevenCoverRangeSumToLocalRelativeMiddle_comp_sum :
+    diskSevenCoverRangeSumToLocalRelativeMiddle ≫
+        diskSevenCoverLocalRelativeSum =
+      diskSevenCoverRangeSum ≫
+        diskSevenCoverSmallRelativeChainProjection := by
+  apply biprod.hom_ext'
+  · simp [diskSevenCoverRangeSumToLocalRelativeMiddle,
+      diskSevenCoverLocalRelativeSum, diskSevenCoverRangeSum]
+  · simp [diskSevenCoverRangeSumToLocalRelativeMiddle,
+      diskSevenCoverLocalRelativeSum, diskSevenCoverRangeSum]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The local relative sum is epi.  This is already forced by the explicit absolute
+range-sum decomposition, after projection to relative chains. -/
+public theorem diskSevenCoverLocalRelativeSum_epi :
+    Epi diskSevenCoverLocalRelativeSum := by
+  let _ : Epi diskSevenCoverRangeSum :=
+    diskSevenCoverRangeSum_epi
+  let _ : Epi diskSevenCoverSmallRelativeChainProjection := by
+    dsimp [diskSevenCoverSmallRelativeChainProjection]
+    infer_instance
+  exact epi_of_epi_fac
+    diskSevenCoverRangeSumToLocalRelativeMiddle_comp_sum
+
+/-- Pasting the absolute two-range pushout with the false-range quotient pushout gives the
+relative two-range pushout. -/
+public theorem diskSevenCoverLocalRelativeSquare_isPushout :
+    IsPushout
+      (diskSevenCoverRangeIntersectionToRangeChains true)
+      (diskSevenCoverRangeIntersectionToRangeChains false ≫
+        diskSevenFalseRangeRelativeProjection)
+      (diskSevenCoverRangeToSmallChains true ≫
+        diskSevenCoverSmallRelativeChainProjection)
+      diskSevenFalseRangeRelativeToCoverSmallRelative :=
+  IsPushout.paste_vert diskSevenCoverRangeChains_isPushout
+    diskSevenFalseRangeRelativeSquare_isPushout
+
+/-- The local difference and sum maps compose to zero. -/
+public theorem diskSevenCoverLocalRelativeDifference_comp_sum :
+    diskSevenCoverLocalRelativeDifference ≫
+      diskSevenCoverLocalRelativeSum = 0 := by
+  rw [diskSevenCoverLocalRelativeDifference,
+    diskSevenCoverLocalRelativeSum, biprod.lift_desc,
+    Preadditive.neg_comp, Category.assoc,
+    diskSevenFalseRangeRelativeProjection_comp_toCoverSmallRelative,
+    ← Category.assoc, ← Category.assoc,
+    diskSevenCoverRangeIntersectionToSmallChains_eq, add_neg_cancel]
+
+/-- The explicit local Mayer--Vietoris short complex for the pair `(D⁷,S⁶)`. -/
+public noncomputable def diskSevenCoverSmallRelativeMayerVietorisShortComplex :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  ShortComplex.mk diskSevenCoverLocalRelativeDifference
+    diskSevenCoverLocalRelativeSum
+    diskSevenCoverLocalRelativeDifference_comp_sum
+
+/-- The remaining chain-level Mayer--Vietoris assertion for the concrete two-set cover. -/
+public def DiskSevenCoverSmallRelativeMayerVietoris : Prop :=
+  diskSevenCoverSmallRelativeMayerVietorisShortComplex.ShortExact
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Exactness of the relative Mayer--Vietoris short complex follows from the concrete pasted
+pushout square. -/
+public theorem diskSevenCoverSmallRelativeMayerVietoris_exact :
+    diskSevenCoverSmallRelativeMayerVietorisShortComplex.Exact := by
+  apply diskSevenCoverSmallRelativeMayerVietorisShortComplex.exact_of_g_is_cokernel
+  let h := diskSevenCoverLocalRelativeSquare_isPushout
+  refine Cofork.IsColimit.mk _
+    (fun s ↦ h.desc (biprod.inl ≫ s.π) (biprod.inr ≫ s.π) (by
+      rw [← sub_eq_zero, ← Category.assoc,
+        ← Category.assoc
+          (diskSevenCoverRangeIntersectionToRangeChains false ≫
+            diskSevenFalseRangeRelativeProjection) biprod.inr s.π,
+        ← Preadditive.sub_comp]
+      rw [show
+        diskSevenCoverRangeIntersectionToRangeChains true ≫ biprod.inl -
+            (diskSevenCoverRangeIntersectionToRangeChains false ≫
+              diskSevenFalseRangeRelativeProjection) ≫ biprod.inr =
+          diskSevenCoverLocalRelativeDifference by
+        apply biprod.hom_ext
+        · simp [diskSevenCoverLocalRelativeDifference]
+        · simp [diskSevenCoverLocalRelativeDifference]]
+      change diskSevenCoverLocalRelativeDifference ≫ s.π = 0
+      have hs := s.condition
+      change diskSevenCoverLocalRelativeDifference ≫ s.π = 0 ≫ s.π at hs
+      rw [zero_comp] at hs
+      exact hs))
+    (fun s ↦ by
+      apply biprod.hom_ext'
+      · simp [diskSevenCoverSmallRelativeMayerVietorisShortComplex,
+          diskSevenCoverLocalRelativeSum]
+      · simp [diskSevenCoverSmallRelativeMayerVietorisShortComplex,
+          diskSevenCoverLocalRelativeSum])
+    (fun s m hm ↦ by
+      change diskSevenCoverLocalRelativeSum ≫ m = s.π at hm
+      apply h.hom_ext
+      · replace hm := biprod.inl ≫= hm
+        simp only [diskSevenCoverLocalRelativeSum,
+          biprod.inl_desc_assoc, Category.assoc] at hm
+        rw [h.inl_desc]
+        simpa only [Category.assoc] using hm
+      · replace hm := biprod.inr ≫= hm
+        simp only [diskSevenCoverLocalRelativeSum,
+          biprod.inr_desc_assoc] at hm
+        rw [h.inr_desc]
+        simpa only [Category.assoc] using hm)
+
+/-- The concrete cover-small relative Mayer--Vietoris sequence is short exact, with no extra
+topological or homological hypothesis. -/
+public theorem diskSevenCoverSmallRelativeMayerVietoris :
+    DiskSevenCoverSmallRelativeMayerVietoris :=
+  { exact := diskSevenCoverSmallRelativeMayerVietoris_exact
+    mono_f := diskSevenCoverLocalRelativeDifference_mono
+    epi_g := diskSevenCoverLocalRelativeSum_epi }
+
+/-- A useful characterization of the Mayer--Vietoris structure in terms of its exactness and
+surjectivity fields.  Both fields are proved unconditionally above. -/
+public theorem diskSevenCoverSmallRelativeMayerVietoris_iff :
+    DiskSevenCoverSmallRelativeMayerVietoris ↔
+      diskSevenCoverSmallRelativeMayerVietorisShortComplex.Exact ∧
+        Epi diskSevenCoverLocalRelativeSum := by
+  constructor
+  · intro h
+    exact ⟨h.exact, h.epi_g⟩
+  · rintro ⟨hexact, hepi⟩
+    exact
+      { exact := hexact
+        mono_f := diskSevenCoverLocalRelativeDifference_mono
+        epi_g := hepi }
+
+/-- The explicit local homology groups whose vanishing suffices in degrees two through four. -/
+public def DiskSevenCoverLocalRelativeLowAcyclic : Prop :=
+  IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 3) ∧
+    IsZero (DiskSevenCoverLocalRelativeMiddleChainComplex.homology 4) ∧
+    IsZero (DiskSevenCoverRangeIntersectionChainComplex.homology 2) ∧
+    IsZero (DiskSevenCoverRangeIntersectionChainComplex.homology 3)
+
+/-- Fully explicit local chain-contraction data.  These are four additive degree-raising maps,
+each satisfying `hd + dh = 1` in the indicated degree. -/
+public def DiskSevenCoverLocalRelativeLowContractions : Prop :=
+  Nonempty (ChainContractionAt DiskSevenCoverLocalRelativeMiddleChainComplex 3) ∧
+    Nonempty (ChainContractionAt DiskSevenCoverLocalRelativeMiddleChainComplex 4) ∧
+    Nonempty (ChainContractionAt DiskSevenCoverRangeIntersectionChainComplex 2) ∧
+    Nonempty (ChainContractionAt DiskSevenCoverRangeIntersectionChainComplex 3)
+
+/-- The explicit contractions imply all four local homology vanishings. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_of_contractions
+    (h : DiskSevenCoverLocalRelativeLowContractions) :
+    DiskSevenCoverLocalRelativeLowAcyclic :=
+  ⟨h.1.some.isZero_homology (by omega),
+    h.2.1.some.isZero_homology (by omega),
+    h.2.2.1.some.isZero_homology (by omega),
+    h.2.2.2.some.isZero_homology (by omega)⟩
+
+/-- Mayer--Vietoris exactness and the four explicit local vanishings imply the two remaining
+cover-small relative vanishings. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_of_local
+    (hMV : DiskSevenCoverSmallRelativeMayerVietoris)
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    DiskSevenCoverSmallRelativeLowAcyclic := by
+  constructor
+  · exact (hMV.homology_exact₃ 3 2
+      (ComplexShape.down_mk 3 2 (by omega))).isZero_X₂
+        (hlocal.1.eq_of_src _ _) (hlocal.2.2.1.eq_of_tgt _ _)
+  · exact (hMV.homology_exact₃ 4 3
+      (ComplexShape.down_mk 4 3 (by omega))).isZero_X₂
+      (hlocal.2.1.eq_of_src _ _) (hlocal.2.2.2.eq_of_tgt _ _)
+
+/-- Thus the four local vanishings are the only remaining input: Mayer--Vietoris exactness for
+the concrete cover has already been proved above. -/
+public theorem diskSevenCoverSmallRelativeLowAcyclic_of_localAcyclic
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    DiskSevenCoverSmallRelativeLowAcyclic :=
+  diskSevenCoverSmallRelativeLowAcyclic_of_local
+    diskSevenCoverSmallRelativeMayerVietoris hlocal
+
+/-- Consequently, the local Mayer--Vietoris calculation gives the desired standard-sphere
+vanishings. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_local
+    (hMV : DiskSevenCoverSmallRelativeMayerVietoris)
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) := by
+  rw [← diskSevenCoverSmallRelativeLowAcyclic_iff_standardSphereSix_low_isZero]
+  exact diskSevenCoverSmallRelativeLowAcyclic_of_local hMV hlocal
+
+/-- The four explicit local homology vanishings alone imply the desired standard-sphere
+vanishings. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_localAcyclic
+    (hlocal : DiskSevenCoverLocalRelativeLowAcyclic) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) :=
+  standardSphereSix_integralSingularHomology_low_isZero_of_local
+    diskSevenCoverSmallRelativeMayerVietoris hlocal
+
+/-- A chain-level endpoint: concrete Mayer--Vietoris exactness plus four displayed contraction
+identities proves both desired low-degree sphere vanishings. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_localContractions
+    (h : DiskSevenCoverLocalRelativeLowContractions) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere 6)).homology 3) :=
+  standardSphereSix_integralSingularHomology_low_isZero_of_localAcyclic
+    (diskSevenCoverLocalRelativeLowAcyclic_of_contractions h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyLowAcyclic.lean
@@ -454,9 +454,6 @@ public theorem diskSevenCoverLocalRelativeDifference_mono :
     dsimp [diskSevenCoverRangeIntersectionToRangeChains, SSet.chainComplexMap,
       SSet.chainComplexFunctor]
     apply +allowSynthFailures Functor.map_mono
-    apply +allowSynthFailures Functor.map_mono
-    dsimp [SSet, SimplicialObject.whiskering, SimplicialObject]
-    infer_instance
   let _ : Mono (diskSevenCoverLocalRelativeDifference ≫
       (biprod.fst : DiskSevenCoverLocalRelativeMiddleChainComplex ⟶
         DiskSevenCoverRangeChainComplex true)) := by

--- a/SphereSixComplex/Topology/DiskSevenRelativeHomologyModTwo.lean
+++ b/SphereSixComplex/Topology/DiskSevenRelativeHomologyModTwo.lean
@@ -1,0 +1,52 @@
+module
+
+public import SphereSixComplex.Topology.DiskSevenRelativeHomologyLow
+public import SphereSixComplex.Topology.HomotopySphereHomology
+public import SphereSixComplex.Topology.SingularHomologyModTwo
+
+/-!
+# From the cover-small disk pair to mod-two middle homology
+
+This file connects the explicit relative-chain reduction for `(D⁷,S⁶)` to the exact mod-two
+homology input used by the Kervaire route.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- The two explicit low-degree cover-small relative calculations imply the required mod-two
+middle-homology vanishing for the project's standard six-sphere. -/
+public theorem sixSphere_modTwoHomology_three_isZero_of_coverSmallRelative
+    (h : DiskSevenCoverSmallRelativeLowAcyclic) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) := by
+  have h₂ : IsZero ((IntegralSingularChainComplexObj
+      (TopCat.sphere 6)).homology 2) :=
+    standardSphereSix_integralSingularHomology_two_isZero_of_coverSmallRelative h.1
+  have h₃ : IsZero ((IntegralSingularChainComplexObj
+      (TopCat.sphere 6)).homology 3) :=
+    standardSphereSix_integralSingularHomology_three_isZero_of_coverSmallRelative h.2
+  have hmod : IsZero ((ModTwoSingularChainComplexObj
+      (TopCat.sphere 6)).homology 3) :=
+    modTwoSingularHomologyThree_isZero (TopCat.sphere 6) h₃ h₂
+  exact hmod.of_iso
+    (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).mapIso
+        (TopCat.isoOfHomeo sixSphereHomeomorphTopCatSphereSix))
+
+/-- The same two local relative calculations give the Kervaire homology input for every marked
+smooth homotopy six-sphere. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_of_coverSmallRelative
+    (h : DiskSevenCoverSmallRelativeLowAcyclic)
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (sixSphere_modTwoHomology_three_isZero_of_coverSmallRelative h) S
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantColumnFiltration.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantColumnFiltration.lean
@@ -1,0 +1,77 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantSingleColumnTotal
+public import Mathlib.Algebra.Homology.Embedding.StupidTrunc
+public import Mathlib.Algebra.Homology.TotalComplexSymmetry
+
+/-!
+# Finite column filtrations of first-quadrant bicomplexes
+
+This file constructs the brutal finite-prefix filtration in the outer direction of a
+first-quadrant bicomplex.  It is the elementary filtration used to promote componentwise
+quasi-isomorphisms to quasi-isomorphisms after direct-sum totalization.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+/-- The finite interval of outer degrees retained by the `n`th brutal prefix. -/
+public abbrev FirstQuadrantColumnPrefixIndex (n : ℕ) := {p : ℕ // p ≤ n}
+
+/-- The chain-complex shape obtained by restricting the usual downward shape on `ℕ` to
+`0, ..., n`.  Defining the shape by restriction avoids all dependent casts at the cutoff. -/
+public def firstQuadrantColumnPrefixShape (n : ℕ) :
+    ComplexShape (FirstQuadrantColumnPrefixIndex n) where
+  Rel p q := (ComplexShape.down ℕ).Rel p.1 q.1
+  next_eq hp hq := Subtype.ext ((ComplexShape.down ℕ).next_eq hp hq)
+  prev_eq hp hq := Subtype.ext ((ComplexShape.down ℕ).prev_eq hp hq)
+
+/-- Inclusion of the finite prefix shape in the first-quadrant outer shape. -/
+public def firstQuadrantColumnPrefixEmbedding (n : ℕ) :
+    (firstQuadrantColumnPrefixShape n).Embedding (ComplexShape.down ℕ) :=
+  ComplexShape.Embedding.mk'
+    (firstQuadrantColumnPrefixShape n) (ComplexShape.down ℕ)
+    Subtype.val Subtype.val_injective (fun _ _ => Iff.rfl)
+
+noncomputable instance (n : ℕ) :
+    (firstQuadrantColumnPrefixEmbedding n).IsRelIff where
+  rel' _ _ h := h
+
+/-- The brutal prefix consisting of outer columns `0, ..., n`.
+
+This is Mathlib's restriction followed by extension by zero.  Consequently the shape and
+`d² = 0` proofs, including the differential crossing the cutoff, come from the generic
+zero-extension construction rather than from hand-written dependent `if` expressions. -/
+public noncomputable def firstQuadrantColumnPrefix
+    (K : FirstQuadrantBicomplex) (n : ℕ) : FirstQuadrantBicomplex :=
+  K.stupidTrunc (firstQuadrantColumnPrefixEmbedding n)
+
+/-- A bicomplex map restricts to every brutal finite column prefix. -/
+public noncomputable def firstQuadrantColumnPrefixMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (n : ℕ) :
+    firstQuadrantColumnPrefix K n ⟶ firstQuadrantColumnPrefix L n :=
+  HomologicalComplex.stupidTruncMap f (firstQuadrantColumnPrefixEmbedding n)
+
+/-- Inside the retained range, the brutal prefix has the original column. -/
+public noncomputable def firstQuadrantColumnPrefixXIso
+    (K : FirstQuadrantBicomplex) (n p : ℕ) (hp : p ≤ n) :
+    (firstQuadrantColumnPrefix K n).X p ≅ K.X p :=
+  K.stupidTruncXIso (firstQuadrantColumnPrefixEmbedding n)
+    (i := ⟨p, hp⟩) rfl
+
+/-- Outside the retained range, the brutal prefix column is zero. -/
+public theorem firstQuadrantColumnPrefix_isZero_X
+    (K : FirstQuadrantBicomplex) (n p : ℕ) (hp : n < p) :
+    IsZero ((firstQuadrantColumnPrefix K n).X p) := by
+  unfold firstQuadrantColumnPrefix
+  apply HomologicalComplex.isZero_stupidTrunc_X
+  intro i hi
+  change i.1 = p at hi
+  omega
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationQuotient.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationQuotient.lean
@@ -1,0 +1,100 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantColumnFiltration
+
+/-!
+# Successive column quotients of finite first-quadrant prefixes
+
+The `(n + 1)`st prefix has a canonical projection to its last column, regarded as a bicomplex
+concentrated in outer degree `n + 1`.  This is the quotient map in the finite column filtration.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+/-- A single outer column of a first-quadrant bicomplex. -/
+public noncomputable abbrev firstQuadrantSingleColumn
+    (K : FirstQuadrantBicomplex) (p : ℕ) : FirstQuadrantBicomplex :=
+  (HomologicalComplex.single (ChainComplex AddCommGrpCat ℕ)
+    (ComplexShape.down ℕ) p).obj (K.X p)
+
+/-- The unique nonzero outer column is canonically the original column. -/
+public noncomputable def firstQuadrantSingleColumnXIso
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    (firstQuadrantSingleColumn K p).X p ≅ K.X p :=
+  HomologicalComplex.singleObjXSelf (ComplexShape.down ℕ) p (K.X p)
+
+/-- Component of the projection from the prefix ending at `p` to its last column. -/
+public noncomputable def firstQuadrantColumnPrefixToLastComponent
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    (firstQuadrantColumnPrefix K p).X q ⟶
+      (firstQuadrantSingleColumn K p).X q := by
+  by_cases hq : q = p
+  · subst q
+    exact (firstQuadrantColumnPrefixXIso K p p le_rfl).hom ≫
+      (firstQuadrantSingleColumnXIso K p).inv
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantColumnPrefixToLastComponent_self
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefixToLastComponent K p p =
+      (firstQuadrantColumnPrefixXIso K p p le_rfl).hom ≫
+        (firstQuadrantSingleColumnXIso K p).inv := by
+  simp [firstQuadrantColumnPrefixToLastComponent]
+
+public theorem firstQuadrantColumnPrefixToLastComponent_eq_zero
+    (K : FirstQuadrantBicomplex) (p q : ℕ) (hq : q ≠ p) :
+    firstQuadrantColumnPrefixToLastComponent K p q = 0 := by
+  simp [firstQuadrantColumnPrefixToLastComponent, hq]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Projection of the finite prefix to its final outer column. -/
+public noncomputable def firstQuadrantColumnPrefixToLast
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefix K p ⟶ firstQuadrantSingleColumn K p where
+  f := firstQuadrantColumnPrefixToLastComponent K p
+  comm' i j hij := by
+    change j + 1 = i at hij
+    by_cases hi : i = p
+    · subst i
+      have hj : j ≠ p := by
+        omega
+      rw [hi, firstQuadrantColumnPrefixToLastComponent_self,
+        firstQuadrantColumnPrefixToLastComponent_eq_zero K p j hj,
+        comp_zero]
+      have hz : (firstQuadrantSingleColumn K p).d p j = 0 := by simp
+      rw [hz, comp_zero]
+    · rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K p i hi,
+        zero_comp]
+      by_cases hj : j = p
+      · subst j
+        have hip : p < i := by
+          omega
+        have hz : IsZero ((firstQuadrantColumnPrefix K p).X i) :=
+          firstQuadrantColumnPrefix_isZero_X K p i hip
+        exact hz.eq_of_src _ _
+      · rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K p j hj,
+          comp_zero]
+
+noncomputable instance firstQuadrantColumnPrefixToLast_epi
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    Epi (firstQuadrantColumnPrefixToLast K p) := by
+  apply HomologicalComplex.epi_of_epi_f
+  intro q
+  by_cases hq : q = p
+  · subst q
+    dsimp [firstQuadrantColumnPrefixToLast]
+    rw [firstQuadrantColumnPrefixToLastComponent_self]
+    infer_instance
+  · have hz : IsZero ((firstQuadrantSingleColumn K p).X q) :=
+      HomologicalComplex.isZero_single_obj_X
+        (ComplexShape.down ℕ) p (K.X p) q hq
+    exact hz.epi _
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationShortExact.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantColumnFiltrationShortExact.lean
@@ -1,0 +1,171 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantColumnFiltrationQuotient
+public import Mathlib.Algebra.Homology.HomologicalComplexAbelian
+public import Mathlib.Algebra.Homology.ShortComplex.Abelian
+
+/-!
+# Short exact sequences for the finite column filtration
+
+The inclusion from the prefix ending in column `p` to the prefix ending in column `p + 1`
+is the kernel of projection to the new final column.  Consequently the successive quotients
+of the finite column filtration are single-column bicomplexes.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The differential of a finite prefix, transported to the original bicomplex in two
+retained degrees. -/
+public theorem firstQuadrantColumnPrefix_d_eq
+    (K : FirstQuadrantBicomplex) (n i j : ℕ) (hi : i ≤ n) (hj : j ≤ n) :
+    (firstQuadrantColumnPrefix K n).d i j =
+      (firstQuadrantColumnPrefixXIso K n i hi).hom ≫ K.d i j ≫
+        (firstQuadrantColumnPrefixXIso K n j hj).inv := by
+  let e := firstQuadrantColumnPrefixEmbedding n
+  have h := HomologicalComplex.extend_d_eq
+    (K := K.restriction e) (e := e)
+    (i' := i) (j' := j) (i := ⟨i, hi⟩) (j := ⟨j, hj⟩) (hi := rfl) (hj := rfl)
+  simpa [e, firstQuadrantColumnPrefix, firstQuadrantColumnPrefixXIso,
+    firstQuadrantColumnPrefixEmbedding, ComplexShape.Embedding.mk',
+    HomologicalComplex.stupidTrunc, HomologicalComplex.stupidTruncXIso,
+    HomologicalComplex.restriction] using h
+
+/-- Component of the canonical inclusion of two consecutive finite column prefixes. -/
+public noncomputable def firstQuadrantColumnPrefixSuccInclusionComponent
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    (firstQuadrantColumnPrefix K p).X q ⟶
+      (firstQuadrantColumnPrefix K (p + 1)).X q := by
+  by_cases hq : q ≤ p
+  · exact (firstQuadrantColumnPrefixXIso K p q hq).hom ≫
+      (firstQuadrantColumnPrefixXIso K (p + 1) q (by omega)).inv
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantColumnPrefixSuccInclusionComponent_of_le
+    (K : FirstQuadrantBicomplex) (p q : ℕ) (hq : q ≤ p) :
+    firstQuadrantColumnPrefixSuccInclusionComponent K p q =
+      (firstQuadrantColumnPrefixXIso K p q hq).hom ≫
+        (firstQuadrantColumnPrefixXIso K (p + 1) q (by omega)).inv := by
+  simp [firstQuadrantColumnPrefixSuccInclusionComponent, hq]
+
+public theorem firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero
+    (K : FirstQuadrantBicomplex) (p q : ℕ) (hq : p < q) :
+    firstQuadrantColumnPrefixSuccInclusionComponent K p q = 0 := by
+  simp [firstQuadrantColumnPrefixSuccInclusionComponent, show ¬ q ≤ p by omega]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Canonical inclusion from the prefix through `p` into the prefix through `p + 1`. -/
+public noncomputable def firstQuadrantColumnPrefixSuccInclusion
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefix K p ⟶ firstQuadrantColumnPrefix K (p + 1) where
+  f := firstQuadrantColumnPrefixSuccInclusionComponent K p
+  comm' i j hij := by
+    change j + 1 = i at hij
+    by_cases hi : i ≤ p
+    · have hj : j ≤ p := by omega
+      rw [firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p i hi,
+        firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p j hj,
+        firstQuadrantColumnPrefix_d_eq K (p + 1) i j (by omega) (by omega),
+        firstQuadrantColumnPrefix_d_eq K p i j hi hj]
+      simp
+    · rw [firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero K p i (by omega),
+        zero_comp]
+      have hz : IsZero ((firstQuadrantColumnPrefix K p).X i) :=
+        firstQuadrantColumnPrefix_isZero_X K p i (by omega)
+      exact hz.eq_of_src _ _
+
+@[reassoc (attr := simp)]
+public theorem firstQuadrantColumnPrefixSuccInclusion_comp_toLast
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    firstQuadrantColumnPrefixSuccInclusion K p ≫
+      firstQuadrantColumnPrefixToLast K (p + 1) = 0 := by
+  apply HomologicalComplex.hom_ext
+  intro q
+  by_cases hq : q ≤ p
+  · have hne : q ≠ p + 1 := by omega
+    change firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+      firstQuadrantColumnPrefixToLastComponent K (p + 1) q = 0
+    rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K (p + 1) q hne,
+      comp_zero]
+  · change firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+      firstQuadrantColumnPrefixToLastComponent K (p + 1) q = 0
+    rw [firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero K p q (by omega),
+      zero_comp]
+
+/-- The inclusion of one finite prefix into the next is the kernel of projection onto the
+new final column. -/
+public noncomputable def firstQuadrantColumnPrefixSuccInclusionIsKernel
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    IsLimit (KernelFork.ofι
+      (firstQuadrantColumnPrefixSuccInclusion K p)
+      (firstQuadrantColumnPrefixSuccInclusion_comp_toLast K p)) := by
+  apply HomologicalComplex.isLimitOfEval
+  intro q
+  refine (Limits.isLimitMapConeForkEquiv'
+    (HomologicalComplex.eval (ChainComplex AddCommGrpCat ℕ) (ComplexShape.down ℕ) q)
+    (firstQuadrantColumnPrefixSuccInclusion_comp_toLast K p)).symm ?_
+  change IsLimit (KernelFork.ofι
+    (HomologicalComplex.Hom.f (firstQuadrantColumnPrefixSuccInclusion K p) q)
+    _)
+  by_cases hq : q ≤ p
+  · let e : (firstQuadrantColumnPrefix K p).X q ≅
+        (firstQuadrantColumnPrefix K (p + 1)).X q :=
+      firstQuadrantColumnPrefixXIso K p q hq ≪≫
+        (firstQuadrantColumnPrefixXIso K (p + 1) q (by omega)).symm
+    have he : (firstQuadrantColumnPrefixSuccInclusion K p).f q = e.hom := by
+      change firstQuadrantColumnPrefixSuccInclusionComponent K p q = e.hom
+      simp [e, firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p q hq]
+    refine KernelFork.IsLimit.ofι _ _
+      (fun {_} k _ => k ≫ e.inv) ?_ ?_
+    · intro W k hk
+      rw [he, Category.assoc, e.inv_hom_id, Category.comp_id]
+    · intro W k hk m hm
+      rw [he] at hm
+      rw [← hm, Category.assoc, e.hom_inv_id, Category.comp_id]
+  · have hpq : p < q := by omega
+    have hz : IsZero ((firstQuadrantColumnPrefix K p).X q) :=
+      firstQuadrantColumnPrefix_isZero_X K p q hpq
+    apply KernelFork.IsLimit.ofMonoOfIsZero _ _ hz
+    by_cases hself : q = p + 1
+    · subst q
+      change Mono (firstQuadrantColumnPrefixToLastComponent K (p + 1) (p + 1))
+      rw [firstQuadrantColumnPrefixToLastComponent_self]
+      infer_instance
+    · have hgt : p + 1 < q := by omega
+      exact (firstQuadrantColumnPrefix_isZero_X K (p + 1) q hgt).mono _
+
+/-- The canonical short complex associated to one step of the finite column filtration. -/
+local instance : Preadditive FirstQuadrantBicomplex :=
+  (inferInstance : Abelian FirstQuadrantBicomplex).toPreadditive
+
+local instance : HasZeroMorphisms FirstQuadrantBicomplex :=
+  Preadditive.preadditiveHasZeroMorphisms
+
+public noncomputable def firstQuadrantColumnPrefixSuccShortComplex
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    ShortComplex FirstQuadrantBicomplex :=
+  ShortComplex.mk
+    (firstQuadrantColumnPrefixSuccInclusion K p)
+    (firstQuadrantColumnPrefixToLast K (p + 1))
+    (firstQuadrantColumnPrefixSuccInclusion_comp_toLast K p)
+
+/-- Each step of the finite column filtration is a short exact sequence whose quotient is
+the newly added single column. -/
+public theorem firstQuadrantColumnPrefixSuccShortComplex_shortExact
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    (firstQuadrantColumnPrefixSuccShortComplex K p).ShortExact := by
+  exact
+    { exact := (firstQuadrantColumnPrefixSuccShortComplex K p).exact_of_f_is_kernel
+        (firstQuadrantColumnPrefixSuccInclusionIsKernel K p)
+      mono_f := mono_of_isLimit_fork
+        (firstQuadrantColumnPrefixSuccInclusionIsKernel K p)
+      epi_g := firstQuadrantColumnPrefixToLast_epi K (p + 1) }
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantRowwiseTotalizationProof.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantRowwiseTotalizationProof.lean
@@ -1,0 +1,977 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantColumnFiltrationShortExact
+public import SphereSixComplex.Topology.BoundarySevenCechLowAssemblyProof
+
+/-!
+# Rowwise quasi-isomorphisms and first-quadrant totalization
+
+This file supplies the degree-local stabilization part of the brutal-filtration proof of
+rowwise totalization.  A total degree `n` only contains outer columns at most `n`; consequently
+the total of the prefix through `N` agrees with the full total in every degree at most `N`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+namespace SphereSixComplex
+
+/-- Component of the canonical map from a finite outer-column prefix to the original
+bicomplex. -/
+public noncomputable def firstQuadrantColumnPrefixToOriginalComponent
+    (K : FirstQuadrantBicomplex) (N p : ℕ) :
+    (firstQuadrantColumnPrefix K N).X p ⟶ K.X p := by
+  by_cases hp : p ≤ N
+  · exact (firstQuadrantColumnPrefixXIso K N p hp).hom
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantColumnPrefixToOriginalComponent_of_le
+    (K : FirstQuadrantBicomplex) (N p : ℕ) (hp : p ≤ N) :
+    firstQuadrantColumnPrefixToOriginalComponent K N p =
+      (firstQuadrantColumnPrefixXIso K N p hp).hom := by
+  simp [firstQuadrantColumnPrefixToOriginalComponent, hp]
+
+public theorem firstQuadrantColumnPrefixToOriginalComponent_eq_zero
+    (K : FirstQuadrantBicomplex) (N p : ℕ) (hp : N < p) :
+    firstQuadrantColumnPrefixToOriginalComponent K N p = 0 := by
+  simp [firstQuadrantColumnPrefixToOriginalComponent, show ¬ p ≤ N by omega]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Canonical map from a finite outer-column prefix to the original bicomplex. -/
+public noncomputable def firstQuadrantColumnPrefixToOriginal
+    (K : FirstQuadrantBicomplex) (N : ℕ) :
+    firstQuadrantColumnPrefix K N ⟶ K where
+  f := firstQuadrantColumnPrefixToOriginalComponent K N
+  comm' i j hij := by
+    change j + 1 = i at hij
+    by_cases hi : i ≤ N
+    · have hj : j ≤ N := by omega
+      rw [firstQuadrantColumnPrefixToOriginalComponent_of_le K N i hi,
+        firstQuadrantColumnPrefixToOriginalComponent_of_le K N j hj,
+        firstQuadrantColumnPrefix_d_eq K N i j hi hj]
+      simp
+    · rw [firstQuadrantColumnPrefixToOriginalComponent_eq_zero K N i (by omega),
+        zero_comp]
+      exact (firstQuadrantColumnPrefix_isZero_X K N i (by omega)).eq_of_src _ _
+
+/-- Totalization of the canonical map from a finite prefix to the full bicomplex. -/
+public noncomputable def firstQuadrantColumnPrefixTotalToOriginal
+    (K : FirstQuadrantBicomplex) (N : ℕ) :
+    (firstQuadrantColumnPrefix K N).total (ComplexShape.down ℕ) ⟶
+      K.total (ComplexShape.down ℕ) :=
+  HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToOriginal K N)
+    (ComplexShape.down ℕ)
+
+/-- In total degree `n ≤ N`, project the full total back to the prefix total by using the
+inverse prefix isomorphism on every antidiagonal summand. -/
+public noncomputable def firstQuadrantColumnPrefixTotalToOriginalInverseComponent
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    (K.total (ComplexShape.down ℕ)).X n ⟶
+      ((firstQuadrantColumnPrefix K N).total (ComplexShape.down ℕ)).X n :=
+  K.totalDesc (fun p q hpq =>
+    (firstQuadrantColumnPrefixXIso K N p (by
+      change p + q = n at hpq
+      omega)).inv.f q ≫
+      (firstQuadrantColumnPrefix K N).ιTotal
+        (ComplexShape.down ℕ) p q n hpq)
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantColumnPrefixTotalToOriginal_hom_inv
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    (firstQuadrantColumnPrefixTotalToOriginal K N).f n ≫
+      firstQuadrantColumnPrefixTotalToOriginalInverseComponent K N n hn =
+        𝟙 _ := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  have hp : p ≤ N := by
+    change p + q = n at hpq
+    omega
+  dsimp [firstQuadrantColumnPrefixTotalToOriginal,
+    firstQuadrantColumnPrefixTotalToOriginalInverseComponent]
+  rw [HomologicalComplex₂.ιTotal_map_assoc]
+  change (firstQuadrantColumnPrefixToOriginalComponent K N p).f q ≫ _ = _
+  rw [
+    firstQuadrantColumnPrefixToOriginalComponent_of_le K N p hp,
+    HomologicalComplex₂.ι_totalDesc]
+  simp
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantColumnPrefixTotalToOriginal_inv_hom
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    firstQuadrantColumnPrefixTotalToOriginalInverseComponent K N n hn ≫
+      (firstQuadrantColumnPrefixTotalToOriginal K N).f n = 𝟙 _ := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  have hp : p ≤ N := by
+    change p + q = n at hpq
+    omega
+  dsimp [firstQuadrantColumnPrefixTotalToOriginal,
+    firstQuadrantColumnPrefixTotalToOriginalInverseComponent]
+  rw [HomologicalComplex₂.ι_totalDesc_assoc]
+  rw [Category.assoc, HomologicalComplex₂.ιTotal_map]
+  change (firstQuadrantColumnPrefixXIso K N p _).inv.f q ≫
+    (firstQuadrantColumnPrefixToOriginalComponent K N p).f q ≫ _ = _
+  rw [firstQuadrantColumnPrefixToOriginalComponent_of_le K N p hp]
+  simp
+
+/-- The finite-prefix total and full total are isomorphic componentwise through the cutoff. -/
+public noncomputable def firstQuadrantColumnPrefixTotalToOriginalComponentIso
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    ((firstQuadrantColumnPrefix K N).total (ComplexShape.down ℕ)).X n ≅
+      (K.total (ComplexShape.down ℕ)).X n where
+  hom := (firstQuadrantColumnPrefixTotalToOriginal K N).f n
+  inv := firstQuadrantColumnPrefixTotalToOriginalInverseComponent K N n hn
+  hom_inv_id := firstQuadrantColumnPrefixTotalToOriginal_hom_inv K N n hn
+  inv_hom_id := firstQuadrantColumnPrefixTotalToOriginal_inv_hom K N n hn
+
+public theorem firstQuadrantColumnPrefixTotalToOriginal_component_isIso
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n ≤ N) :
+    IsIso ((firstQuadrantColumnPrefixTotalToOriginal K N).f n) :=
+  (firstQuadrantColumnPrefixTotalToOriginalComponentIso K N n hn).isIso_hom
+
+set_option linter.style.haveILetI false in
+/-- Once the cutoff contains degree `n + 1`, the prefix-to-full total map is a
+quasi-isomorphism in degree `n`.  The extra degree is exactly the incoming differential needed
+to compute homology in degree `n`. -/
+public theorem firstQuadrantColumnPrefixTotalToOriginal_quasiIsoAt
+    (K : FirstQuadrantBicomplex) (N n : ℕ) (hn : n + 1 ≤ N) :
+    QuasiIsoAt (firstQuadrantColumnPrefixTotalToOriginal K N) n := by
+  rw [quasiIsoAt_iff'
+    (firstQuadrantColumnPrefixTotalToOriginal K N)
+    (n + 1) n ((ComplexShape.down ℕ).next n) (by simp) rfl]
+  let φ := (HomologicalComplex.shortComplexFunctor'
+    AddCommGrpCat (ComplexShape.down ℕ)
+    (n + 1) n ((ComplexShape.down ℕ).next n)).map
+      (firstQuadrantColumnPrefixTotalToOriginal K N)
+  have hnext : (ComplexShape.down ℕ).next n ≤ N := by
+    rcases n with _ | n
+    · simp
+    · simp
+      omega
+  letI : IsIso φ.τ₁ :=
+    firstQuadrantColumnPrefixTotalToOriginal_component_isIso K N (n + 1) hn
+  letI : IsIso φ.τ₂ :=
+    firstQuadrantColumnPrefixTotalToOriginal_component_isIso K N n (by omega)
+  letI : IsIso φ.τ₃ :=
+    firstQuadrantColumnPrefixTotalToOriginal_component_isIso K N
+      ((ComplexShape.down ℕ).next n) hnext
+  letI : IsIso φ := ShortComplex.isIso_of_isIso φ
+  change ShortComplex.QuasiIso φ
+  infer_instance
+
+@[reassoc]
+public theorem firstQuadrantColumnPrefixMap_toOriginal_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N : ℕ) :
+    firstQuadrantColumnPrefixMap f N ≫
+      firstQuadrantColumnPrefixToOriginal L N =
+    firstQuadrantColumnPrefixToOriginal K N ≫ f := by
+  apply HomologicalComplex.hom_ext
+  intro p
+  by_cases hp : p ≤ N
+  · change (firstQuadrantColumnPrefixMap f N).f p ≫
+      firstQuadrantColumnPrefixToOriginalComponent L N p =
+        firstQuadrantColumnPrefixToOriginalComponent K N p ≫ f.f p
+    rw [firstQuadrantColumnPrefixToOriginalComponent_of_le L N p hp,
+      firstQuadrantColumnPrefixToOriginalComponent_of_le K N p hp]
+    exact HomologicalComplex.stupidTruncMap_stupidTruncXIso_hom
+      f (firstQuadrantColumnPrefixEmbedding N) (i := ⟨p, hp⟩) (i' := p) rfl
+  · have hNp : N < p := by omega
+    change (firstQuadrantColumnPrefixMap f N).f p ≫
+      firstQuadrantColumnPrefixToOriginalComponent L N p =
+        firstQuadrantColumnPrefixToOriginalComponent K N p ≫ f.f p
+    rw [firstQuadrantColumnPrefixToOriginalComponent_eq_zero L N p hNp,
+      firstQuadrantColumnPrefixToOriginalComponent_eq_zero K N p hNp,
+      comp_zero, zero_comp]
+
+@[reassoc]
+public theorem firstQuadrantColumnPrefixTotalToOriginal_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N : ℕ) :
+    HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ) ≫
+      firstQuadrantColumnPrefixTotalToOriginal L N =
+      firstQuadrantColumnPrefixTotalToOriginal K N ≫
+      HomologicalComplex₂.total.map f (ComplexShape.down ℕ) := by
+  dsimp only [firstQuadrantColumnPrefixTotalToOriginal]
+  rw [← HomologicalComplex₂.total.map_comp,
+    ← HomologicalComplex₂.total.map_comp]
+  exact congrArg
+    (fun g => HomologicalComplex₂.total.map g (ComplexShape.down ℕ))
+    (firstQuadrantColumnPrefixMap_toOriginal_naturality f N)
+
+set_option linter.style.haveILetI false in
+/-- A quasi-isomorphism on one sufficiently large finite prefix induces a
+quasi-isomorphism of full totals in the requested degree. -/
+public theorem firstQuadrantTotal_quasiIsoAt_of_prefix
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N n : ℕ)
+    (hn : n + 1 ≤ N)
+    (hprefix : QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ))) :
+    QuasiIsoAt (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) n := by
+  letI : QuasiIsoAt
+      (firstQuadrantColumnPrefixTotalToOriginal K N) n :=
+    firstQuadrantColumnPrefixTotalToOriginal_quasiIsoAt K N n hn
+  letI : QuasiIsoAt
+      (firstQuadrantColumnPrefixTotalToOriginal L N) n :=
+    firstQuadrantColumnPrefixTotalToOriginal_quasiIsoAt L N n hn
+  letI : QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ)) := hprefix
+  have hcomp : QuasiIsoAt
+      (firstQuadrantColumnPrefixTotalToOriginal K N ≫
+        HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) n := by
+    rw [← firstQuadrantColumnPrefixTotalToOriginal_naturality f N]
+    infer_instance
+  exact quasiIsoAt_of_comp_left
+    (firstQuadrantColumnPrefixTotalToOriginal K N)
+    (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) n
+
+/-- If a bicomplex map is a quasi-isomorphism after totalizing every finite column prefix,
+then it is a quasi-isomorphism after full first-quadrant totalization. -/
+public theorem firstQuadrantTotal_quasiIso_of_all_prefixes
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hprefix : ∀ N : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ))) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) := by
+  rw [quasiIso_iff]
+  intro n
+  exact firstQuadrantTotal_quasiIsoAt_of_prefix f (n + 1) n le_rfl (hprefix (n + 1))
+
+/-- The map between bicomplexes concentrated in one outer column induced by a bicomplex map. -/
+public noncomputable def firstQuadrantSingleColumnMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantSingleColumn K p ⟶ firstQuadrantSingleColumn L p :=
+  (HomologicalComplex.single (ChainComplex AddCommGrpCat ℕ)
+    (ComplexShape.down ℕ) p).map (f.f p)
+
+/-- Projection from a total supported in outer column `p` to its sole summand in
+total degree `p + q`. -/
+public noncomputable def firstQuadrantSingleColumnTotalXHom
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) ⟶
+      (K.X p).X q :=
+  (firstQuadrantSingleColumn K p).totalDesc (fun r s hrs => by
+    by_cases hr : r = p
+    · subst r
+      have hs : s = q := by
+        change p + s = p + q at hrs
+        omega
+      subst s
+      exact (firstQuadrantSingleColumnXIso K p).hom.f q
+    · exact 0)
+
+/-- Inclusion of the sole summand of a single-column total. -/
+public noncomputable def firstQuadrantSingleColumnTotalXInv
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    (K.X p).X q ⟶
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) :=
+  (firstQuadrantSingleColumnXIso K p).inv.f q ≫
+    (firstQuadrantSingleColumn K p).ιTotal
+      (ComplexShape.down ℕ) p q (p + q) rfl
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantSingleColumnTotalXHom_inv
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    firstQuadrantSingleColumnTotalXHom K p q ≫
+      firstQuadrantSingleColumnTotalXInv K p q = 𝟙 _ := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  by_cases hr : r = p
+  · subst r
+    have hs : s = q := by
+      change p + s = p + q at hrs
+      omega
+    subst s
+    dsimp [firstQuadrantSingleColumnTotalXHom,
+      firstQuadrantSingleColumnTotalXInv]
+    rw [HomologicalComplex₂.ι_totalDesc_assoc]
+    simp
+  · have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) s).map_isZero
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) p (K.X p) r hr)
+    exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+public theorem firstQuadrantSingleColumnTotalXInv_hom
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    firstQuadrantSingleColumnTotalXInv K p q ≫
+      firstQuadrantSingleColumnTotalXHom K p q = 𝟙 _ := by
+  dsimp [firstQuadrantSingleColumnTotalXHom,
+    firstQuadrantSingleColumnTotalXInv]
+  rw [Category.assoc, HomologicalComplex₂.ι_totalDesc]
+  simp
+
+/-- In degree `p + q`, a total supported in outer column `p` is canonically its sole
+summand in inner degree `q`. -/
+public noncomputable def firstQuadrantSingleColumnTotalXIso
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) ≅
+      (K.X p).X q where
+  hom := firstQuadrantSingleColumnTotalXHom K p q
+  inv := firstQuadrantSingleColumnTotalXInv K p q
+  hom_inv_id := firstQuadrantSingleColumnTotalXHom_inv K p q
+  inv_hom_id := firstQuadrantSingleColumnTotalXInv_hom K p q
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Under the sole-summand identification, the differential on the total supported in
+outer column `p` is the vertical differential multiplied by the total-complex sign at `p`. -/
+public theorem firstQuadrantSingleColumnTotalXIso_d
+    (K : FirstQuadrantBicomplex) (p i j : ℕ)
+    (hij : (ComplexShape.down ℕ).Rel i j) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d
+        (p + i) (p + j) ≫
+      (firstQuadrantSingleColumnTotalXIso K p j).hom =
+    (ComplexShape.down ℕ).ε p •
+      ((firstQuadrantSingleColumnTotalXIso K p i).hom ≫ (K.X p).d i j) := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  by_cases hr : r = p
+  · subst r
+    have hs : s = i := by
+      change p + s = p + i at hrs
+      omega
+    subst s
+    rw [Linear.comp_units_smul]
+    dsimp only [HomologicalComplex₂.total_d]
+    rw [← Category.assoc, Preadditive.comp_add,
+      HomologicalComplex₂.ι_D₁, HomologicalComplex₂.ι_D₂]
+    have hd₁ : (firstQuadrantSingleColumn K p).d₁
+        (ComplexShape.down ℕ) p i (p + j) = 0 := by
+      dsimp [HomologicalComplex₂.d₁]
+      simp
+    rw [hd₁, zero_add]
+    rw [HomologicalComplex₂.d₂_eq
+      (firstQuadrantSingleColumn K p) (ComplexShape.down ℕ)
+      p hij (p + j) (by
+        change p + j = p + j
+        rfl)]
+    dsimp [firstQuadrantSingleColumnTotalXIso,
+      firstQuadrantSingleColumnTotalXHom]
+    rw [Linear.units_smul_comp, Category.assoc,
+      HomologicalComplex₂.ι_totalDesc]
+    simp
+  · have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) s).map_isZero
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) p (K.X p) r hr)
+    exact hz.eq_of_src _ _
+
+/-- The sign-twisted sole-summand identification which removes the constant vertical sign
+from a total supported in outer column `p`. -/
+public noncomputable def firstQuadrantSingleColumnTotalScaledXIso
+    (K : FirstQuadrantBicomplex) (p q : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X (p + q) ≅
+      (K.X p).X q :=
+  ((ComplexShape.down ℕ).ε p) ^ q •
+    firstQuadrantSingleColumnTotalXIso K p q
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The scaled sole-summand identifications commute with the differentials. -/
+public theorem firstQuadrantSingleColumnTotalScaledXIso_d
+    (K : FirstQuadrantBicomplex) (p i j : ℕ)
+    (hij : (ComplexShape.down ℕ).Rel i j) :
+    (firstQuadrantSingleColumnTotalScaledXIso K p i).hom ≫ (K.X p).d i j =
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d
+          (p + i) (p + j) ≫
+        (firstQuadrantSingleColumnTotalScaledXIso K p j).hom := by
+  change j + 1 = i at hij
+  subst i
+  change (((ComplexShape.down ℕ).ε p) ^ (j + 1) •
+      (firstQuadrantSingleColumnTotalXIso K p (j + 1)).hom) ≫ _ =
+    _ ≫ (((ComplexShape.down ℕ).ε p) ^ j •
+      (firstQuadrantSingleColumnTotalXIso K p j).hom)
+  rw [Linear.units_smul_comp, Linear.comp_units_smul,
+    firstQuadrantSingleColumnTotalXIso_d K p (j + 1) j (by simp), smul_smul,
+    pow_succ]
+
+/-- Embed inner degree `q` as total degree `p + q`. -/
+public abbrev firstQuadrantColumnDegreeEmbedding (p : ℕ) :
+    (ComplexShape.down ℕ).Embedding (ComplexShape.down ℕ) where
+  f q := p + q
+  injective_f := fun _ _ h => Nat.add_left_cancel h
+  rel := by
+    intro i j hij
+    change j + 1 = i at hij
+    change p + j + 1 = p + i
+    omega
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the unscaled sole-summand identification. -/
+public theorem firstQuadrantSingleColumnTotalXIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p q : ℕ) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f (p + q) ≫
+      (firstQuadrantSingleColumnTotalXIso L p q).hom =
+    (firstQuadrantSingleColumnTotalXIso K p q).hom ≫ (f.f p).f q := by
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  by_cases hr : r = p
+  · subst r
+    have hs : s = q := by
+      change p + s = p + q at hrs
+      omega
+    subst s
+    dsimp [firstQuadrantSingleColumnTotalXIso,
+      firstQuadrantSingleColumnTotalXHom]
+    rw [HomologicalComplex₂.ιTotal_map_assoc,
+      HomologicalComplex₂.ι_totalDesc,
+      HomologicalComplex₂.ι_totalDesc_assoc]
+    dsimp [firstQuadrantSingleColumnMap,
+      firstQuadrantSingleColumnXIso]
+    rw [HomologicalComplex.single_map_f_self]
+    simp
+  · have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) s).map_isZero
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) p (K.X p) r hr)
+    exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the sign-twisted sole-summand identification. -/
+public theorem firstQuadrantSingleColumnTotalScaledXIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p q : ℕ) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f (p + q) ≫
+      (firstQuadrantSingleColumnTotalScaledXIso L p q).hom =
+    (firstQuadrantSingleColumnTotalScaledXIso K p q).hom ≫ (f.f p).f q := by
+  change _ ≫ (((ComplexShape.down ℕ).ε p) ^ q •
+      (firstQuadrantSingleColumnTotalXIso L p q).hom) =
+    (((ComplexShape.down ℕ).ε p) ^ q •
+      (firstQuadrantSingleColumnTotalXIso K p q).hom) ≫ _
+  rw [Linear.comp_units_smul, Linear.units_smul_comp,
+    firstQuadrantSingleColumnTotalXIso_naturality]
+
+/-- Outside degrees `p + q`, the total supported in column `p` is zero. -/
+public theorem firstQuadrantSingleColumnTotalX_isZero_of_not_exists
+    (K : FirstQuadrantBicomplex) (p n : ℕ)
+    (hn : ∀ q : ℕ, p + q ≠ n) :
+    IsZero (((firstQuadrantSingleColumn K p).total
+      (ComplexShape.down ℕ)).X n) := by
+  rw [IsZero.iff_id_eq_zero]
+  apply HomologicalComplex₂.total.hom_ext
+  intro r s hrs
+  rw [Category.comp_id, comp_zero]
+  have hr : r ≠ p := by
+    intro hr
+    subst r
+    exact hn s hrs
+  have hz : IsZero (((firstQuadrantSingleColumn K p).X r).X s) :=
+    (HomologicalComplex.eval AddCommGrpCat
+      (ComplexShape.down ℕ) s).map_isZero
+      (HomologicalComplex.isZero_single_obj_X
+        (ComplexShape.down ℕ) p (K.X p) r hr)
+  exact hz.eq_of_src _ _
+
+/-- The component isomorphism from a single-column total to the extension-by-zero of its
+sole column, when the total degree is explicitly `p + q`. -/
+public noncomputable def firstQuadrantSingleColumnTotalExtendedXIsoOfEq
+    (K : FirstQuadrantBicomplex) (p q n : ℕ) (h : p + q = n) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X n ≅
+      ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).X n :=
+  (((firstQuadrantSingleColumn K p).total
+      (ComplexShape.down ℕ)).XIsoOfEq h).symm ≪≫
+    firstQuadrantSingleColumnTotalScaledXIso K p q ≪≫
+    ((K.X p).extendXIso (firstQuadrantColumnDegreeEmbedding p) h).symm
+
+/-- Componentwise comparison of a single-column total with the extension-by-zero of its
+sole column. -/
+public noncomputable def firstQuadrantSingleColumnTotalExtendedXIso
+    (K : FirstQuadrantBicomplex) (p n : ℕ) :
+    ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).X n ≅
+      ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).X n := by
+  by_cases hn : p ≤ n
+  · exact firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p
+      (n - p) n (by omega)
+  · exact
+      (firstQuadrantSingleColumnTotalX_isZero_of_not_exists K p n
+        (by intro q h; omega)).isoZero ≪≫
+      ((K.X p).isZero_extend_X (firstQuadrantColumnDegreeEmbedding p) n
+        (by
+          intro q h
+          apply hn
+          change p + q = n at h
+          omega)).isoZero.symm
+
+public theorem firstQuadrantSingleColumnTotalExtendedXIso_eq
+    (K : FirstQuadrantBicomplex) (p q n : ℕ) (h : p + q = n) :
+    firstQuadrantSingleColumnTotalExtendedXIso K p n =
+      firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p q n h := by
+  subst n
+  simp [firstQuadrantSingleColumnTotalExtendedXIso]
+
+/-- The extended component comparisons commute with differentials between degrees in the
+image of the degree embedding. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIsoOfEq_d
+    (K : FirstQuadrantBicomplex) (p i j n m : ℕ)
+    (hi : p + i = n) (hj : p + j = m)
+    (hij : (ComplexShape.down ℕ).Rel i j) :
+    (firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p i n hi).hom ≫
+        ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).d n m =
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d n m ≫
+        (firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p j m hj).hom := by
+  subst n
+  subst m
+  dsimp [firstQuadrantSingleColumnTotalExtendedXIsoOfEq]
+  rw [(K.X p).extend_d_eq (firstQuadrantColumnDegreeEmbedding p) rfl rfl]
+  simp only [Category.assoc, Iso.inv_hom_id_assoc]
+  simp only [Category.id_comp]
+  rw [← Category.assoc,
+    firstQuadrantSingleColumnTotalScaledXIso_d K p i j hij]
+  rw [Category.assoc]
+
+/-- The componentwise comparisons commute with all differentials, including the lower
+boundary where extension by zero supplies the missing target degree. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIso_d
+    (K : FirstQuadrantBicomplex) (p n m : ℕ)
+    (hnm : (ComplexShape.down ℕ).Rel n m) :
+    (firstQuadrantSingleColumnTotalExtendedXIso K p n).hom ≫
+        ((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).d n m =
+      ((firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ)).d n m ≫
+        (firstQuadrantSingleColumnTotalExtendedXIso K p m).hom := by
+  change m + 1 = n at hnm
+  by_cases hn : p ≤ n
+  · let q := n - p
+    have hnq : p + q = n := by
+      dsimp [q]
+      omega
+    by_cases hq : q = 0
+    · have hm : m < p := by omega
+      have hz : IsZero
+          (((K.X p).extend (firstQuadrantColumnDegreeEmbedding p)).X m) :=
+        (K.X p).isZero_extend_X (firstQuadrantColumnDegreeEmbedding p) m (by
+          intro r hr
+          change p + r = m at hr
+          omega)
+      exact hz.eq_of_tgt _ _
+    · let j := q - 1
+      have hjq : j + 1 = q := by
+        dsimp [j]
+        omega
+      have hmj : p + j = m := by omega
+      rw [firstQuadrantSingleColumnTotalExtendedXIso_eq K p q n hnq,
+        firstQuadrantSingleColumnTotalExtendedXIso_eq K p j m hmj]
+      exact firstQuadrantSingleColumnTotalExtendedXIsoOfEq_d
+        K p q j n m hnq hmj (by
+          change j + 1 = q
+          exact hjq)
+  · have hz : IsZero
+        (((firstQuadrantSingleColumn K p).total
+          (ComplexShape.down ℕ)).X n) :=
+      firstQuadrantSingleColumnTotalX_isZero_of_not_exists K p n (by
+        intro q h
+        apply hn
+        omega)
+    exact hz.eq_of_src _ _
+
+/-- A total supported in one outer column is the extension by zero of that column, with
+the canonical Koszul untwisting signs. -/
+public noncomputable def firstQuadrantSingleColumnTotalExtendedIso
+    (K : FirstQuadrantBicomplex) (p : ℕ) :
+    (firstQuadrantSingleColumn K p).total (ComplexShape.down ℕ) ≅
+      (K.X p).extend (firstQuadrantColumnDegreeEmbedding p) :=
+  HomologicalComplex.Hom.isoOfComponents
+    (firstQuadrantSingleColumnTotalExtendedXIso K p)
+    (firstQuadrantSingleColumnTotalExtendedXIso_d K p)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the extended comparison in a degree explicitly in the image. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIsoOfEq_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p q n : ℕ)
+    (h : p + q = n) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f n ≫
+      (firstQuadrantSingleColumnTotalExtendedXIsoOfEq L p q n h).hom =
+    (firstQuadrantSingleColumnTotalExtendedXIsoOfEq K p q n h).hom ≫
+      (HomologicalComplex.extendMap (f.f p)
+        (firstQuadrantColumnDegreeEmbedding p)).f n := by
+  subst n
+  dsimp [firstQuadrantSingleColumnTotalExtendedXIsoOfEq]
+  rw [HomologicalComplex.extendMap_f (f.f p)
+    (firstQuadrantColumnDegreeEmbedding p) rfl]
+  simp only [Category.id_comp, Category.assoc, Iso.inv_hom_id_assoc]
+  rw [← Category.assoc,
+    firstQuadrantSingleColumnTotalScaledXIso_naturality,
+    Category.assoc]
+
+/-- Naturality of the componentwise extended comparison in every total degree. -/
+public theorem firstQuadrantSingleColumnTotalExtendedXIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p n : ℕ) :
+    (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ)).f n ≫
+      (firstQuadrantSingleColumnTotalExtendedXIso L p n).hom =
+    (firstQuadrantSingleColumnTotalExtendedXIso K p n).hom ≫
+      (HomologicalComplex.extendMap (f.f p)
+        (firstQuadrantColumnDegreeEmbedding p)).f n := by
+  by_cases hn : p ≤ n
+  · let q := n - p
+    have h : p + q = n := by
+      dsimp [q]
+      omega
+    rw [firstQuadrantSingleColumnTotalExtendedXIso_eq L p q n h,
+      firstQuadrantSingleColumnTotalExtendedXIso_eq K p q n h]
+    exact firstQuadrantSingleColumnTotalExtendedXIsoOfEq_naturality f p q n h
+  · have hz : IsZero
+        (((firstQuadrantSingleColumn K p).total
+          (ComplexShape.down ℕ)).X n) :=
+      firstQuadrantSingleColumnTotalX_isZero_of_not_exists K p n (by
+        intro q h
+        apply hn
+        omega)
+    exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Naturality of the single-column total/extension chain isomorphism. -/
+@[reassoc]
+public theorem firstQuadrantSingleColumnTotalExtendedIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ) ≫
+      (firstQuadrantSingleColumnTotalExtendedIso L p).hom =
+    (firstQuadrantSingleColumnTotalExtendedIso K p).hom ≫
+      HomologicalComplex.extendMap (f.f p)
+        (firstQuadrantColumnDegreeEmbedding p) := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  exact firstQuadrantSingleColumnTotalExtendedXIso_naturality f p n
+
+set_option linter.style.haveILetI false in
+/-- A quasi-isomorphism on the sole column remains a quasi-isomorphism after placing that
+column in any outer degree and totalizing. -/
+public theorem firstQuadrantSingleColumnTotal_quasiIso
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ)
+    (hcolumn : QuasiIso (f.f p)) :
+    QuasiIso (HomologicalComplex₂.total.map
+      (firstQuadrantSingleColumnMap f p) (ComplexShape.down ℕ)) := by
+  let a := HomologicalComplex₂.total.map
+    (firstQuadrantSingleColumnMap f p) (ComplexShape.down ℕ)
+  let b := (firstQuadrantSingleColumnTotalExtendedIso L p).hom
+  let c := (firstQuadrantSingleColumnTotalExtendedIso K p).hom
+  let d := HomologicalComplex.extendMap (f.f p)
+    (firstQuadrantColumnDegreeEmbedding p)
+  letI : IsIso b := by dsimp [b]; infer_instance
+  letI : IsIso c := by dsimp [c]; infer_instance
+  letI : QuasiIso (f.f p) := hcolumn
+  letI : QuasiIso d := by
+    dsimp [d]
+    infer_instance
+  letI : QuasiIso (a ≫ b) := by
+    rw [show a ≫ b = c ≫ d from
+      firstQuadrantSingleColumnTotalExtendedIso_naturality f p]
+    infer_instance
+  exact quasiIso_of_comp_right a b
+
+set_option linter.unnecessarySimpa false in
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrantColumnPrefixMap_XIso_hom
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (N p : ℕ) (hp : p ≤ N) :
+    (firstQuadrantColumnPrefixMap f N).f p ≫
+      (firstQuadrantColumnPrefixXIso L N p hp).hom =
+    (firstQuadrantColumnPrefixXIso K N p hp).hom ≫ f.f p := by
+  simpa [firstQuadrantColumnPrefixMap, firstQuadrantColumnPrefixXIso] using
+    (HomologicalComplex.stupidTruncMap_stupidTruncXIso_hom
+      f (firstQuadrantColumnPrefixEmbedding N)
+      (i := ⟨p, hp⟩) (i' := p) rfl)
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrantColumnPrefixSuccInclusion_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantColumnPrefixMap f p ≫
+      firstQuadrantColumnPrefixSuccInclusion L p =
+    firstQuadrantColumnPrefixSuccInclusion K p ≫
+      firstQuadrantColumnPrefixMap f (p + 1) := by
+  apply HomologicalComplex.hom_ext
+  intro q
+  by_cases hq : q ≤ p
+  · change (firstQuadrantColumnPrefixMap f p).f q ≫
+      firstQuadrantColumnPrefixSuccInclusionComponent L p q =
+        firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+          (firstQuadrantColumnPrefixMap f (p + 1)).f q
+    rw [firstQuadrantColumnPrefixSuccInclusionComponent_of_le L p q hq,
+      firstQuadrantColumnPrefixSuccInclusionComponent_of_le K p q hq]
+    rw [← Category.assoc,
+      firstQuadrantColumnPrefixMap_XIso_hom f p q hq]
+    rw [Category.assoc, Category.assoc]
+    apply (cancel_mono
+      (firstQuadrantColumnPrefixXIso L (p + 1) q (by omega)).hom).1
+    simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id]
+    rw [firstQuadrantColumnPrefixMap_XIso_hom f (p + 1) q (by omega)]
+    simp
+  · have hpq : p < q := by omega
+    change (firstQuadrantColumnPrefixMap f p).f q ≫
+      firstQuadrantColumnPrefixSuccInclusionComponent L p q =
+        firstQuadrantColumnPrefixSuccInclusionComponent K p q ≫
+          (firstQuadrantColumnPrefixMap f (p + 1)).f q
+    rw [firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero L p q hpq,
+      firstQuadrantColumnPrefixSuccInclusionComponent_eq_zero K p q hpq,
+      comp_zero, zero_comp]
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrantColumnPrefixToLast_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantColumnPrefixMap f p ≫
+      firstQuadrantColumnPrefixToLast L p =
+    firstQuadrantColumnPrefixToLast K p ≫
+      firstQuadrantSingleColumnMap f p := by
+  apply HomologicalComplex.hom_ext
+  intro q
+  by_cases hq : q = p
+  · subst q
+    change (firstQuadrantColumnPrefixMap f p).f p ≫
+      firstQuadrantColumnPrefixToLastComponent L p p =
+        firstQuadrantColumnPrefixToLastComponent K p p ≫
+          (firstQuadrantSingleColumnMap f p).f p
+    rw [firstQuadrantColumnPrefixToLastComponent_self,
+      firstQuadrantColumnPrefixToLastComponent_self]
+    rw [← Category.assoc,
+      firstQuadrantColumnPrefixMap_XIso_hom f p p le_rfl]
+    dsimp only [firstQuadrantSingleColumnMap, firstQuadrantSingleColumnXIso]
+    rw [
+      HomologicalComplex.single_map_f_self]
+    simp
+  · change (firstQuadrantColumnPrefixMap f p).f q ≫
+      firstQuadrantColumnPrefixToLastComponent L p q =
+        firstQuadrantColumnPrefixToLastComponent K p q ≫
+          (firstQuadrantSingleColumnMap f p).f q
+    rw [firstQuadrantColumnPrefixToLastComponent_eq_zero L p q hq,
+      firstQuadrantColumnPrefixToLastComponent_eq_zero K p q hq,
+      comp_zero, zero_comp]
+
+/-- A bicomplex map induces a morphism between the successor short exact sequences of its
+finite column filtrations. -/
+public noncomputable def firstQuadrantColumnPrefixSuccShortComplexMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    firstQuadrantColumnPrefixSuccShortComplex K p ⟶
+      firstQuadrantColumnPrefixSuccShortComplex L p where
+  τ₁ := firstQuadrantColumnPrefixMap f p
+  τ₂ := firstQuadrantColumnPrefixMap f (p + 1)
+  τ₃ := firstQuadrantSingleColumnMap f (p + 1)
+  comm₁₂ := firstQuadrantColumnPrefixSuccInclusion_naturality f p
+  comm₂₃ := firstQuadrantColumnPrefixToLast_naturality f (p + 1)
+
+set_option linter.style.haveILetI false in
+/-- The zeroth prefix is already its sole-column quotient. -/
+public theorem firstQuadrantColumnPrefixToLast_zero_isIso
+    (K : FirstQuadrantBicomplex) :
+    IsIso (firstQuadrantColumnPrefixToLast K 0) := by
+  letI : ∀ q : ℕ, IsIso ((firstQuadrantColumnPrefixToLast K 0).f q) := fun q => by
+    by_cases hq : q = 0
+    · subst q
+      change IsIso (firstQuadrantColumnPrefixToLastComponent K 0 0)
+      rw [firstQuadrantColumnPrefixToLastComponent_self]
+      infer_instance
+    · have hpos : 0 < q := by omega
+      change IsIso (firstQuadrantColumnPrefixToLastComponent K 0 q)
+      rw [firstQuadrantColumnPrefixToLastComponent_eq_zero K 0 q hq]
+      exact (firstQuadrantColumnPrefix_isZero_X K 0 q hpos).isIso
+        (HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) 0 (K.X 0) q hq) _
+  exact HomologicalComplex.Hom.isIso_of_components _
+
+@[reassoc]
+public theorem firstQuadrantColumnPrefixToLast_total_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (p : ℕ) :
+    HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f p)
+        (ComplexShape.down ℕ) ≫
+      HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast L p)
+        (ComplexShape.down ℕ) =
+    HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast K p)
+        (ComplexShape.down ℕ) ≫
+      HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ) := by
+  rw [← HomologicalComplex₂.total.map_comp,
+    ← HomologicalComplex₂.total.map_comp]
+  exact congrArg
+    (fun g => HomologicalComplex₂.total.map g (ComplexShape.down ℕ))
+    (firstQuadrantColumnPrefixToLast_naturality f p)
+
+set_option linter.style.haveILetI false in
+/-- If every single-column layer map becomes a quasi-isomorphism on totalization, then every
+finite column-prefix map does as well. -/
+public theorem firstQuadrantFinitePrefixTotal_quasiIso_of_singleColumns
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hsingle : ∀ p : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ))) :
+    ∀ N : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+        (ComplexShape.down ℕ)) := by
+  intro N
+  induction N with
+  | zero =>
+      let a := HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f 0)
+        (ComplexShape.down ℕ)
+      let b := HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast L 0)
+        (ComplexShape.down ℕ)
+      let c := HomologicalComplex₂.total.map (firstQuadrantColumnPrefixToLast K 0)
+        (ComplexShape.down ℕ)
+      let d := HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f 0)
+        (ComplexShape.down ℕ)
+      letI : IsIso (firstQuadrantColumnPrefixToLast K 0) :=
+        firstQuadrantColumnPrefixToLast_zero_isIso K
+      letI : IsIso (firstQuadrantColumnPrefixToLast L 0) :=
+        firstQuadrantColumnPrefixToLast_zero_isIso L
+      letI : IsIso b := by
+        dsimp [b]
+        exact (HomologicalComplex₂.total.mapIso
+          (asIso (firstQuadrantColumnPrefixToLast L 0))
+          (ComplexShape.down ℕ)).isIso_hom
+      letI : IsIso c := by
+        dsimp [c]
+        exact (HomologicalComplex₂.total.mapIso
+          (asIso (firstQuadrantColumnPrefixToLast K 0))
+          (ComplexShape.down ℕ)).isIso_hom
+      letI : QuasiIso d := hsingle 0
+      letI : QuasiIso (a ≫ b) := by
+        rw [show a ≫ b = c ≫ d from
+          firstQuadrantColumnPrefixToLast_total_naturality f 0]
+        infer_instance
+      exact quasiIso_of_comp_right a b
+  | succ N ih =>
+      let T := HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+      let S₁ := firstQuadrantColumnPrefixSuccShortComplex K N
+      let S₂ := firstQuadrantColumnPrefixSuccShortComplex L N
+      let φ := T.mapShortComplex.map
+        (firstQuadrantColumnPrefixSuccShortComplexMap f N)
+      have hS₁ : S₁.ShortExact :=
+        firstQuadrantColumnPrefixSuccShortComplex_shortExact K N
+      have hS₂ : S₂.ShortExact :=
+        firstQuadrantColumnPrefixSuccShortComplex_shortExact L N
+      have hTS₁ : (S₁.map T).ShortExact := firstQuadrantTotal_shortExact S₁ hS₁
+      have hTS₂ : (S₂.map T).ShortExact := firstQuadrantTotal_shortExact S₂ hS₂
+      have h₁ : QuasiIso φ.τ₁ := by
+        change QuasiIso
+          (HomologicalComplex₂.total.map (firstQuadrantColumnPrefixMap f N)
+            (ComplexShape.down ℕ))
+        exact ih
+      have h₃ : QuasiIso φ.τ₃ := by
+        change QuasiIso
+          (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f (N + 1))
+            (ComplexShape.down ℕ))
+        exact hsingle (N + 1)
+      have h₂ : QuasiIso φ.τ₂ :=
+        quasiIso_middle_of_shortExact φ hTS₁ hTS₂ h₁ h₃
+      exact h₂
+
+/-- Columnwise quasi-isomorphisms after totalizing the individual layers imply a
+quasi-isomorphism on the full first-quadrant total. -/
+public theorem firstQuadrantTotal_quasiIso_of_singleColumns
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hsingle : ∀ p : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map (firstQuadrantSingleColumnMap f p)
+        (ComplexShape.down ℕ))) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) :=
+  firstQuadrantTotal_quasiIso_of_all_prefixes f
+    (firstQuadrantFinitePrefixTotal_quasiIso_of_singleColumns f hsingle)
+
+/-- Koszul symmetry for the standard first-quadrant total-complex signs. -/
+public instance firstQuadrantTotalComplexShapeSymmetry :
+    TotalComplexShapeSymmetry
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ) where
+  symm p q := add_comm q p
+  σ p q := (-1 : ℤˣ) ^ (p * q)
+  σ_ε₁ := by
+    rintro p p' hp q
+    change p' + 1 = p at hp
+    subst p
+    dsimp
+    rw [mul_one, add_mul, one_mul, pow_add, pow_mul]
+    exact mul_comm _ _
+  σ_ε₂ := by
+    rintro p q q' hq
+    change q' + 1 = q at hq
+    subst q
+    dsimp
+    rw [one_mul, mul_add, mul_one, pow_add, mul_assoc,
+      Int.units_mul_self, mul_one]
+
+/-- Flip a first-quadrant bicomplex map across the diagonal. -/
+public def firstQuadrantFlipMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) : K.flip ⟶ L.flip :=
+  (HomologicalComplex₂.flipFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map f
+
+/-- A column map of the flipped bicomplex is exactly the corresponding horizontal row map. -/
+public theorem firstQuadrantFlipMap_column_eq_horizontalRowMap
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) (q : ℕ) :
+    (firstQuadrantFlipMap f).f q = firstQuadrantHorizontalRowMap f q := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+@[reassoc]
+public theorem firstQuadrant_totalFlipIso_naturality
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L) :
+    HomologicalComplex₂.total.map (firstQuadrantFlipMap f)
+        (ComplexShape.down ℕ) ≫
+      (L.totalFlipIso (ComplexShape.down ℕ)).hom =
+    (K.totalFlipIso (ComplexShape.down ℕ)).hom ≫
+      HomologicalComplex₂.total.map f (ComplexShape.down ℕ) := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  dsimp only [HomologicalComplex.comp_f]
+  rw [HomologicalComplex₂.ιTotal_map_assoc,
+    HomologicalComplex₂.ιTotal_totalFlipIso_f_hom,
+    HomologicalComplex₂.ιTotal_totalFlipIso_f_hom_assoc]
+  change (f.f q).f p ≫ (_ • _) = (_ • _) ≫ _
+  rw [Linear.comp_units_smul, Linear.units_smul_comp,
+    HomologicalComplex₂.ιTotal_map]
+
+set_option linter.style.haveILetI false in
+/-- It is enough to prove the single-column total statement after flipping: total symmetry then
+returns the desired quasi-isomorphism for the original bicomplex map. -/
+public theorem firstQuadrantTotal_quasiIso_of_flipped_singleColumns
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hsingle : ∀ p : ℕ, QuasiIso
+      (HomologicalComplex₂.total.map
+        (firstQuadrantSingleColumnMap (firstQuadrantFlipMap f) p)
+        (ComplexShape.down ℕ))) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) := by
+  let g := HomologicalComplex₂.total.map (firstQuadrantFlipMap f)
+    (ComplexShape.down ℕ)
+  let eK := (K.totalFlipIso (ComplexShape.down ℕ)).hom
+  let eL := (L.totalFlipIso (ComplexShape.down ℕ)).hom
+  let h := HomologicalComplex₂.total.map f (ComplexShape.down ℕ)
+  letI : QuasiIso g := firstQuadrantTotal_quasiIso_of_singleColumns
+    (firstQuadrantFlipMap f) hsingle
+  letI : IsIso eK := by dsimp [eK]; infer_instance
+  letI : IsIso eL := by dsimp [eL]; infer_instance
+  letI : QuasiIso (eK ≫ h) := by
+    rw [← show g ≫ eL = eK ≫ h from firstQuadrant_totalFlipIso_naturality f]
+    infer_instance
+  exact quasiIso_of_comp_left eK h
+
+/-- Rowwise quasi-isomorphisms of first-quadrant bicomplexes induce a quasi-isomorphism on
+their direct-sum total complexes. -/
+public theorem firstQuadrantTotal_quasiIso_of_rows
+    {K L : FirstQuadrantBicomplex} (f : K ⟶ L)
+    (hrow : ∀ q : ℕ, QuasiIso (firstQuadrantHorizontalRowMap f q)) :
+    QuasiIso (HomologicalComplex₂.total.map f (ComplexShape.down ℕ)) := by
+  apply firstQuadrantTotal_quasiIso_of_flipped_singleColumns f
+  intro q
+  apply firstQuadrantSingleColumnTotal_quasiIso
+    (firstQuadrantFlipMap f) q
+  rw [firstQuadrantFlipMap_column_eq_horizontalRowMap]
+  exact hrow q
+
+/-- The exact generic rowwise-totalization proposition used by the boundary-seven Cech
+assembly is therefore unconditional. -/
+public theorem firstQuadrantRowwiseTotalization :
+    FirstQuadrantRowwiseTotalization := by
+  intro K L f hrow
+  exact firstQuadrantTotal_quasiIso_of_rows f hrow
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantSingleColumnTotal.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantSingleColumnTotal.lean
@@ -1,0 +1,190 @@
+module
+
+public import SphereSixComplex.Topology.FirstQuadrantTotalComplex
+
+/-!
+# The total complex of the horizontal zero column
+
+This file supplies the missing unitor identifying the direct-sum total of a bicomplex supported
+only in horizontal degree zero with its unique nonzero column.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- Put a chain complex in horizontal degree zero of a first-quadrant bicomplex. -/
+public noncomputable abbrev firstQuadrantSingleZeroBicomplex
+    (K : FirstQuadrantChainComplex) : FirstQuadrantBicomplex :=
+  (ChainComplex.single₀ (ChainComplex AddCommGrpCat ℕ)).obj K
+
+/-- The degree-zero horizontal column is canonically the original chain complex. -/
+public noncomputable def firstQuadrantSingleZeroColumnIso
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).X 0 ≅ K :=
+  HomologicalComplex.singleObjXSelf (ComplexShape.down ℕ) 0 K
+
+/-- The canonical inclusion of the actual horizontal zero column into the total complex. -/
+public noncomputable def firstQuadrantZeroColumnToTotal
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).X 0 ⟶
+      (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) where
+  f n := (firstQuadrantSingleZeroBicomplex K).ιTotal
+    (ComplexShape.down ℕ) 0 n n (by simp)
+  comm' := by
+    intro i j hij
+    change _ ≫
+      ((firstQuadrantSingleZeroBicomplex K).D₁
+        (ComplexShape.down ℕ) i j +
+       (firstQuadrantSingleZeroBicomplex K).D₂
+        (ComplexShape.down ℕ) i j) =
+      ((firstQuadrantSingleZeroBicomplex K).X 0).d i j ≫ _
+    rw [Preadditive.comp_add,
+      HomologicalComplex₂.ι_D₁,
+      HomologicalComplex₂.ι_D₂]
+    have hd₁ : (firstQuadrantSingleZeroBicomplex K).d₁
+        (ComplexShape.down ℕ) 0 i j = 0 := by
+      apply HomologicalComplex₂.d₁_eq_zero
+      simp
+    rw [hd₁, zero_add]
+    rw [HomologicalComplex₂.d₂_eq
+      (firstQuadrantSingleZeroBicomplex K)
+      (ComplexShape.down ℕ) 0 hij j (by simp)]
+    change (ComplexShape.down ℕ).ε 0 • _ = _
+    rw [ComplexShape.ε_zero, one_smul]
+
+/-- The canonical inclusion of the unique nonzero column into the total complex. -/
+public noncomputable def firstQuadrantSingleZeroToTotal
+    (K : FirstQuadrantChainComplex) :
+    K ⟶ (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) :=
+  (firstQuadrantSingleZeroColumnIso K).inv ≫ firstQuadrantZeroColumnToTotal K
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The componentwise projection used to descend from the total complex. -/
+public noncomputable def firstQuadrantSingleZeroTotalComponent
+    (K : FirstQuadrantChainComplex) (n p q : ℕ)
+    (hpq : (ComplexShape.down ℕ).π (ComplexShape.down ℕ)
+      (ComplexShape.down ℕ) (p, q) = n) :
+    ((firstQuadrantSingleZeroBicomplex K).X p).X q ⟶ K.X n := by
+  rcases p with _ | p
+  · change 0 + q = n at hpq
+    simp only [zero_add] at hpq
+    subst n
+    exact (firstQuadrantSingleZeroColumnIso K).hom.f q
+  · exact 0
+
+@[simp]
+public theorem firstQuadrantSingleZeroTotalComponent_zero
+    (K : FirstQuadrantChainComplex) (q : ℕ) :
+    firstQuadrantSingleZeroTotalComponent K q 0 q (by simp) =
+      (firstQuadrantSingleZeroColumnIso K).hom.f q := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Project the total complex supported in horizontal degree zero back to its unique column. -/
+public noncomputable def firstQuadrantTotalToSingleZero
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) ⟶ K where
+  f n := (firstQuadrantSingleZeroBicomplex K).totalDesc
+    (firstQuadrantSingleZeroTotalComponent K n)
+  comm' := by
+    intro i j hij
+    apply HomologicalComplex₂.total.hom_ext
+    intro p q hpq
+    rcases p with _ | p
+    · have hqi : q = i := by simpa using hpq
+      subst q
+      rw [← Category.assoc,
+        HomologicalComplex₂.ι_totalDesc]
+      simp only [firstQuadrantSingleZeroTotalComponent_zero]
+      rw [(firstQuadrantSingleZeroColumnIso K).hom.comm i j]
+      change ((firstQuadrantSingleZeroBicomplex K).X 0).d i j ≫
+          (firstQuadrantSingleZeroColumnIso K).hom.f j =
+        (firstQuadrantSingleZeroBicomplex K).ιTotal
+            (ComplexShape.down ℕ) 0 i i (by simp) ≫
+            ((firstQuadrantSingleZeroBicomplex K).D₁
+                (ComplexShape.down ℕ) i j +
+              (firstQuadrantSingleZeroBicomplex K).D₂
+                (ComplexShape.down ℕ) i j) ≫ _
+      rw [← Category.assoc, Preadditive.comp_add,
+        HomologicalComplex₂.ι_D₁,
+        HomologicalComplex₂.ι_D₂]
+      have hd₁ : (firstQuadrantSingleZeroBicomplex K).d₁
+          (ComplexShape.down ℕ) 0 i j = 0 := by
+        apply HomologicalComplex₂.d₁_eq_zero
+        simp
+      rw [hd₁, zero_add]
+      rw [HomologicalComplex₂.d₂_eq
+        (firstQuadrantSingleZeroBicomplex K)
+        (ComplexShape.down ℕ) 0 hij j (by simp)]
+      simp
+    · have hzcol : IsZero
+          ((firstQuadrantSingleZeroBicomplex K).X (p + 1)) :=
+        HomologicalComplex.isZero_single_obj_X
+          (ComplexShape.down ℕ) 0 K (p + 1) (by omega)
+      have hz : IsZero
+          (((firstQuadrantSingleZeroBicomplex K).X (p + 1)).X q) :=
+        (HomologicalComplex.eval AddCommGrpCat
+          (ComplexShape.down ℕ) q).map_isZero hzcol
+      exact hz.eq_of_src _ _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Projection after inclusion is the identity of the unique column. -/
+public theorem firstQuadrantSingleZeroToTotal_comp_projection
+    (K : FirstQuadrantChainComplex) :
+    firstQuadrantSingleZeroToTotal K ≫ firstQuadrantTotalToSingleZero K =
+      𝟙 K := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  change (firstQuadrantSingleZeroBicomplex K).ιTotal
+      (ComplexShape.down ℕ) 0 n n (by simp) ≫
+      (firstQuadrantSingleZeroBicomplex K).totalDesc _ = 𝟙 _
+  rw [HomologicalComplex₂.ι_totalDesc]
+  simp [firstQuadrantSingleZeroTotalComponent,
+    firstQuadrantSingleZeroColumnIso]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Inclusion after projection is the identity of the total complex. -/
+public theorem firstQuadrantTotalToSingleZero_comp_inclusion
+    (K : FirstQuadrantChainComplex) :
+    firstQuadrantTotalToSingleZero K ≫ firstQuadrantSingleZeroToTotal K =
+      𝟙 _ := by
+  apply HomologicalComplex.Hom.ext
+  funext n
+  apply HomologicalComplex₂.total.hom_ext
+  intro p q hpq
+  rcases p with _ | p
+  · have hqn : n = q := by simpa using hpq.symm
+    cases hqn
+    simp only [HomologicalComplex.comp_f, HomologicalComplex.id_f]
+    dsimp only [firstQuadrantTotalToSingleZero,
+      firstQuadrantSingleZeroToTotal]
+    rw [← Category.assoc, HomologicalComplex₂.ι_totalDesc]
+    simp [firstQuadrantSingleZeroTotalComponent,
+      firstQuadrantSingleZeroColumnIso]
+    rfl
+  · have hzcol : IsZero
+        ((firstQuadrantSingleZeroBicomplex K).X (p + 1)) :=
+      HomologicalComplex.isZero_single_obj_X
+        (ComplexShape.down ℕ) 0 K (p + 1) (by omega)
+    have hz : IsZero
+        (((firstQuadrantSingleZeroBicomplex K).X (p + 1)).X q) :=
+      (HomologicalComplex.eval AddCommGrpCat
+        (ComplexShape.down ℕ) q).map_isZero hzcol
+    exact hz.eq_of_src _ _
+
+/-- The total of a first-quadrant bicomplex concentrated in horizontal degree zero is canonically
+isomorphic to its sole column. -/
+public noncomputable def firstQuadrantSingleZeroTotalIso
+    (K : FirstQuadrantChainComplex) :
+    (firstQuadrantSingleZeroBicomplex K).total (ComplexShape.down ℕ) ≅ K where
+  hom := firstQuadrantTotalToSingleZero K
+  inv := firstQuadrantSingleZeroToTotal K
+  hom_inv_id := firstQuadrantTotalToSingleZero_comp_inclusion K
+  inv_hom_id := firstQuadrantSingleZeroToTotal_comp_projection K
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FirstQuadrantTotalComplex.lean
+++ b/SphereSixComplex/Topology/FirstQuadrantTotalComplex.lean
@@ -1,0 +1,277 @@
+module
+
+public import Mathlib.Algebra.Category.Grp.AB
+public import Mathlib.Algebra.Homology.HomologySequenceLemmas
+public import Mathlib.Algebra.Homology.TotalComplex
+
+/-!
+# First-quadrant total complexes
+
+This file isolates the homological-algebra input needed to pass from exact rows of a
+first-quadrant bicomplex to its direct-sum total complex.  Mathlib constructs total complexes,
+but currently has no spectral-sequence or filtered-complex theorem connecting row homology to
+total homology.  We first record the exact finite-filtration induction that such a construction
+must feed.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+public abbrev FirstQuadrantBicomplex :=
+  HomologicalComplex₂ AddCommGrpCat (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+
+public abbrev FirstQuadrantChainComplex :=
+  HomologicalComplex AddCommGrpCat (ComplexShape.down ℕ)
+
+/-- The finite antidiagonal indexing the summands of a first-quadrant total complex in degree
+`n`.  This is deliberately the same fiber used by `GradedObject.mapObj` inside
+`HomologicalComplex₂.total`. -/
+public abbrev FirstQuadrantTotalFiber (n : ℕ) :=
+  {pq : ℕ × ℕ // pq.1 + pq.2 = n}
+
+noncomputable instance (n : ℕ) : Finite (FirstQuadrantTotalFiber n) := by
+  apply Finite.of_injective
+    (fun pq : FirstQuadrantTotalFiber n =>
+      (⟨pq.1.1, by omega⟩ : Fin (n + 1)))
+  intro pq rs h
+  apply Subtype.ext
+  apply Prod.ext
+  · exact Fin.ext_iff.mp h
+  · have h₁ : pq.1.1 = rs.1.1 := Fin.ext_iff.mp h
+    omega
+
+/-- Before taking the coproduct in total degree `n`, a bicomplex gives the discrete diagram of
+its entries on the `n`th antidiagonal. -/
+@[simps]
+public def firstQuadrantTotalFiberDiagramFunctor (n : ℕ) :
+    FirstQuadrantBicomplex ⥤ (Discrete (FirstQuadrantTotalFiber n) ⥤ AddCommGrpCat) where
+  obj K := Discrete.functor fun pq => (K.X pq.1.1).X pq.1.2
+  map f := Discrete.natTrans fun pq => (f.f pq.as.1.1).f pq.as.1.2
+
+/-- Evaluation of the antidiagonal diagram is the corresponding pair of evaluations of the
+bicomplex. -/
+public def firstQuadrantTotalFiberEvaluationIso (n : ℕ)
+    (pq : Discrete (FirstQuadrantTotalFiber n)) :
+    firstQuadrantTotalFiberDiagramFunctor n ⋙
+        (evaluation (Discrete (FirstQuadrantTotalFiber n)) AddCommGrpCat).obj pq ≅
+      HomologicalComplex.eval FirstQuadrantChainComplex (ComplexShape.down ℕ) pq.as.1.1 ⋙
+        HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) pq.as.1.2 :=
+  NatIso.ofComponents (fun _ => Iso.refl _)
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteLimits (firstQuadrantTotalFiberDiagramFunctor n) := by
+  apply preservesFiniteLimits_of_evaluation
+  intro pq
+  exact preservesFiniteLimits_of_natIso
+    (firstQuadrantTotalFiberEvaluationIso n pq).symm
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteColimits (firstQuadrantTotalFiberDiagramFunctor n) := by
+  apply preservesFiniteColimits_of_evaluation
+  intro pq
+  exact preservesFiniteColimits_of_natIso
+    (firstQuadrantTotalFiberEvaluationIso n pq).symm
+
+/-- The exact functor which takes the finite coproduct of all entries in total degree `n`. -/
+public noncomputable def firstQuadrantTotalDegreeFunctor (n : ℕ) :
+    FirstQuadrantBicomplex ⥤ AddCommGrpCat :=
+  firstQuadrantTotalFiberDiagramFunctor n ⋙
+    colim (J := Discrete (FirstQuadrantTotalFiber n)) (C := AddCommGrpCat)
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteLimits (firstQuadrantTotalDegreeFunctor n) := by
+  dsimp only [firstQuadrantTotalDegreeFunctor]
+  infer_instance
+
+noncomputable instance (n : ℕ) :
+    PreservesFiniteColimits (firstQuadrantTotalDegreeFunctor n) := by
+  dsimp only [firstQuadrantTotalDegreeFunctor]
+  infer_instance
+
+@[simp]
+public theorem firstQuadrant_totalDegree_eq_add (pq : ℕ × ℕ) :
+    ComplexShape.π (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+      (ComplexShape.down ℕ) pq = pq.1 + pq.2 := rfl
+
+/-- Evaluation of Mathlib's direct-sum total complex agrees with the explicit finite
+antidiagonal coproduct functor above. -/
+public noncomputable def firstQuadrantTotalEvaluationIso (n : ℕ) :
+    HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ) ⋙
+      HomologicalComplex.eval AddCommGrpCat (ComplexShape.down ℕ) n ≅
+    firstQuadrantTotalDegreeFunctor n :=
+  NatIso.ofComponents (fun _ => Iso.refl _)
+
+noncomputable instance : PreservesFiniteLimits
+    (HomologicalComplex₂.totalFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)) := by
+  refine ⟨by
+    intro J _ _
+    apply HomologicalComplex.preservesLimitsOfShape_of_eval
+    intro n
+    exact preservesLimitsOfShape_of_natIso
+      (J := J) (firstQuadrantTotalEvaluationIso n).symm⟩
+
+noncomputable instance : PreservesFiniteColimits
+    (HomologicalComplex₂.totalFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)) := by
+  refine ⟨by
+    intro J _ _
+    apply HomologicalComplex.preservesColimitsOfShape_of_eval
+    intro n
+    exact preservesColimitsOfShape_of_natIso
+      (J := J) (firstQuadrantTotalEvaluationIso n).symm⟩
+
+/-- Direct-sum totalization of first-quadrant bicomplexes preserves short exact sequences.
+The finiteness of each antidiagonal is the essential boundedness input. -/
+public theorem firstQuadrantTotal_shortExact
+    (S : ShortComplex FirstQuadrantBicomplex) (hS : S.ShortExact) :
+    (S.map (HomologicalComplex₂.totalFunctor AddCommGrpCat
+      (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ))).ShortExact :=
+  hS.map_of_exact _
+
+set_option linter.style.haveILetI false in
+/-- The middle-map version of two-out-of-three for a morphism of short exact sequences of
+complexes.  Mathlib currently only packages the corresponding result for `τ₃`; this form is
+the induction step needed for finite filtrations. -/
+public theorem quasiIso_middle_of_shortExact
+    {C ι : Type*} [Category* C] [Abelian C] {c : ComplexShape ι}
+    {S₁ S₂ : ShortComplex (HomologicalComplex C c)}
+    (f : S₁ ⟶ S₂) (hS₁ : S₁.ShortExact) (hS₂ : S₂.ShortExact)
+    (h₁ : QuasiIso f.τ₁) (h₃ : QuasiIso f.τ₃) : QuasiIso f.τ₂ := by
+  rw [quasiIso_iff]
+  intro i
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  have hi₁ : QuasiIsoAt f.τ₁ i := (quasiIso_iff f.τ₁).mp h₁ i
+  have hi₃ : QuasiIsoAt f.τ₃ i := (quasiIso_iff f.τ₃).mp h₃ i
+  let φ := (HomologicalComplex.homologyFunctor C c i).mapShortComplex.map f
+  letI : IsIso φ.τ₁ := by
+    dsimp [φ]
+    exact (quasiIsoAt_iff_isIso_homologyMap f.τ₁ i).mp hi₁
+  letI : IsIso φ.τ₃ := by
+    dsimp [φ]
+    exact (quasiIsoAt_iff_isIso_homologyMap f.τ₃ i).mp hi₃
+  letI : Mono φ.τ₂ := by
+    by_cases hi : ∃ k, c.Rel k i
+    · obtain ⟨k, hki⟩ := hi
+      have hk₃ : QuasiIsoAt f.τ₃ k := (quasiIso_iff f.τ₃).mp h₃ k
+      letI : IsIso (HomologicalComplex.homologyMap f.τ₃ k) :=
+        (quasiIsoAt_iff_isIso_homologyMap f.τ₃ k).mp hk₃
+      let Φ := ((CategoryTheory.ComposableArrows.δ₀Functor ⋙
+        CategoryTheory.ComposableArrows.δ₀Functor).map
+          (HomologicalComplex.HomologySequence.mapComposableArrows₅
+            f hS₁ hS₂ k i hki))
+      apply CategoryTheory.Abelian.mono_of_epi_of_mono_of_mono Φ
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₁ k i hki).δ₀.δ₀
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₂ k i hki).δ₀.δ₀
+      · change Epi (HomologicalComplex.homologyMap f.τ₃ k)
+        infer_instance
+      · change Mono (HomologicalComplex.homologyMap f.τ₁ i)
+        infer_instance
+      · change Mono (HomologicalComplex.homologyMap f.τ₃ i)
+        infer_instance
+    · letI : Mono (HomologicalComplex.homologyMap S₂.f i) := by
+        have := hS₂.mono_f
+        exact HomologicalComplex.mono_homologyMap_of_mono_of_not_rel S₂.f i
+          (by simpa using hi)
+      apply ShortComplex.mono_of_mono_of_mono_of_mono φ (hS₁.homology_exact₂ i)
+      · change Mono (HomologicalComplex.homologyMap S₂.f i)
+        infer_instance
+      all_goals infer_instance
+  letI : Epi φ.τ₂ := by
+    by_cases hi : ∃ j, c.Rel i j
+    · obtain ⟨j, hij⟩ := hi
+      have hj₁ : QuasiIsoAt f.τ₁ j := (quasiIso_iff f.τ₁).mp h₁ j
+      letI : IsIso (HomologicalComplex.homologyMap f.τ₁ j) :=
+        (quasiIsoAt_iff_isIso_homologyMap f.τ₁ j).mp hj₁
+      let Φ := ((CategoryTheory.ComposableArrows.δlastFunctor ⋙
+        CategoryTheory.ComposableArrows.δlastFunctor).map
+          (HomologicalComplex.HomologySequence.mapComposableArrows₅
+            f hS₁ hS₂ i j hij))
+      apply CategoryTheory.Abelian.epi_of_epi_of_epi_of_mono Φ
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₁ i j hij).δlast.δlast
+      · exact (HomologicalComplex.HomologySequence.composableArrows₅_exact
+          hS₂ i j hij).δlast.δlast
+      · change Epi (HomologicalComplex.homologyMap f.τ₁ i)
+        infer_instance
+      · change Epi (HomologicalComplex.homologyMap f.τ₃ i)
+        infer_instance
+      · change Mono (HomologicalComplex.homologyMap f.τ₁ j)
+        infer_instance
+    · letI : Epi (HomologicalComplex.homologyMap S₁.g i) := by
+        have := hS₁.epi_g
+        exact HomologicalComplex.epi_homologyMap_of_epi_of_not_rel S₁.g i
+          (by simpa using hi)
+      apply ShortComplex.epi_of_epi_of_epi_of_epi φ (hS₂.homology_exact₂ i)
+      · change Epi (HomologicalComplex.homologyMap S₁.g i)
+        infer_instance
+      all_goals infer_instance
+  change IsIso φ.τ₂
+  apply isIso_of_mono_of_epi
+
+set_option linter.style.haveILetI false in
+/-- A map between two filtrations is a quasi-isomorphism at every finite stage if it is one on
+the initial subobject and on every successive quotient.  The isomorphisms `glue` allow adjacent
+short exact sequences to use merely isomorphic (rather than definitionally equal) models for a
+filtration stage. -/
+public theorem quasiIso_of_successive_shortExact_extensions
+    {C ι : Type*} [Category* C] [Abelian C] {c : ComplexShape ι}
+    (A B : ℕ → ShortComplex (HomologicalComplex C c))
+    (f : ∀ n, A n ⟶ B n)
+    (hA : ∀ n, (A n).ShortExact) (hB : ∀ n, (B n).ShortExact)
+    (hbase : QuasiIso (f 0).τ₁) (hgraded : ∀ n, QuasiIso (f n).τ₃)
+    (glue : ∀ n, Arrow.mk (f n).τ₂ ≅ Arrow.mk (f (n + 1)).τ₁) :
+    ∀ n, QuasiIso (f n).τ₂ := by
+  intro n
+  induction n with
+  | zero =>
+      exact quasiIso_middle_of_shortExact (f 0) (hA 0) (hB 0) hbase (hgraded 0)
+  | succ n ih =>
+      letI : QuasiIso (f n).τ₂ := ih
+      have hleft : QuasiIso (f (n + 1)).τ₁ :=
+        quasiIso_of_arrow_mk_iso
+          (f n).τ₂ (f (n + 1)).τ₁ (glue n)
+      exact quasiIso_middle_of_shortExact (f (n + 1))
+        (hA (n + 1)) (hB (n + 1)) hleft (hgraded (n + 1))
+
+/-- The finite-filtration criterion specialized to first-quadrant direct-sum totals.  This is the
+formal endpoint consumed by a brutal-column filtration: one supplies short exact bicomplex
+layers, quasi-isomorphisms on the initial layer and the single-column quotients, and the canonical
+identifications between consecutive stages. -/
+public theorem firstQuadrantTotal_quasiIso_of_successive_extensions
+    (A B : ℕ → ShortComplex FirstQuadrantBicomplex)
+    (f : ∀ n, A n ⟶ B n)
+    (hA : ∀ n, (A n).ShortExact) (hB : ∀ n, (B n).ShortExact)
+    (hbase : QuasiIso
+      ((HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map
+          (f 0).τ₁))
+    (hgraded : ∀ n, QuasiIso
+      ((HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map
+          (f n).τ₃))
+    (glue : ∀ n, Arrow.mk (f n).τ₂ ≅ Arrow.mk (f (n + 1)).τ₁) :
+    ∀ n, QuasiIso
+      ((HomologicalComplex₂.totalFunctor AddCommGrpCat
+        (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)).map
+          (f n).τ₂) := by
+  let T := HomologicalComplex₂.totalFunctor AddCommGrpCat
+    (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+  apply quasiIso_of_successive_shortExact_extensions
+    (fun n => (A n).map T) (fun n => (B n).map T)
+    (fun n => T.mapShortComplex.map (f n))
+  · exact fun n => firstQuadrantTotal_shortExact (A n) (hA n)
+  · exact fun n => firstQuadrantTotal_shortExact (B n) (hB n)
+  · exact hbase
+  · exact hgraded
+  · exact fun n => T.mapArrow.mapIso (glue n)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/HomotopySphereHomology.lean
+++ b/SphereSixComplex/Topology/HomotopySphereHomology.lean
@@ -1,0 +1,71 @@
+module
+
+public import SphereSixComplex.Topology.OrientedSmoothHomotopySphere
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Homology transport for marked homotopy six-spheres
+
+A marking is an actual homotopy equivalence with the standard six-sphere.  This file packages the
+resulting singular-homology isomorphism for arbitrary coefficients in `AddCommGrpCat`, so the
+mod-two middle-homology input in the Kervaire argument reduces exactly to the corresponding
+calculation for the standard sphere.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap
+
+namespace SphereSixComplex
+
+/-- Singular homology with arbitrary abelian-group coefficients is invariant under a specified
+homotopy equivalence. -/
+public noncomputable def singularHomologyIsoOfHomotopyEquiv
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (R : AddCommGrpCat) (k : ℕ) (e : X ≃ₕ Y) :
+    ((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of X) ≅
+      ((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of Y) := by
+  let F := (singularHomologyFunctor AddCommGrpCat k).obj R
+  let f : TopCat.of X ⟶ TopCat.of Y := TopCat.ofHom e.toFun
+  let g : TopCat.of Y ⟶ TopCat.of X := TopCat.ofHom e.invFun
+  exact CategoryTheory.Iso.mk (F.map f) (F.map g) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.left_inv.some R k) (by
+    rw [← F.map_comp, ← F.map_id]
+    exact TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      e.right_inv.some R k)
+
+/-- Vanishing of a singular-homology group transports backward across a homotopy equivalence. -/
+public theorem singularHomology_isZero_of_homotopyEquiv
+    {X Y : Type} [TopologicalSpace X] [TopologicalSpace Y]
+    (R : AddCommGrpCat) (k : ℕ) (e : X ≃ₕ Y)
+    (hY : IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of Y))) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj (TopCat.of X)) :=
+  hY.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
+
+/-- For a marked smooth homotopy six-sphere, every coefficientwise homology-vanishing theorem for
+the standard sphere immediately transports to its carrier. -/
+public theorem OrientedMarkedSmoothHomotopySixSphere.singularHomology_isZero_of_standard
+    (S : OrientedMarkedSmoothHomotopySixSphere) (R : AddCommGrpCat) (k : ℕ)
+    (hstandard :
+      IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj
+        (TopCat.of SixSphere))) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat k).obj R).obj
+      (TopCat.of S.carrier)) :=
+  singularHomology_isZero_of_homotopyEquiv R k S.marking hstandard
+
+/-- The exact middle-dimensional mod-two input for the Kervaire argument on all marked homotopy
+six-spheres follows from the single standard-sphere calculation. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (hstandard :
+      IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+        (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)))
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  S.singularHomology_isZero_of_standard (AddCommGrpCat.of (ZMod 2)) 3 hstandard
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/OrientedSmoothHomotopySphere.lean
+++ b/SphereSixComplex/Topology/OrientedSmoothHomotopySphere.lean
@@ -1,0 +1,220 @@
+module
+
+public import SphereSixComplex.Topology.SmoothRecognition
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+
+/-!
+# Oriented marked smooth homotopy six-spheres
+
+This file packages the geometric objects underlying the classical group `Θ₆`.  A *marking* is an
+actual homotopy equivalence with the standard sphere.  Classically its degree is `+1` or `-1` and
+therefore determines an orientation.  Mathlib does not yet define orientations of manifolds or the
+degree of a map between manifolds, so retaining the marking is the strongest concrete replacement
+currently available for an oriented homotopy sphere.
+
+This is deliberately different from an unoriented diffeomorphism class of smooth structures on a
+topological sphere.  No quotient and no h-cobordism theorem is introduced here.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open ContinuousMap
+open scoped ContDiff Manifold
+
+namespace SphereSixComplex
+
+/-- A closed smooth homotopy six-sphere with a chosen homotopy marking to the standard sphere.
+
+The explicit marking is the formal orientation datum: replacing it by its composite with the
+antipodal map reverses the induced classical orientation.  The Hausdorff and countability fields
+record the hypotheses used by the classical differential-topology theorems. -/
+public structure OrientedMarkedSmoothHomotopySixSphere.{u} where
+  /-- The underlying carrier. -/
+  carrier : Type u
+  /-- Topology of the carrier. -/
+  [topologicalSpace : TopologicalSpace carrier]
+  /-- Smooth atlas modelled on real six-space. -/
+  [chartedSpace : ChartedSpace RealModel carrier]
+  /-- Classical manifolds are Hausdorff. -/
+  [t2Space : T2Space carrier]
+  /-- Classical manifolds are second countable. -/
+  [secondCountableTopology : SecondCountableTopology carrier]
+  /-- The given atlas is smooth. -/
+  [isManifold : IsManifold 𝓘(ℝ, RealModel) ∞ carrier]
+  /-- The homotopy sphere is compact. -/
+  [compactSpace : CompactSpace carrier]
+  /-- The homotopy sphere is connected. -/
+  [connectedSpace : ConnectedSpace carrier]
+  /-- The ends used in h-cobordisms are closed manifolds. -/
+  [boundaryless : BoundarylessManifold 𝓘(ℝ, RealModel) carrier]
+  /-- The marking whose degree determines the orientation. -/
+  marking : carrier ≃ₕ SixSphere
+
+namespace OrientedMarkedSmoothHomotopySixSphere
+
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : TopologicalSpace S.carrier :=
+  S.topologicalSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : ChartedSpace RealModel S.carrier :=
+  S.chartedSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : T2Space S.carrier := S.t2Space
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : SecondCountableTopology S.carrier :=
+  S.secondCountableTopology
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : IsManifold 𝓘(ℝ, RealModel) ∞ S.carrier :=
+  S.isManifold
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : CompactSpace S.carrier := S.compactSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) : ConnectedSpace S.carrier := S.connectedSpace
+instance (S : OrientedMarkedSmoothHomotopySixSphere) :
+    BoundarylessManifold 𝓘(ℝ, RealModel) S.carrier :=
+  S.boundaryless
+
+/-- Forgetting the explicit marking gives the recognition layer's smooth homotopy-sphere
+contract. -/
+public theorem smoothHomotopySixSphere (S : OrientedMarkedSmoothHomotopySixSphere) :
+    SmoothHomotopySixSphere S.carrier where
+  isManifold := inferInstance
+  compact := inferInstance
+  connected := inferInstance
+  homotopyEquiv := ⟨S.marking⟩
+
+/-- The standard marked sphere. -/
+public def standard : OrientedMarkedSmoothHomotopySixSphere where
+  carrier := SixSphere
+  connectedSpace := sixSphere_connectedSpace
+  marking := ContinuousMap.HomotopyEquiv.refl SixSphere
+
+/-- The antipodal self-homeomorphism of the standard sphere, regarded as a homotopy
+equivalence.  Classically this map has degree `-1` in dimension six. -/
+public def antipodalMarking : SixSphere ≃ₕ SixSphere :=
+  (Homeomorph.neg SixSphere).toHomotopyEquiv
+
+@[simp]
+public theorem antipodalMarking_apply (x : SixSphere) : antipodalMarking x = -x :=
+  rfl
+
+/-- Reverse the orientation represented by a marking by postcomposing it with the antipodal map
+of `S⁶`.  This changes no underlying smooth-manifold data. -/
+public def reverseOrientation (S : OrientedMarkedSmoothHomotopySixSphere) :
+    OrientedMarkedSmoothHomotopySixSphere where
+  carrier := S.carrier
+  marking := S.marking.trans antipodalMarking
+
+@[simp]
+public theorem reverseOrientation_carrier (S : OrientedMarkedSmoothHomotopySixSphere) :
+    S.reverseOrientation.carrier = S.carrier :=
+  rfl
+
+/-- The presently missing degree theory for self-homotopy equivalences of `S⁶`.
+
+The composition law and the assertion that every self-equivalence has degree `±1` prevent this
+from being a bare label for the desired antipodal conclusion.  A future implementation should
+construct `degree` from the induced map on top integral homology. -/
+public structure SixSphereDegreeTheory where
+  /-- Degree of a self-homotopy equivalence. -/
+  degree : (SixSphere ≃ₕ SixSphere) → ℤ
+  /-- The identity has degree one. -/
+  degree_refl : degree (ContinuousMap.HomotopyEquiv.refl SixSphere) = 1
+  /-- Degree is multiplicative under composition. -/
+  degree_trans : ∀ f g, degree (f.trans g) = degree f * degree g
+  /-- Every homotopy equivalence has degree `±1`. -/
+  degree_eq_one_or_neg_one : ∀ f, degree f = 1 ∨ degree f = -1
+  /-- The antipodal equivalence has degree `-1` in even sphere dimension. -/
+  degree_antipodal : degree antipodalMarking = -1
+  /-- Homotopic self-maps have the same degree. -/
+  degree_homotopic : ∀ f g : SixSphere ≃ₕ SixSphere,
+    f.toFun.Homotopic g.toFun → degree f = degree g
+
+/-- Availability of degree theory, isolated as a named proposition rather than an axiom. -/
+public def SixSphereDegreeTheoryObligation : Prop := Nonempty SixSphereDegreeTheory
+
+/-- Two markings of the same homotopy sphere induce the same orientation when their transition
+self-equivalence of `S⁶` has degree one. -/
+public def SameOrientation (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    (e₁ e₂ : X ≃ₕ SixSphere) : Prop :=
+  D.degree (e₁.symm.trans e₂) = 1
+
+namespace SameOrientation
+
+/-- Homotopic markings induce the same orientation. -/
+public theorem of_homotopic (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    {e₁ e₂ : X ≃ₕ SixSphere} (h : e₁.toFun.Homotopic e₂.toFun) :
+    SameOrientation D e₁ e₂ := by
+  unfold SameOrientation
+  have htransition : (e₁.symm.trans e₂).toFun.Homotopic
+      (ContinuousMap.HomotopyEquiv.refl SixSphere).toFun :=
+    (ContinuousMap.Homotopic.comp h.symm (.refl e₁.invFun)).trans e₁.right_inv
+  rw [D.degree_homotopic _ _ htransition]
+  exact D.degree_refl
+
+/-- A marking induces the same orientation as itself. -/
+public theorem refl (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    (e : X ≃ₕ SixSphere) : SameOrientation D e e := by
+  unfold SameOrientation
+  rw [D.degree_homotopic (e.symm.trans e)
+    (ContinuousMap.HomotopyEquiv.refl SixSphere) e.right_inv]
+  exact D.degree_refl
+
+/-- Reversing the comparison of two markings preserves the same-orientation condition. -/
+public theorem symm (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    {e₁ e₂ : X ≃ₕ SixSphere} (h : SameOrientation D e₁ e₂) :
+    SameOrientation D e₂ e₁ := by
+  let f := e₁.symm.trans e₂
+  have hf : D.degree f = 1 := h
+  have hfinv : D.degree f.symm = 1 := by
+    calc
+      D.degree f.symm = D.degree f * D.degree f.symm := by rw [hf, one_mul]
+      _ = D.degree (f.trans f.symm) := (D.degree_trans f f.symm).symm
+      _ = D.degree (ContinuousMap.HomotopyEquiv.refl SixSphere) :=
+        D.degree_homotopic _ _ f.left_inv
+      _ = 1 := D.degree_refl
+  exact hfinv
+
+/-- Same orientation is transitive on markings of a fixed homotopy sphere. -/
+public theorem trans (D : SixSphereDegreeTheory) {X : Type*} [TopologicalSpace X]
+    {e₁ e₂ e₃ : X ≃ₕ SixSphere}
+    (h₁₂ : SameOrientation D e₁ e₂) (h₂₃ : SameOrientation D e₂ e₃) :
+    SameOrientation D e₁ e₃ := by
+  let f₁₂ := e₁.symm.trans e₂
+  let f₂₃ := e₂.symm.trans e₃
+  have hcomp : D.degree (f₁₂.trans f₂₃) = 1 := by
+    rw [D.degree_trans, show D.degree f₁₂ = 1 from h₁₂,
+      show D.degree f₂₃ = 1 from h₂₃, one_mul]
+  have hcancel : (f₁₂.trans f₂₃).toFun.Homotopic
+      (e₁.symm.trans e₃).toFun := by
+    exact ContinuousMap.Homotopic.comp (.refl e₃.toFun)
+      (ContinuousMap.Homotopic.comp e₂.left_inv (.refl e₁.invFun))
+  exact (D.degree_homotopic _ _ hcancel).symm.trans hcomp
+
+/-- Precomposing both markings by a homotopy equivalence does not change their relative
+orientation. -/
+public theorem precomp (D : SixSphereDegreeTheory)
+    {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    {e₁ e₂ : X ≃ₕ SixSphere} (a : Y ≃ₕ X) (h : SameOrientation D e₁ e₂) :
+    SameOrientation D (a.trans e₁) (a.trans e₂) := by
+  unfold SameOrientation at h ⊢
+  have hcancel : ((a.trans e₁).symm.trans (a.trans e₂)).toFun.Homotopic
+      (e₁.symm.trans e₂).toFun := by
+    exact ContinuousMap.Homotopic.comp (.refl e₂.toFun)
+      (ContinuousMap.Homotopic.comp a.right_inv (.refl e₁.invFun))
+  rw [D.degree_homotopic _ _ hcancel]
+  exact h
+
+/-- Postcomposition with the antipodal map genuinely reverses the orientation represented by a
+marking. -/
+public theorem not_reverseOrientation (D : SixSphereDegreeTheory)
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    ¬ SameOrientation D S.marking S.reverseOrientation.marking := by
+  unfold SameOrientation
+  have hcancel :
+      (S.marking.symm.trans S.reverseOrientation.marking).toFun.Homotopic
+        antipodalMarking.toFun := by
+    exact ContinuousMap.Homotopic.comp (.refl antipodalMarking.toFun) S.marking.right_inv
+  rw [D.degree_homotopic _ _ hcancel, D.degree_antipodal]
+  norm_num
+
+end SameOrientation
+
+end OrientedMarkedSmoothHomotopySixSphere
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSingularComparison.lean
+++ b/SphereSixComplex/Topology/SimplicialSingularComparison.lean
@@ -1,0 +1,133 @@
+module
+
+public import SphereSixComplex.Topology.HomotopySphereHomology
+public import SphereSixComplex.Topology.SimplicialSixSphereHomology
+public import SphereSixComplex.Topology.SingularHomologyModTwo
+public import Mathlib.Algebra.Homology.QuasiIso
+public import Mathlib.AlgebraicTopology.SimplicialSet.TopAdj
+
+/-!
+# The canonical simplicial-to-singular comparison
+
+The unit of the geometric-realization/singular-set adjunction sends every simplex of a simplicial
+set to the corresponding singular simplex of its realization.  Applying simplicial chains gives
+the canonical comparison map.  This file packages that concrete map and proves that its
+quasi-isomorphism, together with a homeomorphism `|∂Δ[7]| ≃ S⁶`, transports the already-computed
+degree-two and degree-three homology vanishing to the standard topological sphere.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical chain map from simplicial chains to singular chains on geometric realization. -/
+public noncomputable def simplicialToRealizationSingularChainMap
+    (K : SSet.{0}) (R : AddCommGrpCat) :
+    K.chainComplex R ⟶
+      (TopCat.toSSet.obj (SSet.toTop.obj K)).chainComplex R :=
+  SSet.chainComplexMap (sSetTopAdj.unit.app K) R
+
+/-- The precise general comparison theorem needed here. -/
+public def SimplicialToSingularComparisonQuasiIsomorphism
+    (K : SSet.{0}) (R : AddCommGrpCat) : Prop :=
+  QuasiIso (simplicialToRealizationSingularChainMap K R)
+
+/-- A quasi-isomorphic comparison transports vanishing from simplicial homology to singular
+homology of the realization. -/
+public theorem realizationSingularHomology_isZero_of_simplicial
+    (K : SSet.{0}) (R : AddCommGrpCat) (k : ℕ)
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism K R)
+    (hsimplicial : IsZero ((K.chainComplex R).homology k)) :
+    IsZero (((TopCat.toSSet.obj (SSet.toTop.obj K)).chainComplex R).homology k) := by
+  let _ : QuasiIso (simplicialToRealizationSingularChainMap K R) := hcomparison
+  exact hsimplicial.of_iso
+    (isoOfQuasiIsoAt (simplicialToRealizationSingularChainMap K R) k).symm
+
+/-- The geometric identification of the realization of the boundary of the seven-simplex with
+the project's standard six-sphere. -/
+public def BoundarySevenRealizationHomeomorphSixSphere : Prop :=
+  Nonempty ((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ SixSphere)
+
+/-- The two exact comparison inputs, isolated from the finite cone calculation. -/
+public def BoundarySevenComparisonInputs (R : AddCommGrpCat) : Prop :=
+  SimplicialToSingularComparisonQuasiIsomorphism (∂Δ[7] : SSet.{0}) R ∧
+    BoundarySevenRealizationHomeomorphSixSphere
+
+/-- The boundary comparison inputs imply degree-three singular homology vanishing for `S⁶`. -/
+public theorem sixSphere_singularHomology_three_isZero_of_boundaryComparison
+    (R : AddCommGrpCat) (h : BoundarySevenComparisonInputs R) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj R).obj
+      (TopCat.of SixSphere)) := by
+  obtain ⟨hcomparison, ⟨e⟩⟩ := h
+  have hrealization :
+      IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj R).obj
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))) :=
+    realizationSingularHomology_isZero_of_simplicial
+      (∂Δ[7] : SSet.{0}) R 3 hcomparison
+        (boundarySeven_simplicialHomology_three_isZero R)
+  exact hrealization.of_iso
+    (((singularHomologyFunctor AddCommGrpCat 3).obj R).mapIso
+      (TopCat.isoOfHomeo e.symm))
+
+/-- Likewise, the comparison inputs imply degree-two singular homology vanishing for `S⁶`. -/
+public theorem sixSphere_singularHomology_two_isZero_of_boundaryComparison
+    (R : AddCommGrpCat) (h : BoundarySevenComparisonInputs R) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 2).obj R).obj
+      (TopCat.of SixSphere)) := by
+  obtain ⟨hcomparison, ⟨e⟩⟩ := h
+  have hrealization :
+      IsZero (((singularHomologyFunctor AddCommGrpCat 2).obj R).obj
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))) :=
+    realizationSingularHomology_isZero_of_simplicial
+      (∂Δ[7] : SSet.{0}) R 2 hcomparison
+        (boundarySeven_simplicialHomology_two_isZero R)
+  exact hrealization.of_iso
+    (((singularHomologyFunctor AddCommGrpCat 2).obj R).mapIso
+      (TopCat.isoOfHomeo e.symm))
+
+/-- The comparison theorem over `𝔽₂` supplies exactly the standard-sphere Kervaire input. -/
+public theorem sixSphere_modTwoHomology_three_isZero_of_boundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of (ZMod 2))) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) :=
+  sixSphere_singularHomology_three_isZero_of_boundaryComparison
+    (AddCommGrpCat.of (ZMod 2)) h
+
+/-- It is enough to prove the simplicial-to-singular comparison with integral coefficients:
+degree-two and degree-three integral vanishing pass to mod-two degree-three homology through the
+proved coefficient Bockstein sequence. -/
+public theorem sixSphere_modTwoHomology_three_isZero_of_integralBoundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of ℤ)) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of SixSphere)) := by
+  apply modTwoSingularHomologyThree_isZero (TopCat.of SixSphere)
+  · exact sixSphere_singularHomology_three_isZero_of_boundaryComparison
+      (AddCommGrpCat.of ℤ) h
+  · exact sixSphere_singularHomology_two_isZero_of_boundaryComparison
+      (AddCommGrpCat.of ℤ) h
+
+/-- Consequently, the same two comparison inputs give the middle-dimensional mod-two vanishing
+for every marked smooth homotopy six-sphere. -/
+public theorem markedHomotopySixSphere_modTwoHomology_three_isZero_of_boundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of (ZMod 2)))
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (sixSphere_modTwoHomology_three_isZero_of_boundaryComparison h) S
+
+/-- The integral comparison inputs therefore also suffice for every marked homotopy sphere. -/
+public theorem
+    markedHomotopySixSphere_modTwoHomology_three_isZero_of_integralBoundaryComparison
+    (h : BoundarySevenComparisonInputs (AddCommGrpCat.of ℤ))
+    (S : OrientedMarkedSmoothHomotopySixSphere) :
+    IsZero (((singularHomologyFunctor AddCommGrpCat 3).obj
+      (AddCommGrpCat.of (ZMod 2))).obj (TopCat.of S.carrier)) :=
+  markedHomotopySixSphere_modTwoHomology_three_isZero_of_standard
+    (sixSphere_modTwoHomology_three_isZero_of_integralBoundaryComparison h) S
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSingularComparisonProof.lean
+++ b/SphereSixComplex/Topology/SimplicialSingularComparisonProof.lean
@@ -1,0 +1,339 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import SphereSixComplex.Topology.SingularExcisionOpenCover
+
+/-!
+# Reduction of simplicial--singular comparison to cover-small chains
+
+For an open cover of the realization, the affine subdivision theorem proves that cover-small
+singular chains include quasi-isomorphically into all singular chains.  Consequently, whenever
+the adjunction unit lands in the cover-small singular subcomplex, the canonical comparison is a
+quasi-isomorphism exactly when its lift to cover-small chains is one.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+variable {iota : Type} (K : SSet.{0})
+  (U : iota → Set (SSet.toTop.obj K))
+
+/-- The adjunction unit defining the simplicial--singular comparison has image in the simplices
+small for `U`. -/
+public def SimplicialRealizationUnitLandsInCoverSmall : Prop :=
+  SSet.Subcomplex.range (sSetTopAdj.unit.app K) ≤
+    coverSmallSingularSubcomplex (SSet.toTop.obj K) U
+
+/-- Elementwise form of cover-smallness: every canonical realized simplex factors through one
+member of the cover. -/
+public theorem simplicialRealizationUnitLandsInCoverSmall_iff :
+    SimplicialRealizationUnitLandsInCoverSmall K U ↔
+      ∀ (n : SimplexCategoryᵒᵖ) (x : K.obj n),
+        ∃ (j : iota)
+          (y : (TopCat.toSSet.obj (TopCat.of (U j))).obj n),
+          (TopCat.toSSet.map
+            (topologicalSubsetInclusion (SSet.toTop.obj K) (U j))).app n y =
+            (sSetTopAdj.unit.app K).app n x := by
+  constructor
+  · intro h n x
+    apply (mem_coverSmallSingularSubcomplex_iff_exists_preimage
+      (SSet.toTop.obj K) U _).mp
+    exact h n ⟨x, rfl⟩
+  · intro h n z hz
+    obtain ⟨x, rfl⟩ := hz
+    exact (mem_coverSmallSingularSubcomplex_iff_exists_preimage
+      (SSet.toTop.obj K) U _).mpr (h n x)
+
+/-- The adjunction unit lifted to the cover-small singular simplicial set. -/
+public noncomputable def simplicialToCoverSmallSingularSet
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    K ⟶ coverSmallSingularSubcomplex (SSet.toTop.obj K) U :=
+  SSet.Subcomplex.lift (sSetTopAdj.unit.app K) hsmall
+
+@[reassoc (attr := simp)]
+public theorem simplicialToCoverSmallSingularSet_comp_inclusion
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    simplicialToCoverSmallSingularSet K U hsmall ≫
+        (coverSmallSingularSubcomplex (SSet.toTop.obj K) U).ι =
+      sSetTopAdj.unit.app K :=
+  SSet.Subcomplex.lift_ι _ _
+
+/-- The integral simplicial comparison, with codomain restricted to cover-small singular
+chains. -/
+public noncomputable def simplicialToCoverSmallSingularChainMap
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    K.chainComplex (AddCommGrpCat.of ℤ) ⟶
+      CoverSmallIntegralSingularChainComplex (SSet.toTop.obj K) U :=
+  SSet.chainComplexMap (simplicialToCoverSmallSingularSet K U hsmall)
+    (AddCommGrpCat.of ℤ)
+
+/-- The cover-small lift followed by inclusion is the canonical comparison map. -/
+@[reassoc]
+public theorem simplicialToCoverSmallSingularChainMap_comp_inclusion
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    simplicialToCoverSmallSingularChainMap K U hsmall ≫
+        coverSmallIntegralSingularChainInclusion (SSet.toTop.obj K) U =
+      simplicialToRealizationSingularChainMap K (AddCommGrpCat.of ℤ) := by
+  change
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (simplicialToCoverSmallSingularSet K U hsmall) ≫
+      ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+          (coverSmallSingularSubcomplex (SSet.toTop.obj K) U).ι =
+    ((SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)).map
+      (sSetTopAdj.unit.app K)
+  rw [← Functor.map_comp,
+    simplicialToCoverSmallSingularSet_comp_inclusion]
+
+/-- For an open cover, affine subdivision removes the full-singular-chain part of the comparison
+problem: the canonical comparison is a quasi-isomorphism if and only if its cover-small lift is.
+-/
+public theorem simplicialToSingularComparisonQuasiIsomorphism_iff_coverSmallLift
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall K U) :
+    SimplicialToSingularComparisonQuasiIsomorphism K (AddCommGrpCat.of ℤ) ↔
+      QuasiIso (simplicialToCoverSmallSingularChainMap K U hsmall) := by
+  have hcover : QuasiIso
+      (coverSmallIntegralSingularChainInclusion (SSet.toTop.obj K) U) :=
+    coverSmallChainQuasiIsomorphism_of_openCover
+      (SSet.toTop.obj K) U hUopen hUcover
+  change QuasiIso
+      (simplicialToRealizationSingularChainMap K (AddCommGrpCat.of ℤ)) ↔
+    QuasiIso (simplicialToCoverSmallSingularChainMap K U hsmall)
+  rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion K U hsmall]
+  exact quasiIso_iff_comp_right _ _ (hφ' := hcover)
+
+/-- The canonical map from the boundary realization to the ordinary affine standard
+seven-simplex, duplicated here so that the comparison proof is independent of any later geometric
+identification of the boundary realization. -/
+public noncomputable def boundarySevenComparisonToStdSimplex :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
+  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι x),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
+      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
+
+/-- On a codimension-one face, the comparison map is the usual affine face inclusion. -/
+public theorem boundarySevenComparisonToStdSimplex_face
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenComparisonToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
+  unfold boundarySevenComparisonToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
+  rw [← ConcreteCategory.comp_apply]
+  rw [← SSet.toTop.map_comp]
+  rw [SSet.boundary.ι_ι]
+  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
+
+/-- An open neighborhood of the `i`-th affine face, pulled back to the realization of
+`∂Δ[7]`. -/
+public def boundarySevenComparisonFaceNeighborhood (i : Fin 8) :
+    Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
+  {x | boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8}
+
+/-- The affine face neighborhoods are open. -/
+public theorem boundarySevenComparisonFaceNeighborhood_isOpen (i : Fin 8) :
+    IsOpen (boundarySevenComparisonFaceNeighborhood i) := by
+  apply isOpen_lt
+  · exact ((continuous_apply i).comp continuous_subtype_val).comp
+      boundarySevenComparisonToStdSimplex.continuous
+  · exact continuous_const
+
+/-- The realization of the `i`-th simplicial face lands in its corresponding open affine
+neighborhood. -/
+public noncomputable def boundarySevenFaceToComparisonFaceNeighborhood (i : Fin 8) :
+    SSet.toTop.obj (Δ[6] : SSet.{0}) ⟶
+      TopCat.of (boundarySevenComparisonFaceNeighborhood i) := by
+  refine TopCat.ofHom
+    { toFun := fun x ↦ ⟨SSet.toTop.map (SSet.boundary.ι i) x, ?_⟩
+      continuous_toFun := ?_ }
+  · change boundarySevenComparisonToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) i < (1 : ℝ) / 8
+    rw [boundarySevenComparisonToStdSimplex_face]
+    change stdSimplex.map i.succAbove
+      (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) i < (1 : ℝ) / 8
+    have hz : stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) i = 0 := by
+      classical
+      simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+      apply Finset.sum_eq_zero
+      intro j hj
+      exact (Fin.succAbove_ne i j (Finset.mem_filter.mp hj).2).elim
+    rw [hz]
+    norm_num
+  · exact (SSet.toTop.map (SSet.boundary.ι i)).hom.continuous.subtype_mk _
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenFaceToComparisonFaceNeighborhood_comp_inclusion
+    (i : Fin 8) :
+    boundarySevenFaceToComparisonFaceNeighborhood i ≫
+        topologicalSubsetInclusion (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          (boundarySevenComparisonFaceNeighborhood i) =
+      SSet.toTop.map (SSet.boundary.ι i) := by
+  rfl
+
+/-- The unit on one standard face, mapped into the cover-small singular simplicial set of the
+boundary realization. -/
+public noncomputable def boundarySevenFaceUnitToSmallSingularSet (i : Fin 8) :
+    (Δ[6] : SSet.{0}) ⟶
+      coverSmallSingularSubcomplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood :=
+  sSetTopAdj.unit.app (Δ[6] : SSet.{0}) ≫
+    TopCat.toSSet.map (boundarySevenFaceToComparisonFaceNeighborhood i) ≫
+      coverMemberToSmallSingularSet
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood i
+
+/-- The facewise small unit is the restriction of the boundary comparison unit. -/
+@[reassoc (attr := simp)]
+public theorem boundarySevenFaceUnitToSmallSingularSet_comp_inclusion (i : Fin 8) :
+    boundarySevenFaceUnitToSmallSingularSet i ≫
+        (coverSmallSingularSubcomplex
+          (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+          boundarySevenComparisonFaceNeighborhood).ι =
+      SSet.boundary.ι i ≫ sSetTopAdj.unit.app (∂Δ[7] : SSet.{0}) := by
+  unfold boundarySevenFaceUnitToSmallSingularSet
+  rw [Category.assoc, Category.assoc,
+    coverMemberToSmallSingularSet_comp_inclusion]
+  rw [← Functor.map_comp,
+    boundarySevenFaceToComparisonFaceNeighborhood_comp_inclusion]
+  exact (sSetTopAdj.unit.naturality (SSet.boundary.ι i)).symm
+
+/-- Every canonical simplicial simplex of `∂Δ[7]` lands in one of the eight affine face
+neighborhoods. -/
+public theorem boundarySevenComparisonUnitLandsInFaceNeighborhoods :
+    SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood := by
+  intro n z hz
+  obtain ⟨x, rfl⟩ := hz
+  have hx := x.2
+  simp only [SSet.boundary_eq_iSup, SSet.stdSimplex.face_singleton_compl,
+    Subfunctor.iSup_obj, Set.mem_iUnion,
+    SSet.Subcomplex.mem_ofSimplex_obj_iff, Opposite.op_unop] at hx
+  obtain ⟨i, ⟨y, hy⟩⟩ := hx
+  let y' : (Δ[6] : SSet.{0}).obj n := SSet.stdSimplex.objEquiv.symm y
+  have hxy : (SSet.boundary.ι i).app n y' = x := by
+    apply Subtype.ext
+    change (SSet.stdSimplex.map (SimplexCategory.δ i)).app n y' = x.1
+    exact hy
+  let w := (boundarySevenFaceUnitToSmallSingularSet i).app n y'
+  have hw : w.1 = (sSetTopAdj.unit.app (∂Δ[7] : SSet.{0})).app n x := by
+    have h := ConcreteCategory.congr_hom
+      (congr_app (boundarySevenFaceUnitToSmallSingularSet_comp_inclusion i) n) y'
+    change ((boundarySevenFaceUnitToSmallSingularSet i).app n y').1 =
+      (sSetTopAdj.unit.app (∂Δ[7] : SSet.{0})).app n
+        ((SSet.boundary.ι i).app n y') at h
+    simpa only [hxy] using h
+  rw [← hw]
+  exact w.2
+
+/-- The remaining global geometric assertion needed to know that the eight explicit affine face
+neighborhoods cover the whole realization.  It states precisely that the comparison map from the
+realized simplicial boundary lands in the affine boundary. -/
+public def BoundarySevenComparisonMapLandsInAffineBoundary : Prop :=
+  ∀ x : SSet.toTop.obj (∂Δ[7] : SSet.{0}),
+    ∃ i : Fin 8, boundarySevenComparisonToStdSimplex x i = 0
+
+/-- If the comparison map lands in the affine boundary, the eight explicit face neighborhoods
+cover the realization. -/
+public theorem boundarySevenComparisonFaceNeighborhood_iUnion
+    (hboundary : BoundarySevenComparisonMapLandsInAffineBoundary) :
+    ⋃ i, boundarySevenComparisonFaceNeighborhood i = Set.univ := by
+  apply Set.eq_univ_of_forall
+  intro x
+  obtain ⟨i, hi⟩ := hboundary x
+  apply Set.mem_iUnion.2
+  refine ⟨i, ?_⟩
+  change boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8
+  rw [hi]
+  norm_num
+
+/-- Specialized sharp reduction for the boundary of the seven-simplex.  It remains only to prove
+that the explicitly lifted map into cover-small chains is a quasi-isomorphism. -/
+public theorem boundarySeven_integralComparison_iff_coverSmallLift
+    (U : iota → Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})))
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) U) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ↔
+      QuasiIso (simplicialToCoverSmallSingularChainMap
+        (∂Δ[7] : SSet.{0}) U hsmall) :=
+  simplicialToSingularComparisonQuasiIsomorphism_iff_coverSmallLift
+    (∂Δ[7] : SSet.{0}) U hUopen hUcover hsmall
+
+/-- The second, purely chain-level input for the concrete eight-member face-neighborhood cover:
+the explicitly lifted simplicial comparison must be a quasi-isomorphism. -/
+public def BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism : Prop :=
+  QuasiIso (simplicialToCoverSmallSingularChainMap
+    (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods)
+
+/-- Once the realized boundary is known to map to the affine boundary, the original comparison
+problem is exactly the quasi-isomorphism problem for the explicit face-neighborhood-small lift. -/
+public theorem boundarySeven_integralComparison_iff_faceNeighborhoodLift
+    (hboundary : BoundarySevenComparisonMapLandsInAffineBoundary) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ↔
+      BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism := by
+  unfold BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism
+  exact boundarySeven_integralComparison_iff_coverSmallLift
+    boundarySevenComparisonFaceNeighborhood
+    boundarySevenComparisonFaceNeighborhood_isOpen
+    (boundarySevenComparisonFaceNeighborhood_iUnion hboundary)
+    boundarySevenComparisonUnitLandsInFaceNeighborhoods
+
+/-- The two explicit remaining inputs imply the requested canonical integral comparison. -/
+public theorem boundarySeven_integralComparison_of_faceNeighborhoodLift
+    (hboundary : BoundarySevenComparisonMapLandsInAffineBoundary)
+    (hlift : BoundarySevenFaceNeighborhoodLiftQuasiIsomorphism) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  (boundarySeven_integralComparison_iff_faceNeighborhoodLift hboundary).2 hlift
+
+/-- Any open cover for which the cover-small lift is a quasi-isomorphism supplies the requested
+canonical integral comparison for `∂Δ[7]`. -/
+public theorem boundarySeven_integralComparison_of_coverSmallLift
+    (U : iota → Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})))
+    (hUopen : ∀ i, IsOpen (U i)) (hUcover : ⋃ i, U i = Set.univ)
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) U)
+    (hlift : QuasiIso (simplicialToCoverSmallSingularChainMap
+      (∂Δ[7] : SSet.{0}) U hsmall)) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  (boundarySeven_integralComparison_iff_coverSmallLift
+    U hUopen hUcover hsmall).2 hlift
+
+/-- The exact remaining cover-level input for the integral boundary comparison: an open cover
+subordinate to all canonical simplicial simplices, on which the lifted comparison is a
+quasi-isomorphism. -/
+public def BoundarySevenIntegralCoverSmallComparison : Prop :=
+  ∃ (iota : Type)
+    (U : iota → Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})))
+    (hsmall : SimplicialRealizationUnitLandsInCoverSmall
+      (∂Δ[7] : SSet.{0}) U),
+    (∀ i, IsOpen (U i)) ∧
+      ⋃ i, U i = Set.univ ∧
+      QuasiIso (simplicialToCoverSmallSingularChainMap
+        (∂Δ[7] : SSet.{0}) U hsmall)
+
+/-- The cover-level comparison input implies the requested canonical quasi-isomorphism. -/
+public theorem boundarySeven_integralComparison_of_coverSmallComparison
+    (h : BoundarySevenIntegralCoverSmallComparison) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) := by
+  obtain ⟨iota, U, hsmall, hUopen, hUcover, hlift⟩ := h
+  exact boundarySeven_integralComparison_of_coverSmallLift
+    U hUopen hUcover hsmall hlift
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSixSphereHomology.lean
+++ b/SphereSixComplex/Topology/SimplicialSixSphereHomology.lean
@@ -1,0 +1,212 @@
+module
+
+public import SphereSixComplex.Topology.SingularStandardSimplexCone
+public import Mathlib.AlgebraicTopology.SimplicialSet.Boundary
+
+/-!
+# Low-degree simplicial homology of the boundary of the seven-simplex
+
+The simplicial boundary `∂Δ[7]` is a finite combinatorial model of a six-sphere.  In degrees
+below six, prepending the zero vertex remains in the boundary and gives the usual cone
+contraction.  This file constructs that cone on Mathlib's actual coproduct chain groups, with an
+arbitrary coefficient object in `AddCommGrpCat`.
+
+This computes simplicial homology only.  Identifying the realization of `∂Δ[7]` with the
+topological six-sphere and comparing simplicial with singular homology are separate missing
+theorems.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- In low degrees, coning a simplex of `∂Δ[7]` to the zero vertex remains in `∂Δ[7]`. -/
+public noncomputable def boundarySevenZeroConeSimplex
+    (n : ℕ) (hn : n + 1 < 7)
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n))) :
+    (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk (n + 1))) :=
+  ⟨standardSimplexZeroConeSimplex 7 n x.1, by
+    rw [SSet.boundary_obj_eq_univ (n + 1) 7 hn]
+    exact Set.mem_univ _⟩
+
+/-- Removing the new cone vertex recovers the original boundary simplex. -/
+@[simp]
+public theorem boundarySevenZeroConeSimplex_delta_zero
+    (n : ℕ) (hn : n + 1 < 7)
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n))) :
+    (∂Δ[7] : SSet.{0}).δ 0 (boundarySevenZeroConeSimplex n hn x) = x := by
+  apply Subtype.ext
+  exact standardSimplexZeroConeSimplex_delta_zero 7 n x.1
+
+/-- Every later face of a low-degree boundary cone is the cone on the preceding face. -/
+@[simp]
+public theorem boundarySevenZeroConeSimplex_delta_succ
+    (n : ℕ) (hn : n + 2 < 7) (i : Fin (n + 2))
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk (n + 1)))) :
+    (∂Δ[7] : SSet.{0}).δ i.succ
+        (boundarySevenZeroConeSimplex (n + 1) hn x) =
+      boundarySevenZeroConeSimplex n (by omega)
+        ((∂Δ[7] : SSet.{0}).δ i x) := by
+  apply Subtype.ext
+  exact standardSimplexZeroConeSimplex_delta_succ 7 n i x.1
+
+/-- The zero-vertex cone on low-degree chains of `∂Δ[7]`. -/
+public noncomputable def boundarySevenZeroConeComponent
+    (R : AddCommGrpCat) (n : ℕ) (hn : n + 1 < 7) :
+    ((∂Δ[7] : SSet.{0}).chainComplex R).X n ⟶
+      ((∂Δ[7] : SSet.{0}).chainComplex R).X (n + 1) :=
+  Sigma.desc (fun x ↦
+    (∂Δ[7] : SSet.{0}).ιChainComplex
+      (boundarySevenZeroConeSimplex n hn x))
+
+@[reassoc (attr := simp)]
+public theorem iota_boundarySevenZeroConeComponent
+    (R : AddCommGrpCat) (n : ℕ) (hn : n + 1 < 7)
+    (x : (∂Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n))) :
+    (∂Δ[7] : SSet.{0}).ιChainComplex x ≫
+        boundarySevenZeroConeComponent R n hn =
+      (∂Δ[7] : SSet.{0}).ιChainComplex
+        (boundarySevenZeroConeSimplex n hn x) := by
+  apply Sigma.ι_desc
+
+/-- In positive degrees below six, the boundary cone contracts the chain complex of `∂Δ[7]`.
+-/
+public theorem boundarySevenZeroConeComponent_boundary_succ
+    (R : AddCommGrpCat) (n : ℕ) (hn : n + 2 < 7) :
+    boundarySevenZeroConeComponent R (n + 1) hn ≫
+          ((∂Δ[7] : SSet.{0}).chainComplex R).d (n + 2) (n + 1) +
+        ((∂Δ[7] : SSet.{0}).chainComplex R).d (n + 1) n ≫
+          boundarySevenZeroConeComponent R n (by omega) =
+      𝟙 (((∂Δ[7] : SSet.{0}).chainComplex R).X (n + 1)) := by
+  apply (∂Δ[7] : SSet.{0}).chainComplex_hom_ext
+  intro x
+  simp only [Preadditive.comp_add, Category.comp_id]
+  rw [← Category.assoc, iota_boundarySevenZeroConeComponent,
+    SSet.ιChainComplex_d]
+  rw [← Category.assoc, SSet.ιChainComplex_d, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp, iota_boundarySevenZeroConeComponent]
+  rw [Fin.sum_univ_succ]
+  simp only [Fin.val_zero, pow_zero, one_zsmul,
+    boundarySevenZeroConeSimplex_delta_zero,
+    boundarySevenZeroConeSimplex_delta_succ, Fin.val_succ, pow_succ]
+  rw [add_assoc, ← Finset.sum_add_distrib]
+  simp
+
+/-- In degrees `4 → 3 → 2`, the identity of the boundary chain short complex is
+null-homotopic. -/
+public noncomputable def boundarySevenShortComplexIdentityHomotopyThree
+    (R : AddCommGrpCat) :
+    let K := (∂Δ[7] : SSet.{0}).chainComplex R
+    ShortComplex.Homotopy (𝟙 (K.sc' 4 3 2)) 0 := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  let c1 := boundarySevenZeroConeComponent R 1 (by omega)
+  let c2 := boundarySevenZeroConeComponent R 2 (by omega)
+  let c3 := boundarySevenZeroConeComponent R 3 (by omega)
+  let c4 := boundarySevenZeroConeComponent R 4 (by omega)
+  refine
+    { h₀ := c4 ≫ K.d 5 4
+      h₀_f := ?_
+      h₁ := c3
+      h₂ := c2
+      h₃ := K.d 2 1 ≫ c1
+      g_h₃ := ?_
+      comm₁ := ?_
+      comm₂ := ?_
+      comm₃ := ?_ }
+  · dsimp
+    change (c4 ≫ K.d 5 4) ≫ K.d 4 3 = 0
+    rw [Category.assoc, K.d_comp_d, comp_zero]
+  ·
+    change K.d 3 2 ≫ (K.d 2 1 ≫ c1) = 0
+    rw [← Category.assoc, K.d_comp_d, zero_comp]
+  · change 𝟙 (K.X 4) = K.d 4 3 ≫ c3 + c4 ≫ K.d 5 4 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 3 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 3) = K.d 3 2 ≫ c2 + c3 ≫ K.d 4 3 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 2 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 2) = K.d 2 1 ≫ c1 + c2 ≫ K.d 3 2 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 1 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+
+/-- The degree-three simplicial homology of the combinatorial six-sphere `∂Δ[7]` vanishes,
+with arbitrary coefficients in `AddCommGrpCat`. -/
+public theorem boundarySeven_simplicialHomology_three_isZero
+    (R : AddCommGrpCat) :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex R).homology 3) := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  rw [← K.exactAt_iff_isZero_homology]
+  apply (K.exactAt_iff' (i := 4) (j := 3) (k := 2) (by simp) (by simp)).2
+  rw [ShortComplex.exact_iff_isZero_homology, IsZero.iff_id_eq_zero]
+  have h := (boundarySevenShortComplexIdentityHomotopyThree R).homologyMap_congr
+  simpa only [ShortComplex.homologyMap_id, ShortComplex.homologyMap_zero] using h
+
+/-- In particular, degree-three simplicial homology of `∂Δ[7]` vanishes over `𝔽₂`. -/
+public theorem boundarySeven_simplicialHomology_three_zModTwo_isZero :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex
+      (AddCommGrpCat.of (ZMod 2))).homology 3) :=
+  boundarySeven_simplicialHomology_three_isZero (AddCommGrpCat.of (ZMod 2))
+
+/-- In degrees `3 → 2 → 1`, the same zero-vertex cone null-homotopes the identity. -/
+public noncomputable def boundarySevenShortComplexIdentityHomotopyTwo
+    (R : AddCommGrpCat) :
+    let K := (∂Δ[7] : SSet.{0}).chainComplex R
+    ShortComplex.Homotopy (𝟙 (K.sc' 3 2 1)) 0 := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  let c0 := boundarySevenZeroConeComponent R 0 (by omega)
+  let c1 := boundarySevenZeroConeComponent R 1 (by omega)
+  let c2 := boundarySevenZeroConeComponent R 2 (by omega)
+  let c3 := boundarySevenZeroConeComponent R 3 (by omega)
+  refine
+    { h₀ := c3 ≫ K.d 4 3
+      h₀_f := ?_
+      h₁ := c2
+      h₂ := c1
+      h₃ := K.d 1 0 ≫ c0
+      g_h₃ := ?_
+      comm₁ := ?_
+      comm₂ := ?_
+      comm₃ := ?_ }
+  · dsimp
+    change (c3 ≫ K.d 4 3) ≫ K.d 3 2 = 0
+    rw [Category.assoc, K.d_comp_d, comp_zero]
+  · change K.d 2 1 ≫ (K.d 1 0 ≫ c0) = 0
+    rw [← Category.assoc, K.d_comp_d, zero_comp]
+  · change 𝟙 (K.X 3) = K.d 3 2 ≫ c2 + c3 ≫ K.d 4 3 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 2 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 2) = K.d 2 1 ≫ c1 + c2 ≫ K.d 3 2 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 1 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+  · change 𝟙 (K.X 1) = K.d 1 0 ≫ c0 + c1 ≫ K.d 2 1 + 0
+    have h := boundarySevenZeroConeComponent_boundary_succ R 0 (by omega)
+    rw [add_zero]
+    exact (by simpa [add_comm] using h.symm)
+
+/-- Degree-two simplicial homology of `∂Δ[7]` also vanishes for arbitrary coefficients. -/
+public theorem boundarySeven_simplicialHomology_two_isZero
+    (R : AddCommGrpCat) :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex R).homology 2) := by
+  let K := (∂Δ[7] : SSet.{0}).chainComplex R
+  rw [← K.exactAt_iff_isZero_homology]
+  apply (K.exactAt_iff' (i := 3) (j := 2) (k := 1) (by simp) (by simp)).2
+  rw [ShortComplex.exact_iff_isZero_homology, IsZero.iff_id_eq_zero]
+  have h := (boundarySevenShortComplexIdentityHomotopyTwo R).homologyMap_congr
+  simpa only [ShortComplex.homologyMap_id, ShortComplex.homologyMap_zero] using h
+
+/-- In particular, degree-two simplicial homology of `∂Δ[7]` vanishes over `𝔽₂`. -/
+public theorem boundarySeven_simplicialHomology_two_zModTwo_isZero :
+    IsZero (((∂Δ[7] : SSet.{0}).chainComplex
+      (AddCommGrpCat.of (ZMod 2))).homology 2) :=
+  boundarySeven_simplicialHomology_two_isZero (AddCommGrpCat.of (ZMod 2))
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SingularHomologyModTwo.lean
+++ b/SphereSixComplex/Topology/SingularHomologyModTwo.lean
@@ -1,0 +1,188 @@
+module
+
+public import SphereSixComplex.Topology.RelativeSingularHomology
+public import Mathlib.Algebra.Category.Grp.AB
+public import Mathlib.Data.ZMod.QuotientGroup
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- Multiplication by two on the integral coefficient object. -/
+public def integralCoefficientTimesTwo :
+    AddCommGrpCat.of ℤ ⟶ AddCommGrpCat.of ℤ :=
+  AddCommGrpCat.ofHom
+    { toFun := fun z ↦ 2 * z
+      map_zero' := by simp
+      map_add' := by simp [mul_add] }
+
+/-- Reduction of integral coefficients modulo two. -/
+public def integralCoefficientReductionModTwo :
+    AddCommGrpCat.of ℤ ⟶ AddCommGrpCat.of (ZMod 2) :=
+  AddCommGrpCat.ofHom (Int.castAddHom (ZMod 2))
+
+/-- The coefficient short complex `ℤ --2→ ℤ → ZMod 2`. -/
+public noncomputable def integralModTwoCoefficientShortComplex :
+    ShortComplex AddCommGrpCat :=
+  ShortComplex.mk integralCoefficientTimesTwo
+    integralCoefficientReductionModTwo (by
+      ext
+      simp [integralCoefficientTimesTwo,
+        integralCoefficientReductionModTwo]
+      decide)
+
+/-- The standard integral-to-mod-two coefficient sequence is short exact. -/
+public theorem integralModTwoCoefficientShortComplex_shortExact :
+    integralModTwoCoefficientShortComplex.ShortExact := by
+  refine
+    { exact := ?_
+      mono_f := ?_
+      epi_g := ?_ }
+  · rw [ShortComplex.ab_exact_iff]
+    change ∀ z : ℤ, (z : ZMod 2) = 0 → ∃ y : ℤ, 2 * y = z
+    intro z hz
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd] at hz
+    obtain ⟨y, rfl⟩ := hz
+    exact ⟨y, by simp⟩
+  · rw [AddCommGrpCat.mono_iff_injective]
+    change Function.Injective (fun z : ℤ ↦ 2 * z)
+    intro a b h
+    nlinarith
+  · rw [AddCommGrpCat.epi_iff_surjective]
+    change Function.Surjective (fun z : ℤ ↦ (z : ZMod 2))
+    exact ZMod.intCast_surjective
+
+/-- The functor taking an abelian group to a coproduct of copies indexed by `I`. -/
+public noncomputable def coefficientCoproductFunctor (I : Type) :
+    CategoryTheory.Functor AddCommGrpCat AddCommGrpCat :=
+  sigmaConst ⋙ (evaluation (Type) AddCommGrpCat).obj I
+
+public instance (I : Type) : (coefficientCoproductFunctor I).Additive := by
+  dsimp [coefficientCoproductFunctor]
+  infer_instance
+
+private noncomputable def coefficientCoproductFunctorExactModel (I : Type) :
+    CategoryTheory.Functor AddCommGrpCat AddCommGrpCat :=
+  (Functor.const (Discrete I) : CategoryTheory.Functor AddCommGrpCat
+      (CategoryTheory.Functor (Discrete I) AddCommGrpCat)) ⋙ colim
+
+private instance (I : Type) : PreservesFiniteLimits
+    (coefficientCoproductFunctorExactModel I) := by
+  dsimp [coefficientCoproductFunctorExactModel]
+  infer_instance
+
+private instance (I : Type) : PreservesFiniteColimits
+    (coefficientCoproductFunctorExactModel I) := by
+  dsimp [coefficientCoproductFunctorExactModel]
+  infer_instance
+
+private noncomputable def coefficientCoproductFunctorIso (I : Type) :
+    coefficientCoproductFunctor I ≅ coefficientCoproductFunctorExactModel I :=
+  NatIso.ofComponents
+    (fun A ↦ Limits.Sigma.isoColimit ((Functor.const (Discrete I)).obj A)) (by
+      intro A B f
+      apply Limits.Sigma.hom_ext
+      intro i
+      simp only [coefficientCoproductFunctor, coefficientCoproductFunctorExactModel,
+        Functor.comp_map, evaluation_obj_map, sigmaConst]
+      rw [Limits.Sigma.ι_map_assoc]
+      have hB :
+          Limits.Sigma.ι (fun _ : I ↦ B) i ≫
+            (Limits.Sigma.isoColimit ((Functor.const (Discrete I)).obj B)).hom =
+          colimit.ι ((Functor.const (Discrete I)).obj B) ⟨i⟩ := by
+        simpa only [Functor.const_obj_obj] using
+          Limits.Sigma.ι_isoColimit_hom ((Functor.const (Discrete I)).obj B) i
+      have hA :
+          Limits.Sigma.ι (fun _ : I ↦ A) i ≫
+            (Limits.Sigma.isoColimit ((Functor.const (Discrete I)).obj A)).hom =
+          colimit.ι ((Functor.const (Discrete I)).obj A) ⟨i⟩ := by
+        simpa only [Functor.const_obj_obj] using
+          Limits.Sigma.ι_isoColimit_hom ((Functor.const (Discrete I)).obj A) i
+      rw [hB, ← Category.assoc, hA]
+      change f ≫ colimit.ι ((Functor.const (Discrete I)).obj B) ⟨i⟩ =
+        colimit.ι ((Functor.const (Discrete I)).obj A) ⟨i⟩ ≫
+          colimMap ((Functor.const (Discrete I)).map f)
+      rw [ι_colimMap, Functor.const_map_app])
+
+/-- A coproduct of copies preserves the integral-to-mod-two coefficient short exact sequence. -/
+public theorem integralModTwoCoefficientShortComplex_map_coproduct_shortExact (I : Type) :
+    (integralModTwoCoefficientShortComplex.map
+      (coefficientCoproductFunctor I)).ShortExact := by
+  have hG := integralModTwoCoefficientShortComplex_shortExact.map_of_exact
+    (coefficientCoproductFunctorExactModel I)
+  exact ShortComplex.shortExact_of_iso
+    (integralModTwoCoefficientShortComplex.mapNatIso
+      (coefficientCoproductFunctorIso I).symm) hG
+
+/-- Singular chains of `X`, regarded as a functor of the coefficient object. -/
+public noncomputable def singularChainComplexCoefficientFunctor (X : TopCat) :
+    CategoryTheory.Functor AddCommGrpCat (ChainComplex AddCommGrpCat ℕ) :=
+  singularChainComplexFunctor AddCommGrpCat ⋙
+    (evaluation TopCat (ChainComplex AddCommGrpCat ℕ)).obj X
+
+public instance (X : TopCat) :
+    (singularChainComplexCoefficientFunctor X).Additive := by
+  dsimp [singularChainComplexCoefficientFunctor]
+  infer_instance
+
+/-- Singular chains with mod-two coefficients. -/
+public noncomputable abbrev ModTwoSingularChainComplexObj (X : TopCat) :
+    ChainComplex AddCommGrpCat ℕ :=
+  (singularChainComplexCoefficientFunctor X).obj (AddCommGrpCat.of (ZMod 2))
+
+/-- The coefficient short complex after applying singular chains of `X`. -/
+public noncomputable def integralModTwoSingularChainShortComplex (X : TopCat) :
+    ShortComplex (ChainComplex AddCommGrpCat ℕ) :=
+  integralModTwoCoefficientShortComplex.map
+    (singularChainComplexCoefficientFunctor X)
+
+/-- Singular chains preserve the integral-to-mod-two coefficient short exact sequence. -/
+public theorem integralModTwoSingularChainShortComplex_shortExact (X : TopCat) :
+    (integralModTwoSingularChainShortComplex X).ShortExact := by
+  rw [HomologicalComplex.shortExact_iff_degreewise_shortExact]
+  intro n
+  unfold integralModTwoSingularChainShortComplex
+  rw [← ShortComplex.map_comp]
+  dsimp [singularChainComplexCoefficientFunctor, singularChainComplexFunctor,
+    SSet.chainComplexFunctor]
+  change (integralModTwoCoefficientShortComplex.map
+    (sigmaConst ⋙ (evaluation (Type) AddCommGrpCat).obj
+      ((TopCat.toSSet.obj X).obj (Opposite.op (SimplexCategory.mk n))))).ShortExact
+  exact integralModTwoCoefficientShortComplex_map_coproduct_shortExact _
+
+/-- The Bockstein reduction at degree three, assuming the coefficient short complex remains short
+exact after applying singular chains.  Vanishing of integral homology in degrees three and two
+then forces vanishing with mod-two coefficients in degree three. -/
+public theorem modTwoSingularHomologyThree_isZero_of_chainShortExact
+    (X : TopCat)
+    (hS : (integralModTwoSingularChainShortComplex X).ShortExact)
+    (h₃ : IsZero ((IntegralSingularChainComplexObj X).homology 3))
+    (h₂ : IsZero ((IntegralSingularChainComplexObj X).homology 2)) :
+    IsZero ((ModTwoSingularChainComplexObj X).homology 3) := by
+  have hexact := hS.homology_exact₃ 3 2
+    (ComplexShape.down_mk 3 2 (by omega))
+  have h₃' : IsZero ((integralModTwoSingularChainShortComplex X).X₂.homology 3) := by
+    simpa [integralModTwoSingularChainShortComplex,
+      integralModTwoCoefficientShortComplex,
+      singularChainComplexCoefficientFunctor] using h₃
+  have h₂' : IsZero ((integralModTwoSingularChainShortComplex X).X₁.homology 2) := by
+    simpa [integralModTwoSingularChainShortComplex,
+      integralModTwoCoefficientShortComplex,
+      singularChainComplexCoefficientFunctor] using h₂
+  exact hexact.isZero_X₂ (h₃'.eq_of_src _ _) (h₂'.eq_of_tgt _ _)
+
+/-- Integral homology vanishing in degrees three and two forces mod-two singular homology to
+vanish in degree three. -/
+public theorem modTwoSingularHomologyThree_isZero
+    (X : TopCat)
+    (h₃ : IsZero ((IntegralSingularChainComplexObj X).homology 3))
+    (h₂ : IsZero ((IntegralSingularChainComplexObj X).homology 2)) :
+    IsZero ((ModTwoSingularChainComplexObj X).homology 3) :=
+  modTwoSingularHomologyThree_isZero_of_chainShortExact X
+    (integralModTwoSingularChainShortComplex_shortExact X) h₃ h₂
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereLowIntegralHomology.lean
+++ b/SphereSixComplex/Topology/SixSphereLowIntegralHomology.lean
@@ -1,0 +1,232 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenFaceNeighborhoodLocalComparison
+public import SphereSixComplex.Topology.BoundarySevenRealizationInjective
+public import SphereSixComplex.Topology.DiskSevenCoverRangeGeometryChains
+
+/-!
+# Low integral homology of the standard six-sphere: the exact remaining comparison
+
+The simplicial boundary of the seven-simplex has already been proved to have zero integral
+homology in degrees two and three, and its realization has already been identified with the
+standard six-sphere.  Consequently the desired singular-homology calculation needs only the
+degree-two and degree-three pieces of the canonical simplicial-to-singular comparison; a full
+quasi-isomorphism in every degree is unnecessary.
+
+This file records that sharp equivalence and connects it to the completed local relative
+Mayer--Vietoris calculation for the seven-disk.  It also isolates a degreewise Čech-total input
+which is strictly weaker than the earlier all-degree Čech comparison structure.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical integral comparison for the boundary of the seven-simplex. -/
+public noncomputable abbrev boundarySevenIntegralComparisonMap :=
+  simplicialToRealizationSingularChainMap
+    (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)
+
+/-- Only the two degrees actually needed in the six-sphere argument. -/
+public def BoundarySevenLowIntegralComparison : Prop :=
+  QuasiIsoAt boundarySevenIntegralComparisonMap 2 ∧
+    QuasiIsoAt boundarySevenIntegralComparisonMap 3
+
+/-- A full canonical comparison immediately supplies its two low-degree components. -/
+public theorem boundarySevenLowIntegralComparison_of_quasiIso
+    (h : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) :
+    BoundarySevenLowIntegralComparison := by
+  change QuasiIso boundarySevenIntegralComparisonMap at h
+  exact ⟨(quasiIso_iff boundarySevenIntegralComparisonMap).mp h 2,
+    (quasiIso_iff boundarySevenIntegralComparisonMap).mp h 3⟩
+
+/-- The low comparison is exactly equivalent to low singular-homology vanishing on the
+realization.  The reverse implication uses the already computed vanishing of simplicial
+homology, so any map between the two zero homology objects is an isomorphism. -/
+public theorem boundarySevenLowIntegralComparison_iff_realization_low_isZero :
+    BoundarySevenLowIntegralComparison ↔
+      IsZero (((TopCat.toSSet.obj (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).chainComplex
+        (AddCommGrpCat.of ℤ)).homology 2) ∧
+      IsZero (((TopCat.toSSet.obj (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).chainComplex
+        (AddCommGrpCat.of ℤ)).homology 3) := by
+  constructor
+  · rintro ⟨h₂, h₃⟩
+    let _ : QuasiIsoAt boundarySevenIntegralComparisonMap 2 := h₂
+    let _ : QuasiIsoAt boundarySevenIntegralComparisonMap 3 := h₃
+    exact
+      ⟨(boundarySeven_simplicialHomology_two_isZero (AddCommGrpCat.of ℤ)).of_iso
+          (isoOfQuasiIsoAt boundarySevenIntegralComparisonMap 2).symm,
+        (boundarySeven_simplicialHomology_three_isZero (AddCommGrpCat.of ℤ)).of_iso
+          (isoOfQuasiIsoAt boundarySevenIntegralComparisonMap 3).symm⟩
+  · rintro ⟨h₂, h₃⟩
+    constructor
+    · rw [quasiIsoAt_iff_isIso_homologyMap]
+      exact (boundarySeven_simplicialHomology_two_isZero
+        (AddCommGrpCat.of ℤ)).isIso h₂ _
+    · rw [quasiIsoAt_iff_isIso_homologyMap]
+      exact (boundarySeven_simplicialHomology_three_isZero
+        (AddCommGrpCat.of ℤ)).isIso h₃ _
+
+/-- The completed realization homeomorphism, followed by the project's identification of its
+metric sphere with `TopCat.sphere 6`. -/
+public noncomputable def boundarySevenRealizationHomeomorphTopCatSphereSix :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ
+      (TopCat.sphere.{0} 6 : Type) :=
+  Classical.choice boundarySevenRealizationHomeomorphSixSphere |>.trans
+    sixSphereHomeomorphTopCatSphereSix
+
+/-- Degreewise integral singular homology is transported by the preceding homeomorphism. -/
+public noncomputable def boundarySevenRealizationHomologyIsoTopCatSphereSix (k : ℕ) :
+    ((IntegralSingularChainComplexObj
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).homology k) ≅
+      ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology k) :=
+  ((singularHomologyFunctor AddCommGrpCat k).obj
+    (AddCommGrpCat.of ℤ)).mapIso
+      (TopCat.isoOfHomeo boundarySevenRealizationHomeomorphTopCatSphereSix)
+
+/-- Thus the two desired standard-sphere vanishings are equivalent to the two degreewise
+components of the canonical boundary comparison. -/
+public theorem boundarySevenLowIntegralComparison_iff_standardSphereSix_low_isZero :
+    BoundarySevenLowIntegralComparison ↔
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3) := by
+  rw [boundarySevenLowIntegralComparison_iff_realization_low_isZero]
+  constructor
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨h₂.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 2).symm,
+        h₃.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 3).symm⟩
+  · rintro ⟨h₂, h₃⟩
+    exact
+      ⟨h₂.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 2),
+        h₃.of_iso (boundarySevenRealizationHomologyIsoTopCatSphereSix 3)⟩
+
+/-- The disk-cover local acyclicity obligation is neither stronger nor weaker than the missing
+low-degree boundary comparison: they are exactly equivalent. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_iff_boundarySevenLowIntegralComparison :
+    DiskSevenCoverLocalRelativeLowAcyclic ↔ BoundarySevenLowIntegralComparison := by
+  rw [diskSevenCoverLocalRelativeLowAcyclic_iff_sphereSix_low_isZero,
+    boundarySevenLowIntegralComparison_iff_standardSphereSix_low_isZero]
+
+/-- A direct endpoint producing both standard-sphere homology vanishings from the minimal
+degreewise comparison input. -/
+public theorem standardSphereSix_integralSingularHomology_low_isZero_of_boundaryLowComparison
+    (h : BoundarySevenLowIntegralComparison) :
+    IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3) :=
+  boundarySevenLowIntegralComparison_iff_standardSphereSix_low_isZero.mp h
+
+/-- The same minimal comparison input discharges all four fields of the local relative
+Mayer--Vietoris acyclicity package. -/
+public theorem diskSevenCoverLocalRelativeLowAcyclic_of_boundaryLowComparison
+    (h : BoundarySevenLowIntegralComparison) :
+    DiskSevenCoverLocalRelativeLowAcyclic :=
+  diskSevenCoverLocalRelativeLowAcyclic_iff_boundarySevenLowIntegralComparison.mpr h
+
+/-! ## A degreewise Čech-total endpoint -/
+
+/-- The remaining global Čech construction can be restricted to degrees two and three.  Unlike
+`BoundarySevenFaceNeighborhoodCechTotalComparison`, this structure asks for no quasi-isomorphism
+outside those two degrees. -/
+public structure BoundarySevenFaceNeighborhoodCechLowComparison where
+  boundaryToCech :
+    (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ) ⟶
+      boundarySevenFaceNeighborhoodCechTotal
+  augmentation :
+    boundarySevenFaceNeighborhoodCechTotal ⟶
+      CoverSmallIntegralSingularChainComplex
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood
+  fac : boundaryToCech ≫ augmentation =
+    simplicialToCoverSmallSingularChainMap
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods
+  boundaryToCech_quasiIsoAt_two : QuasiIsoAt boundaryToCech 2
+  boundaryToCech_quasiIsoAt_three : QuasiIsoAt boundaryToCech 3
+  augmentation_quasiIsoAt_two : QuasiIsoAt augmentation 2
+  augmentation_quasiIsoAt_three : QuasiIsoAt augmentation 3
+
+/-- A full Čech-total comparison restricts to the low-degree one. -/
+public noncomputable def BoundarySevenFaceNeighborhoodCechTotalComparison.toLow
+    (h : BoundarySevenFaceNeighborhoodCechTotalComparison) :
+    BoundarySevenFaceNeighborhoodCechLowComparison where
+  boundaryToCech := h.boundaryToCech
+  augmentation := h.augmentation
+  fac := h.fac
+  boundaryToCech_quasiIsoAt_two := h.boundaryToCech_quasiIso.quasiIsoAt 2
+  boundaryToCech_quasiIsoAt_three := h.boundaryToCech_quasiIso.quasiIsoAt 3
+  augmentation_quasiIsoAt_two := h.augmentation_quasiIso.quasiIsoAt 2
+  augmentation_quasiIsoAt_three := h.augmentation_quasiIso.quasiIsoAt 3
+
+/-- A low Čech-total comparison gives the two degreewise quasi-isomorphisms for the cover-small
+lift. -/
+public theorem boundarySevenFaceNeighborhoodLift_lowComparison_of_cechLow
+    (h : BoundarySevenFaceNeighborhoodCechLowComparison) :
+    QuasiIsoAt
+        (simplicialToCoverSmallSingularChainMap
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods) 2 ∧
+      QuasiIsoAt
+        (simplicialToCoverSmallSingularChainMap
+          (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+          boundarySevenComparisonUnitLandsInFaceNeighborhoods) 3 := by
+  constructor
+  · rw [← h.fac]
+    exact quasiIsoAt_comp h.boundaryToCech h.augmentation 2
+      (hφ := h.boundaryToCech_quasiIsoAt_two)
+      (hφ' := h.augmentation_quasiIsoAt_two)
+  · rw [← h.fac]
+    exact quasiIsoAt_comp h.boundaryToCech h.augmentation 3
+      (hφ := h.boundaryToCech_quasiIsoAt_three)
+      (hφ' := h.augmentation_quasiIsoAt_three)
+
+/-- Since inclusion of cover-small chains is already a quasi-isomorphism by affine
+subdivision, the low Čech-total package suffices for the desired low canonical comparison. -/
+public theorem boundarySevenLowIntegralComparison_of_cechLow
+    (h : BoundarySevenFaceNeighborhoodCechLowComparison) :
+    BoundarySevenLowIntegralComparison := by
+  have hlift := boundarySevenFaceNeighborhoodLift_lowComparison_of_cechLow h
+  have hinclusion : QuasiIso
+      (coverSmallIntegralSingularChainInclusion
+        (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+        boundarySevenComparisonFaceNeighborhood) :=
+    coverSmallChainQuasiIsomorphism_of_openCover
+      (SSet.toTop.obj (∂Δ[7] : SSet.{0}))
+      boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonFaceNeighborhood_isOpen
+      boundarySevenComparisonFaceNeighborhood_iUnion_unconditional
+  constructor
+  · change QuasiIsoAt
+      (simplicialToRealizationSingularChainMap
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 2
+    rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods]
+    exact quasiIsoAt_comp _ _ 2
+      (hφ := hlift.1) (hφ' := hinclusion.quasiIsoAt 2)
+  · change QuasiIsoAt
+      (simplicialToRealizationSingularChainMap
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 3
+    rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion
+      (∂Δ[7] : SSet.{0}) boundarySevenComparisonFaceNeighborhood
+      boundarySevenComparisonUnitLandsInFaceNeighborhoods]
+    exact quasiIsoAt_comp _ _ 3
+      (hφ := hlift.2) (hφ' := hinclusion.quasiIsoAt 3)
+
+/-- Consequently a degreewise Čech-total comparison proves the local relative acyclicity and
+the two low standard-sphere homology vanishings simultaneously. -/
+public theorem sixSphere_lowHomology_and_diskLocalAcyclic_of_cechLow
+    (h : BoundarySevenFaceNeighborhoodCechLowComparison) :
+    (IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 2) ∧
+      IsZero ((IntegralSingularChainComplexObj (TopCat.sphere.{0} 6)).homology 3)) ∧
+      DiskSevenCoverLocalRelativeLowAcyclic := by
+  have hc := boundarySevenLowIntegralComparison_of_cechLow h
+  exact ⟨standardSphereSix_integralSingularHomology_low_isZero_of_boundaryLowComparison hc,
+    diskSevenCoverLocalRelativeLowAcyclic_of_boundaryLowComparison hc⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparison.lean
+++ b/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparison.lean
@@ -1,0 +1,217 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import SphereSixComplex.Topology.HomotopySphereHomology
+public import Mathlib.AlgebraicTopology.ExtraDegeneracy
+public import Mathlib.AlgebraicTopology.SingularHomology.HomologyZero
+public import Mathlib.Analysis.Convex.Contractible
+public import Mathlib.Algebra.Homology.SingleHomology
+
+/-!
+# Simplicial--singular comparison for a standard simplex
+
+The realization of a standard simplex is contractible.  Both its simplicial chains and its
+singular chains therefore have zero positive-degree homology, while degree-zero homology is the
+coefficient group.  The canonical adjunction unit respects the degree-zero augmentations, so its
+chain map is a quasi-isomorphism in every degree.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- In a nonnegatively graded chain complex, degree-zero chains are canonically the degree-zero
+cycles, since the outgoing differential vanishes. -/
+public noncomputable def chainComplexXZeroIsoCyclesZero
+    (K : ChainComplex AddCommGrpCat ℕ) : K.X 0 ≅ K.cycles 0 where
+  hom := K.liftCycles (𝟙 _) 0 (by simp) (by simp)
+  inv := K.iCycles 0
+  hom_inv_id := by simp
+  inv_hom_id := by
+    rw [← cancel_mono (K.iCycles 0)]
+    simp
+
+/-- The canonical augmentation on degree-zero simplicial homology is natural in the simplicial
+set.  This is the residual naturality calculation needed in the standard-simplex comparison. -/
+public theorem simplicialHomologyZeroAugmentation_naturality
+    {X Y : SSet.{0}} (f : X ⟶ Y) :
+    SSet.homologyMap f (AddCommGrpCat.of ℤ) 0 ≫
+        Y.homology₀ε (AddCommGrpCat.of ℤ) =
+      X.homology₀ε (AddCommGrpCat.of ℤ) := by
+  let R := AddCommGrpCat.of ℤ
+  let K := X.chainComplex R
+  let L := Y.chainComplex R
+  let φ := SSet.chainComplexMap f R
+  let e₀ := chainComplexXZeroIsoCyclesZero K
+  apply (cancel_epi (K.homologyπ 0)).1
+  apply (cancel_epi e₀.hom).1
+  apply X.chainComplex_hom_ext
+  intro x
+  change X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫
+      HomologicalComplex.homologyMap φ 0 ≫ Y.homology₀ε R =
+    X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫ X.homology₀ε R
+  rw [HomologicalComplex.homologyπ_naturality_assoc]
+  change X.ιChainComplex x ≫
+      K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+        HomologicalComplex.cyclesMap φ 0 ≫ L.homologyπ 0 ≫
+          Y.homology₀ε R =
+    X.ιChainComplex x ≫ K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  simp only [← Category.assoc, HomologicalComplex.comp_liftCycles,
+    Category.comp_id]
+  simp only [HomologicalComplex.liftCycles_comp_cyclesMap]
+  change L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) ≫
+        L.homologyπ 0 ≫ Y.homology₀ε R =
+    K.liftCycles (X.ιChainComplex x) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  have hlift : L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) =
+      L.liftCycles (Y.ιChainComplex (f.app _ x)) 0 (by simp) (by simp) := by
+    apply (cancel_mono (L.iCycles 0)).1
+    simpa only [HomologicalComplex.liftCycles_i] using
+      SSet.ι_chainComplexMap_f X Y f R x
+  rw [hlift]
+  calc
+    _ = 𝟙 R := by
+      simpa only [] using
+        Y.liftCycles_ιChainComplex_homologyπ_homology₀ε R (f.app _ x)
+    _ = _ := by
+      symm
+      simpa only [] using
+        X.liftCycles_ιChainComplex_homologyπ_homology₀ε R x
+
+/-- Every standard simplex is connected as a simplicial set. -/
+public theorem standardSimplex_isConnected (n : ℕ) :
+    (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected := by
+  rw [SSet.isConnected_iff]
+  constructor
+  · constructor
+    intro a b
+    induction a using SSet.π₀.rec with
+    | mk x =>
+      induction b using SSet.π₀.rec with
+      | mk y =>
+        let i := SSet.stdSimplex.obj₀Equiv x
+        let j := SSet.stdSimplex.obj₀Equiv y
+        rcases le_total i j with hij | hji
+        · let s := SSet.stdSimplex.edge n i j hij
+          have hs : SSet.π₀.mk x = SSet.π₀.mk y := by
+            have hsrc : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 1 s = x := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            have htgt : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 0 s = y := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            simpa only [hsrc, htgt] using SSet.π₀.sound (SSet.Edge.mk' s)
+          exact hs
+        · let s := SSet.stdSimplex.edge n j i hji
+          have hs : SSet.π₀.mk y = SSet.π₀.mk x := by
+            have hsrc : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 1 s = y := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            have htgt : (SSet.stdSimplex.obj (SimplexCategory.mk n)).δ 0 s = x := by
+              apply SSet.stdSimplex.obj₀Equiv.injective
+              rfl
+            simpa only [hsrc, htgt] using SSet.π₀.sound (SSet.Edge.mk' s)
+          exact hs.symm
+  · exact ⟨SSet.stdSimplex.const n 0 _⟩
+
+/-- The geometric realization of every standard simplex is contractible. -/
+public theorem standardSimplexRealization_contractibleSpace (n : ℕ) :
+    ContractibleSpace
+      (SSet.toTop.obj (SSet.stdSimplex.obj (SimplexCategory.mk n)) : Type) := by
+  letI : ContractibleSpace (stdSimplex ℝ (Fin (n + 1))) :=
+    (convex_stdSimplex ℝ (Fin (n + 1))).contractibleSpace
+      ⟨stdSimplex.vertex (0 : Fin (n + 1)),
+        (stdSimplex.vertex (0 : Fin (n + 1))).2⟩
+  exact (SimplexCategory.toTopHomeo (SimplexCategory.mk n)).contractibleSpace
+
+/-- Simplicial chains of a standard simplex are exact in every positive degree, by the canonical
+extra degeneracy. -/
+public theorem standardSimplex_simplicialChains_exactAt
+    (n k : ℕ) (hk : k ≠ 0) :
+    ((Δ[n] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).ExactAt k := by
+  let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
+    (SimplexCategory.mk n)).map (sigmaConst.obj (AddCommGrpCat.of ℤ))
+  let e := ed.homotopyEquiv
+  exact (exactAt_iff_of_quasiIsoAt e.hom k).mpr
+    (HomologicalComplex.exactAt_single_obj _ _ _ _ hk)
+
+/-- Singular chains of the realization of a standard simplex are exact in every positive degree,
+by contractibility and homotopy invariance. -/
+public theorem standardSimplexRealization_singularChains_exactAt
+    (n k : ℕ) (hk : k ≠ 0) :
+    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex
+      (AddCommGrpCat.of ℤ)).ExactAt k := by
+  letI : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    standardSimplexRealization_contractibleSpace n
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type)
+  have hunit := AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+    AddCommGrpCat k (AddCommGrpCat.of ℤ) (TopCat.of Unit) hk
+  have hzero := hunit.of_iso (singularHomologyIsoOfHomotopyEquiv
+    (AddCommGrpCat.of ℤ) k e)
+  rw [HomologicalComplex.exactAt_iff_isZero_homology]
+  exact hzero
+
+/-- The canonical realization/singular adjunction-unit chain map is a quasi-isomorphism for every
+standard simplex. -/
+public theorem standardSimplex_simplicialToRealizationSingularChainMap_quasiIso
+    (n : ℕ) :
+    QuasiIso (simplicialToRealizationSingularChainMap
+      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)) := by
+  rw [quasiIso_iff]
+  intro k
+  by_cases hk : k = 0
+  · subst hk
+    rw [quasiIsoAt_iff_isIso_homologyMap]
+    letI : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
+      standardSimplex_isConnected n
+    letI : ContractibleSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+      standardSimplexRealization_contractibleSpace n
+    letI : PathConnectedSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) := inferInstance
+    letI : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
+      inferInstance
+    let φ := simplicialToRealizationSingularChainMap
+      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)
+    have hε : HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+          (AddCommGrpCat.of ℤ) =
+      (Δ[n] : SSet.{0}).homology₀ε (AddCommGrpCat.of ℤ) := by
+      exact simplicialHomologyZeroAugmentation_naturality
+        (sSetTopAdj.unit.app (Δ[n] : SSet.{0}))
+    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε
+        (AddCommGrpCat.of ℤ)) := inferInstance
+    let htarget : IsIso
+        ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+          (AddCommGrpCat.of ℤ)) :=
+      inferInstanceAs (IsIso ((TopCat.toSSet.obj
+        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε (AddCommGrpCat.of ℤ)))
+    have hcomp : IsIso (HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+          (AddCommGrpCat.of ℤ)) := by
+      rw [hε]
+      exact hsource
+    exact @IsIso.of_isIso_comp_right _ _ _ _ _
+      (HomologicalComplex.homologyMap φ 0)
+      ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
+        (AddCommGrpCat.of ℤ)) htarget hcomp
+  · exact (quasiIsoAt_iff_exactAt _ k
+      (standardSimplex_simplicialChains_exactAt n k hk)).mpr
+        (standardSimplexRealization_singularChains_exactAt n k hk)
+
+/-- In the terminology used by the project, every standard simplex satisfies the canonical
+integral simplicial--singular comparison. -/
+public theorem standardSimplex_integralComparison (n : ℕ) :
+    SimplicialToSingularComparisonQuasiIsomorphism
+      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
+  standardSimplex_simplicialToRealizationSingularChainMap_quasiIso n
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparisonGeneral.lean
+++ b/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparisonGeneral.lean
@@ -1,0 +1,133 @@
+module
+
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparison
+
+/-!
+# Simplicial--singular comparison for a standard simplex with arbitrary coefficients
+
+The integral proof does not use a special property of `ℤ`.  This file records the coefficient-
+general statement, including the degree-zero augmentation calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The degree-zero simplicial augmentation is natural for an arbitrary coefficient object. -/
+public theorem simplicialHomologyZeroAugmentation_naturality_general
+    {X Y : SSet.{0}} (f : X ⟶ Y) (R : AddCommGrpCat) :
+    SSet.homologyMap f R 0 ≫ Y.homology₀ε R = X.homology₀ε R := by
+  let K := X.chainComplex R
+  let L := Y.chainComplex R
+  let φ := SSet.chainComplexMap f R
+  let e₀ := chainComplexXZeroIsoCyclesZero K
+  apply (cancel_epi (K.homologyπ 0)).1
+  apply (cancel_epi e₀.hom).1
+  apply X.chainComplex_hom_ext
+  intro x
+  change X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫
+      HomologicalComplex.homologyMap φ 0 ≫ Y.homology₀ε R =
+    X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫ X.homology₀ε R
+  rw [HomologicalComplex.homologyπ_naturality_assoc]
+  change X.ιChainComplex x ≫
+      K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+        HomologicalComplex.cyclesMap φ 0 ≫ L.homologyπ 0 ≫
+          Y.homology₀ε R =
+    X.ιChainComplex x ≫ K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  simp only [← Category.assoc, HomologicalComplex.comp_liftCycles,
+    Category.comp_id]
+  simp only [HomologicalComplex.liftCycles_comp_cyclesMap]
+  change L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) ≫
+        L.homologyπ 0 ≫ Y.homology₀ε R =
+    K.liftCycles (X.ιChainComplex x) 0 (by simp) (by simp) ≫
+      K.homologyπ 0 ≫ X.homology₀ε R
+  have hlift : L.liftCycles
+      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) =
+      L.liftCycles (Y.ιChainComplex (f.app _ x)) 0 (by simp) (by simp) := by
+    apply (cancel_mono (L.iCycles 0)).1
+    simpa only [HomologicalComplex.liftCycles_i] using
+      SSet.ι_chainComplexMap_f X Y f R x
+  rw [hlift]
+  calc
+    _ = 𝟙 R := by
+      simpa only [] using
+        Y.liftCycles_ιChainComplex_homologyπ_homology₀ε R (f.app _ x)
+    _ = _ := by
+      symm
+      simpa only [] using
+        X.liftCycles_ιChainComplex_homologyπ_homology₀ε R x
+
+/-- Simplicial chains of a standard simplex are exact in positive degrees for arbitrary
+coefficients. -/
+public theorem standardSimplex_simplicialChains_exactAt_general
+    (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
+    ((Δ[n] : SSet.{0}).chainComplex R).ExactAt k := by
+  let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
+    (SimplexCategory.mk n)).map (sigmaConst.obj R)
+  let e := ed.homotopyEquiv
+  exact (exactAt_iff_of_quasiIsoAt e.hom k).mpr
+    (HomologicalComplex.exactAt_single_obj _ _ _ _ hk)
+
+/-- Singular chains of the realization of a standard simplex are exact in positive degrees for
+arbitrary coefficients. -/
+public theorem standardSimplexRealization_singularChains_exactAt_general
+    (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
+    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex R).ExactAt k := by
+  letI : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    standardSimplexRealization_contractibleSpace n
+  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
+    (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type)
+  have hunit := AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
+    AddCommGrpCat k R (TopCat.of Unit) hk
+  have hzero := hunit.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
+  rw [HomologicalComplex.exactAt_iff_isZero_homology]
+  exact hzero
+
+/-- The canonical comparison for a standard simplex is a quasi-isomorphism with every
+coefficient object in `AddCommGrpCat`. -/
+public theorem standardSimplex_simplicialToRealizationSingularChainMap_quasiIso_general
+    (R : AddCommGrpCat) (n : ℕ) :
+    QuasiIso (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) := by
+  rw [quasiIso_iff]
+  intro k
+  by_cases hk : k = 0
+  · subst hk
+    rw [quasiIsoAt_iff_isIso_homologyMap]
+    letI : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
+      standardSimplex_isConnected n
+    letI : ContractibleSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+      standardSimplexRealization_contractibleSpace n
+    letI : PathConnectedSpace
+        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) := inferInstance
+    letI : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
+      inferInstance
+    let φ := simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R
+    have hε : HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R =
+      (Δ[n] : SSet.{0}).homology₀ε R :=
+      simplicialHomologyZeroAugmentation_naturality_general
+        (sSetTopAdj.unit.app (Δ[n] : SSet.{0})) R
+    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε R) := inferInstance
+    let htarget : IsIso
+        ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) :=
+      inferInstanceAs (IsIso ((TopCat.toSSet.obj
+        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε R))
+    have hcomp : IsIso (HomologicalComplex.homologyMap φ 0 ≫
+        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) := by
+      rw [hε]
+      exact hsource
+    exact @IsIso.of_isIso_comp_right _ _ _ _ _
+      (HomologicalComplex.homologyMap φ 0)
+      ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) htarget hcomp
+  · exact (quasiIsoAt_iff_exactAt _ k
+      (standardSimplex_simplicialChains_exactAt_general R n k hk)).mpr
+        (standardSimplexRealization_singularChains_exactAt_general R n k hk)
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- promote the complete canonical simplicial-to-singular comparison stack
- include the disk-seven relative homology and mod-two reduction
- globalize the boundary-seven Cech comparison through first-quadrant totalization
- prove H3(S6; F2) = 0 and transport it to every marked smooth homotopy six-sphere
- expose the terminal theorem module through Main

This collects the already reviewed and merged continuation PRs #59 through #64 onto main. The pure H3 route remains decoupled from the separate degree-transport development.

## Diff

- 39 files
- 11273 additions
- no deletions

## Verification

- all focused module builds passed across #59 through #64
- lake build SphereSixComplex.Topology.BoundarySevenCechTotalQuasiIsoProof completed successfully: 3209 jobs
- lake build SphereSixComplex completed successfully: 9400 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- endpoint axiom audit reports only propext, Classical.choice, and Quot.sound