### PR TITLE
Compute top homology of the boundary seven-simplex

### DIFF
--- a/SphereSixComplex/Topology/SimplicialSixSphereTopHomology.lean
+++ b/SphereSixComplex/Topology/SimplicialSixSphereTopHomology.lean
@@ -1,0 +1,63 @@
+module
+
+public import SphereSixComplex.Topology.SixSphereDegreeComparison
+public import Mathlib.AlgebraicTopology.SimplicialSet.Homology.Nondegenerate
+
+/-!
+# Top homology of the combinatorial six-sphere: finite reduction
+
+The unnormalized simplicial chain complex contains degenerate simplices in every degree.  Mathlib's
+normalization theorem removes them by a chain-homotopy equivalence.  Since `∂Δ[7]` has dimension
+strictly below seven, its normalized degree-seven group vanishes, so degree-six homology is exactly
+the kernel of its one finite differential `C₆ → C₅`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+public noncomputable abbrev BoundarySevenNormalizedIntegralChains :
+    ChainComplex AddCommGrpCat ℕ :=
+  (∂Δ[7] : SSet.{0}).normalizedChainComplex (AddCommGrpCat.of ℤ)
+
+/-- The precise finite integer-matrix calculation left for top homology: the kernel of the
+normalized boundary map from the eight oriented facets is infinite cyclic. -/
+public def BoundarySevenNormalizedTopCyclesOrientation : Prop :=
+  Nonempty ((kernel (BoundarySevenNormalizedIntegralChains.d 6 5) :
+    AddCommGrpCat) ≃+ ℤ)
+
+/-- The normalized complex has no incoming group in degree six. -/
+public theorem boundarySeven_normalizedChains_degreeSeven_isZero :
+    IsZero (BoundarySevenNormalizedIntegralChains.X 7) :=
+  (∂Δ[7] : SSet.{0}).isZero_normalizedChainComplex_X_of_hasDimensionLT
+    (AddCommGrpCat.of ℤ) 7 7
+
+/-- Consequently, normalized degree-six homology is the kernel of its outgoing differential. -/
+public noncomputable def boundarySeven_normalizedHomologySixIsoTopCycles :
+    BoundarySevenNormalizedIntegralChains.homology 6 ≅
+      kernel (BoundarySevenNormalizedIntegralChains.d 6 5) := by
+  let K := BoundarySevenNormalizedIntegralChains
+  let S := K.sc' 7 6 5
+  have hf : S.f = 0 :=
+    boundarySeven_normalizedChains_degreeSeven_isZero.eq_of_src _ _
+  exact K.homologyIsoSc' 7 6 5 (by simp) (by simp) ≪≫
+    (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoKernel
+
+/-- The finite normalized kernel calculation supplies the combinatorial top generator. -/
+public theorem boundarySevenSimplicialTopHomologyOrientation_of_normalizedCycles
+    (h : BoundarySevenNormalizedTopCyclesOrientation) :
+    BoundarySevenSimplicialTopHomologyOrientation := by
+  obtain ⟨orientation⟩ := h
+  let _ : QuasiIso ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+      (AddCommGrpCat.of ℤ)) := inferInstance
+  let normalizationIso := isoOfQuasiIsoAt
+    ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex (AddCommGrpCat.of ℤ)) 6
+  exact ⟨normalizationIso.addCommGroupIsoToAddEquiv.trans
+    (boundarySeven_normalizedHomologySixIsoTopCycles.addCommGroupIsoToAddEquiv.trans
+      orientation)⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SimplicialSixSphereTopHomologyKernel.lean
+++ b/SphereSixComplex/Topology/SimplicialSixSphereTopHomologyKernel.lean
@@ -1,0 +1,203 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSixSphereTopHomology
+public import Mathlib.AlgebraicTopology.ExtraDegeneracy
+public import Mathlib.Algebra.Homology.SingleHomology
+
+/-!
+# The top normalized cycles of the boundary of the seven-simplex
+
+This file compares the normalized chains of the boundary with those of the full standard
+seven-simplex.  The latter is acyclic in positive degrees by its extra degeneracy, while its
+unique nondegenerate seven-simplex supplies the orientation cycle.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Simplicial
+  AlgebraicTopology HomologicalComplex
+
+namespace SphereSixComplex
+
+public noncomputable abbrev StandardSevenNormalizedIntegralChains :
+    ChainComplex AddCommGrpCat ℕ :=
+  (Δ[7] : SSet.{0}).normalizedChainComplex (AddCommGrpCat.of ℤ)
+
+/-- The normalized chains of the full standard seven-simplex are exact in every positive
+degree. -/
+public theorem standardSeven_normalizedChains_exactAt (n : ℕ) (hn : n ≠ 0) :
+    StandardSevenNormalizedIntegralChains.ExactAt n := by
+  let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
+    (SimplexCategory.mk 7)).map ((sigmaConst.obj (AddCommGrpCat.of ℤ)))
+  let e := ed.homotopyEquiv
+  have hchains : ((Δ[7] : SSet.{0}).chainComplex
+      (AddCommGrpCat.of ℤ)).ExactAt n := by
+    exact (exactAt_iff_of_quasiIsoAt e.hom n).mpr
+      (exactAt_single_obj _ _ _ _ hn)
+  exact (exactAt_iff_of_quasiIsoAt
+    ((Δ[7] : SSet.{0}).toNormalizedChainComplex (AddCommGrpCat.of ℤ)) n).mp hchains
+
+/-- In degrees below seven, send each nondegenerate simplex of the full simplex to the same
+simplex, regarded as a simplex of the boundary. -/
+public noncomputable def standardSevenNormalizedChainsToBoundary
+    (n : ℕ) (hn : n < 7) :
+    StandardSevenNormalizedIntegralChains.X n ⟶
+      BoundarySevenNormalizedIntegralChains.X n :=
+  ((Δ[7] : SSet.{0}).isColimitCofanNormalizedChainComplex
+    (AddCommGrpCat.of ℤ) n).desc
+      (Cofan.mk _ (fun x ↦
+        (∂Δ[7] : SSet.{0}).ιNormalizedChainComplex
+            ⟨x.1, by rw [SSet.boundary_obj_eq_univ n 7 hn]; trivial⟩))
+
+public theorem ιNormalizedChainComplex_standardSevenNormalizedChainsToBoundary
+    (n : ℕ) (hn : n < 7)
+    (x : (Δ[7] : SSet.{0}).obj (Opposite.op (SimplexCategory.mk n)))
+    (hx : x ∈ (Δ[7] : SSet.{0}).nonDegenerate n) :
+    (Δ[7] : SSet.{0}).ιNormalizedChainComplex x ≫
+        standardSevenNormalizedChainsToBoundary n hn =
+      (∂Δ[7] : SSet.{0}).ιNormalizedChainComplex
+        ⟨x, by rw [SSet.boundary_obj_eq_univ n 7 hn]; trivial⟩ := by
+  exact ((Δ[7] : SSet.{0}).isColimitCofanNormalizedChainComplex
+    (AddCommGrpCat.of ℤ) n).fac
+      (Cofan.mk _ (fun x ↦
+        (∂Δ[7] : SSet.{0}).ιNormalizedChainComplex
+          ⟨x.1, by rw [SSet.boundary_obj_eq_univ n 7 hn]; trivial⟩)) ⟨x, hx⟩
+
+/-- Below the top dimension, normalized chains of the boundary and of the full simplex agree. -/
+public noncomputable def boundarySevenNormalizedChainsXIsoStandard
+    (n : ℕ) (hn : n < 7) :
+    BoundarySevenNormalizedIntegralChains.X n ≅
+      StandardSevenNormalizedIntegralChains.X n where
+  hom := (SSet.normalizedChainComplexMap
+    (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+      (AddCommGrpCat.of ℤ)).f n
+  inv := standardSevenNormalizedChainsToBoundary n hn
+  hom_inv_id := by
+    apply (∂Δ[7] : SSet.{0}).normalizedChainComplex_hom_ext
+    intro x hx
+    rw [← Category.assoc, SSet.ι_normalizedChainComplexMap_f, Category.comp_id]
+    have hx' : x.1 ∈ (Δ[7] : SSet.{0}).nonDegenerate n := by
+      rwa [← (SSet.boundary 7).mem_nonDegenerate_iff x]
+    convert ιNormalizedChainComplex_standardSevenNormalizedChainsToBoundary
+      n hn x.1 hx' using 1 <;> try rfl
+  inv_hom_id := by
+    apply (Δ[7] : SSet.{0}).normalizedChainComplex_hom_ext
+    intro x hx
+    rw [← Category.assoc, Category.comp_id]
+    rw [ιNormalizedChainComplex_standardSevenNormalizedChainsToBoundary n hn x hx]
+    calc
+      _ = (Δ[7] : SSet.{0}).ιNormalizedChainComplex
+          (((SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι).app _
+            ⟨x, by rw [SSet.boundary_obj_eq_univ n 7 hn]; trivial⟩) :=
+        SSet.ι_normalizedChainComplexMap_f
+          (f := (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι)
+          (R := AddCommGrpCat.of ℤ) _
+      _ = _ := by congr
+
+/-- The degree-six cycle kernels of the boundary and the full simplex agree, because their
+normalized groups and differential agree in degrees six and five. -/
+public noncomputable def boundarySevenTopCyclesIsoStandardSevenTopCycles :
+    kernel (BoundarySevenNormalizedIntegralChains.d 6 5) ≅
+      kernel (StandardSevenNormalizedIntegralChains.d 6 5) := by
+  let f := SSet.normalizedChainComplexMap
+    (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+      (AddCommGrpCat.of ℤ)
+  let e₆ := boundarySevenNormalizedChainsXIsoStandard 6 (by omega)
+  let e₅ := boundarySevenNormalizedChainsXIsoStandard 5 (by omega)
+  letI : IsIso (f.f 6) := by
+    change IsIso e₆.hom
+    infer_instance
+  letI : IsIso (f.f 5) := by
+    change IsIso e₅.hom
+    infer_instance
+  let φ := (shortComplexFunctor' AddCommGrpCat (ComplexShape.down ℕ) 7 6 5).map f
+  letI : IsIso φ.τ₂ := by
+    dsimp [φ, shortComplexFunctor']
+    infer_instance
+  letI : IsIso φ.τ₃ := by
+    dsimp [φ, shortComplexFunctor']
+    infer_instance
+  exact ((BoundarySevenNormalizedIntegralChains.sc' 7 6 5).cyclesIsoKernel).symm ≪≫
+    asIso (ShortComplex.cyclesMap φ) ≪≫
+      (StandardSevenNormalizedIntegralChains.sc' 7 6 5).cyclesIsoKernel
+
+/-- The top normalized group of the full seven-simplex is one copy of `ℤ`, indexed by its
+unique nondegenerate top simplex. -/
+public noncomputable def standardSevenNormalizedChainsXSevenIsoInt :
+    StandardSevenNormalizedIntegralChains.X 7 ≅ AddCommGrpCat.of ℤ := by
+  let top : (Δ[7] : SSet.{0}).nonDegenerate 7 :=
+    ⟨SSet.stdSimplex.objEquiv.symm (𝟙 (SimplexCategory.mk 7)),
+      SSet.stdSimplex.objEquiv_symm_id_mem_nonDegenerate 7⟩
+  letI : Unique ((Δ[7] : SSet.{0}).nonDegenerate 7) :=
+    { default := top
+      uniq := fun x ↦ by
+        apply Subtype.ext
+        have hx := x.2
+        have hx' : x.1 ∈
+            ({SSet.stdSimplex.objEquiv.symm (𝟙 (SimplexCategory.mk 7))} :
+              Set ((Δ[7] : SSet.{0}).obj
+                (Opposite.op (SimplexCategory.mk 7)))) := by
+          rw [← SSet.stdSimplex.nonDegenerate_top_dim]
+          exact hx
+        simpa [top] using hx' }
+  exact IsColimit.coconePointUniqueUpToIso
+    ((Δ[7] : SSet.{0}).isColimitCofanNormalizedChainComplex
+      (AddCommGrpCat.of ℤ) 7)
+    (Cofan.isColimitMkOfUnique (Iso.refl (AddCommGrpCat.of ℤ))
+      ((Δ[7] : SSet.{0}).nonDegenerate 7))
+
+/-- Exactness in degree seven and vanishing in degree eight make the top differential of the
+full simplex a monomorphism. -/
+public theorem standardSeven_normalized_d_seven_six_mono :
+    Mono (StandardSevenNormalizedIntegralChains.d 7 6) := by
+  have h₇ := standardSeven_normalizedChains_exactAt 7 (by omega)
+  have h₇' : (StandardSevenNormalizedIntegralChains.sc' 8 7 6).Exact :=
+    ShortComplex.exact_of_iso
+      (StandardSevenNormalizedIntegralChains.isoSc' 8 7 6 (by simp) (by simp)) h₇
+  have h₈ : IsZero (StandardSevenNormalizedIntegralChains.X 8) :=
+    (Δ[7] : SSet.{0}).isZero_normalizedChainComplex_X_of_hasDimensionLT
+      (AddCommGrpCat.of ℤ) 8 8
+  apply h₇'.mono_g
+  exact h₈.eq_of_src _ _
+
+/-- Exactness in degree six identifies the top differential with the kernel of the next
+differential. -/
+public noncomputable def standardSevenNormalizedChainsXSevenIsoTopCycles :
+    StandardSevenNormalizedIntegralChains.X 7 ≅
+      kernel (StandardSevenNormalizedIntegralChains.d 6 5) := by
+  letI : Mono (StandardSevenNormalizedIntegralChains.d 7 6) :=
+    standardSeven_normalized_d_seven_six_mono
+  have h₆ := standardSeven_normalizedChains_exactAt 6 (by omega)
+  have h₆' : (StandardSevenNormalizedIntegralChains.sc' 7 6 5).Exact :=
+    ShortComplex.exact_of_iso
+      (StandardSevenNormalizedIntegralChains.isoSc' 7 6 5 (by simp) (by simp)) h₆
+  letI : Mono (StandardSevenNormalizedIntegralChains.sc' 7 6 5).f := by
+    change Mono (StandardSevenNormalizedIntegralChains.d 7 6)
+    exact standardSeven_normalized_d_seven_six_mono
+  exact IsLimit.conePointUniqueUpToIso h₆'.fIsKernel
+    (limit.isLimit (parallelPair (StandardSevenNormalizedIntegralChains.d 6 5) 0))
+
+/-- The degree-six cycle kernel of the full seven-simplex is infinite cyclic, generated by the
+boundary of its unique nondegenerate top simplex. -/
+public noncomputable def standardSevenTopCyclesIsoInt :
+    kernel (StandardSevenNormalizedIntegralChains.d 6 5) ≅ AddCommGrpCat.of ℤ :=
+  standardSevenNormalizedChainsXSevenIsoTopCycles.symm ≪≫
+    standardSevenNormalizedChainsXSevenIsoInt
+
+/-- The normalized top cycles of the boundary of the seven-simplex form one infinite cyclic
+group. -/
+public theorem boundarySevenNormalizedTopCyclesOrientation :
+    BoundarySevenNormalizedTopCyclesOrientation :=
+  ⟨(boundarySevenTopCyclesIsoStandardSevenTopCycles ≪≫
+    standardSevenTopCyclesIsoInt).addCommGroupIsoToAddEquiv⟩
+
+/-- Therefore degree-six simplicial homology of the boundary of the seven-simplex is
+unconditionally infinite cyclic. -/
+public theorem boundarySevenSimplicialTopHomologyOrientation :
+    BoundarySevenSimplicialTopHomologyOrientation :=
+  boundarySevenSimplicialTopHomologyOrientation_of_normalizedCycles
+    boundarySevenNormalizedTopCyclesOrientation
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereDegreeComparison.lean
+++ b/SphereSixComplex/Topology/SixSphereDegreeComparison.lean
@@ -1,0 +1,86 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import SphereSixComplex.Topology.SixSphereDegreeHomology
+
+/-!
+# Top-homology orientation from the boundary-simplex comparison
+
+This file connects the canonical simplicial--singular comparison with the homological degree
+package.  Once degree-six simplicial homology of `∂Δ[7]` is identified with `ℤ`, the integral
+comparison quasi-isomorphism and realization homeomorphism transport that generator to singular
+top homology of `S⁶`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- An isomorphism in `AddCommGrpCat` gives the corresponding additive equivalence of its
+underlying groups. -/
+public noncomputable def addEquivOfAddCommGrpCatIso {X Y : AddCommGrpCat}
+    (e : X ≅ Y) : X ≃+ Y where
+  toFun := e.hom.hom
+  invFun := e.inv.hom
+  left_inv x := by
+    simp
+  right_inv y := by
+    simp
+  map_add' x y := e.hom.hom.map_add x y
+
+/-- The remaining finite top-dimensional computation on the combinatorial sphere. -/
+public def BoundarySevenSimplicialTopHomologyOrientation : Prop :=
+  Nonempty (((∂Δ[7] : SSet.{0}).chainComplex
+    (AddCommGrpCat.of ℤ)).homology 6 ≃+ ℤ)
+
+/-- Integral comparison and the realization homeomorphism transport a combinatorial generator to
+an additive orientation of singular top homology of the standard six-sphere. -/
+public noncomputable def sixSphereTopHomologyAddEquivOfBoundaryComparison
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ SixSphere)
+    (orientation : ((∂Δ[7] : SSet.{0}).chainComplex
+      (AddCommGrpCat.of ℤ)).homology 6 ≃+ ℤ) :
+    IntegralSingularHomology 6 SixSphere ≃+ ℤ := by
+  let _ : QuasiIso (simplicialToRealizationSingularChainMap
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) := hcomparison
+  let comparisonIso := isoOfQuasiIsoAt
+    (simplicialToRealizationSingularChainMap
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 6
+  let homeomorphismIso :=
+    ((singularHomologyFunctor AddCommGrpCat 6).obj
+      (AddCommGrpCat.of ℤ)).mapIso
+        (TopCat.isoOfHomeo e :
+          SSet.toTop.obj (∂Δ[7] : SSet.{0}) ≅ TopCat.of SixSphere)
+  exact (addEquivOfAddCommGrpCatIso
+    (comparisonIso.trans homeomorphismIso)).symm.trans orientation
+
+/-- The packaged boundary comparison inputs and finite top-homology computation supply exactly
+the additive orientation used by homological degree. -/
+public theorem sixSphereTopHomologyOrientation_of_boundaryComparison
+    (hcomparison : BoundarySevenComparisonInputs (AddCommGrpCat.of ℤ))
+    (htop : BoundarySevenSimplicialTopHomologyOrientation) :
+    Nonempty (IntegralSingularHomology 6 SixSphere ≃+ ℤ) := by
+  obtain ⟨hc, ⟨e⟩⟩ := hcomparison
+  obtain ⟨orientation⟩ := htop
+  exact ⟨sixSphereTopHomologyAddEquivOfBoundaryComparison hc e orientation⟩
+
+/-- After the comparison inputs, the complete degree theory is reduced to the finite top-homology
+generator and the single calculation that antipodal sends its transported generator to `-1`. -/
+public theorem sixSphereDegreeTheory_of_boundaryComparison
+    (hcomparison : BoundarySevenComparisonInputs (AddCommGrpCat.of ℤ))
+    (htop : BoundarySevenSimplicialTopHomologyOrientation)
+    (hantipodal : ∀ orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ,
+      sixSphereHomologicalDegree orientation
+        OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1) :
+    Nonempty OrientedMarkedSmoothHomotopySixSphere.SixSphereDegreeTheory := by
+  obtain ⟨orientation⟩ :=
+    sixSphereTopHomologyOrientation_of_boundaryComparison hcomparison htop
+  exact ⟨SixSphereTopHomologyOrientation.toDegreeTheory
+    ⟨orientation, hantipodal orientation⟩⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereDegreeHomology.lean
+++ b/SphereSixComplex/Topology/SixSphereDegreeHomology.lean
@@ -1,0 +1,151 @@
+module
+
+public import SphereSixComplex.Topology.OrientedSmoothHomotopySphere
+public import Mathlib.Algebra.Group.Int.Units
+public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
+
+/-!
+# Degree from top integral homology
+
+This file constructs the degree laws for self-homotopy equivalences of `S⁶` from an additive
+identification `H₆(S⁶; ℤ) ≃ ℤ`.  The only geometric calculation left as input is that the analytic
+antipodal map acts by `-1` on the selected generator.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap
+
+namespace SphereSixComplex
+
+/-- The endomorphism of top integral singular homology induced by a continuous self-map of the
+standard six-sphere. -/
+public noncomputable def sixSphereTopIntegralHomologyMap
+    (f : C(SixSphere, SixSphere)) :
+    IntegralSingularHomology 6 SixSphere →+ IntegralSingularHomology 6 SixSphere :=
+  (((singularHomologyFunctor AddCommGrpCat 6).obj (AddCommGrpCat.of ℤ)).map
+    (TopCat.ofHom f)).hom
+
+/-- Degree computed on a chosen top-homology generator. -/
+public noncomputable def sixSphereHomologicalDegree
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (f : C(SixSphere, SixSphere)) : ℤ :=
+  orientation (sixSphereTopIntegralHomologyMap f (orientation.symm 1))
+
+/-- An additive endomorphism of `ℤ` is multiplication by its value at one. -/
+public theorem intAddHom_apply_eq_mul_apply_one (f : ℤ →+ ℤ) (z : ℤ) :
+    f z = z * f 1 := by
+  calc
+    f z = f (z • (1 : ℤ)) := by simp
+    _ = z • f 1 := f.map_zsmul z 1
+    _ = z * f 1 := by simp
+
+/-- Homotopic self-maps have the same top-homology map. -/
+public theorem sixSphereTopIntegralHomologyMap_eq_of_homotopic
+    {f g : C(SixSphere, SixSphere)} (h : f.Homotopic g) :
+    sixSphereTopIntegralHomologyMap f = sixSphereTopIntegralHomologyMap g := by
+  let F := (singularHomologyFunctor AddCommGrpCat 6).obj (AddCommGrpCat.of ℤ)
+  have hcat : F.map (TopCat.ofHom f) = F.map (TopCat.ofHom g) :=
+    TopCat.Homotopy.congr_homologyMap_singularChainComplexFunctor
+      h.some (AddCommGrpCat.of ℤ) 6
+  exact congrArg (fun u : F.obj (TopCat.of SixSphere) ⟶
+    F.obj (TopCat.of SixSphere) ↦ u.hom) hcat
+
+/-- Homological degree is invariant under homotopy. -/
+public theorem sixSphereHomologicalDegree_eq_of_homotopic
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    {f g : C(SixSphere, SixSphere)} (h : f.Homotopic g) :
+    sixSphereHomologicalDegree orientation f =
+      sixSphereHomologicalDegree orientation g := by
+  rw [sixSphereHomologicalDegree, sixSphereHomologicalDegree,
+    sixSphereTopIntegralHomologyMap_eq_of_homotopic h]
+
+/-- The identity self-map has degree one. -/
+public theorem sixSphereHomologicalDegree_id
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation (ContinuousMap.id SixSphere) = 1 := by
+  change orientation
+    (sixSphereTopIntegralHomologyMap (ContinuousMap.id SixSphere)
+      (orientation.symm 1)) = 1
+  have hmap : sixSphereTopIntegralHomologyMap (ContinuousMap.id SixSphere) =
+      AddMonoidHom.id _ := by
+    let F := (singularHomologyFunctor AddCommGrpCat 6).obj (AddCommGrpCat.of ℤ)
+    change (F.map (𝟙 (TopCat.of SixSphere))).hom = _
+    calc
+      (F.map (𝟙 (TopCat.of SixSphere))).hom =
+          ((𝟙 (F.obj (TopCat.of SixSphere))) :
+            F.obj (TopCat.of SixSphere) ⟶ F.obj (TopCat.of SixSphere)).hom :=
+        congrArg (fun u : F.obj (TopCat.of SixSphere) ⟶
+          F.obj (TopCat.of SixSphere) ↦ u.hom) (F.map_id _)
+      _ = AddMonoidHom.id _ := rfl
+  rw [hmap]
+  exact orientation.apply_symm_apply 1
+
+/-- Degree is multiplicative under composition. -/
+public theorem sixSphereHomologicalDegree_comp
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (f g : C(SixSphere, SixSphere)) :
+    sixSphereHomologicalDegree orientation (g.comp f) =
+      sixSphereHomologicalDegree orientation f *
+        sixSphereHomologicalDegree orientation g := by
+  let H := IntegralSingularHomology 6 SixSphere
+  let F := (singularHomologyFunctor AddCommGrpCat 6).obj (AddCommGrpCat.of ℤ)
+  let fH : H →+ H := sixSphereTopIntegralHomologyMap f
+  let gH : H →+ H := sixSphereTopIntegralHomologyMap g
+  let fZ : ℤ →+ ℤ := orientation.toAddMonoidHom.comp
+    (fH.comp orientation.symm.toAddMonoidHom)
+  let gZ : ℤ →+ ℤ := orientation.toAddMonoidHom.comp
+    (gH.comp orientation.symm.toAddMonoidHom)
+  have hcomp : sixSphereTopIntegralHomologyMap (g.comp f) = gH.comp fH := by
+    apply AddMonoidHom.ext
+    intro z
+    change (F.map (TopCat.ofHom (g.comp f))).hom z = _
+    have hfg : TopCat.ofHom (g.comp f) = TopCat.ofHom f ≫ TopCat.ofHom g := rfl
+    rw [hfg, Functor.map_comp]
+    rfl
+  have hf (z : ℤ) : orientation (fH (orientation.symm z)) =
+      z * sixSphereHomologicalDegree orientation f := by
+    change fZ z = z * fZ 1
+    exact intAddHom_apply_eq_mul_apply_one fZ z
+  have hg (z : ℤ) : orientation (gH (orientation.symm z)) =
+      z * sixSphereHomologicalDegree orientation g := by
+    change gZ z = z * gZ 1
+    exact intAddHom_apply_eq_mul_apply_one gZ z
+  rw [sixSphereHomologicalDegree, hcomp]
+  have hf1 := hf 1
+  have hgdeg := hg (sixSphereHomologicalDegree orientation f)
+  rw [one_mul] at hf1
+  rw [← hf1, orientation.symm_apply_apply] at hgdeg
+  exact hgdeg.trans (congrArg
+    (fun z : ℤ => z * sixSphereHomologicalDegree orientation g) hf1)
+
+/-- The remaining input for the degree package: top homology is infinite cyclic and the antipodal
+map sends the selected generator to its negative. -/
+public structure SixSphereTopHomologyOrientation where
+  orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ
+  antipodal_degree : sixSphereHomologicalDegree orientation
+    OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1
+
+/-- The homological construction supplies all fields of `SixSphereDegreeTheory`. -/
+public noncomputable def SixSphereTopHomologyOrientation.toDegreeTheory
+    (O : SixSphereTopHomologyOrientation) :
+    OrientedMarkedSmoothHomotopySixSphere.SixSphereDegreeTheory where
+  degree e := sixSphereHomologicalDegree O.orientation e.toFun
+  degree_refl := sixSphereHomologicalDegree_id O.orientation
+  degree_trans f g := by
+    exact sixSphereHomologicalDegree_comp O.orientation f.toFun g.toFun
+  degree_eq_one_or_neg_one f := by
+    let a := sixSphereHomologicalDegree O.orientation f.toFun
+    let b := sixSphereHomologicalDegree O.orientation f.invFun
+    have hab : a * b = 1 := by
+      rw [← sixSphereHomologicalDegree_comp]
+      exact (sixSphereHomologicalDegree_eq_of_homotopic O.orientation f.left_inv).trans
+        (sixSphereHomologicalDegree_id O.orientation)
+    exact Int.eq_one_or_neg_one_of_mul_eq_one hab
+  degree_antipodal := O.antipodal_degree
+  degree_homotopic f g h :=
+    sixSphereHomologicalDegree_eq_of_homotopic O.orientation h
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- define homological degree from top integral singular homology
- connect the boundary-simplex comparison to a top-homology orientation
- reduce normalized degree-six homology to the finite cycle kernel
- prove H6(boundary Delta[7]; Z) is infinite cyclic

This is PR 1 of 7 in the boundary-seven degree-transport stack.

## Verification

- lake build SphereSixComplex.Topology.SimplicialSixSphereTopHomologyKernel
- Build completed successfully: 3042 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- endpoint axiom audit: only propext, Classical.choice, and Quot.sound