### PR TITLE
Model coordinate reflection on the six-sphere

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenReflectionEquivariantModel.lean
+++ b/SphereSixComplex/Topology/BoundarySevenReflectionEquivariantModel.lean
@@ -1,0 +1,362 @@
+module
+
+public import SphereSixComplex.Topology.SixSphereCoordinateReflectionHomology
+public import Mathlib.Analysis.Normed.Module.Ball.RadialEquiv
+
+/-!
+# A reflection-equivariant radial model of the seven-simplex boundary
+
+We use seven explicit linear coordinates on the affine hyperplane of barycentric coordinates.
+The first is the difference of barycentric coordinates zero and one; the remaining six are the
+centered coordinates at vertices two through seven.  Thus swapping vertices zero and one becomes
+literal negation of ambient coordinate zero.  Radial normalization then gives the desired map to
+the unit six-sphere.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open ContinuousMap Metric Set
+
+namespace SphereSixComplex
+
+/-- Explicit linear coordinates on the centered barycentric hyperplane. -/
+public noncomputable def boundarySevenReflectionCoordinates
+    (w : Fin 8 → ℝ) : EuclideanSpace ℝ (Fin 7) :=
+  WithLp.toLp 2 ![
+    w 0 - w 1,
+    w 2 - (1 / 8 : ℝ),
+    w 3 - (1 / 8 : ℝ),
+    w 4 - (1 / 8 : ℝ),
+    w 5 - (1 / 8 : ℝ),
+    w 6 - (1 / 8 : ℝ),
+    w 7 - (1 / 8 : ℝ)]
+
+/-- Reconstruct centered barycentric coordinates from the seven reflection coordinates. -/
+public noncomputable def boundarySevenReflectionCoordinatesInverse
+    (y : EuclideanSpace ℝ (Fin 7)) : Fin 8 → ℝ :=
+  ![
+    (y 0 - (y 1 + y 2 + y 3 + y 4 + y 5 + y 6)) / 2,
+    (-y 0 - (y 1 + y 2 + y 3 + y 4 + y 5 + y 6)) / 2,
+    y 1, y 2, y 3, y 4, y 5, y 6]
+
+public theorem boundarySevenReflectionCoordinatesInverse_sum
+    (y : EuclideanSpace ℝ (Fin 7)) :
+    ∑ i, boundarySevenReflectionCoordinatesInverse y i = 0 := by
+  simp [boundarySevenReflectionCoordinatesInverse, Fin.sum_univ_succ]
+  ring
+
+public theorem boundarySevenReflectionCoordinates_inverse_apply
+    (y : EuclideanSpace ℝ (Fin 7)) :
+    boundarySevenReflectionCoordinates
+        (fun i ↦ boundarySevenReflectionCoordinatesInverse y i + (1 / 8 : ℝ)) = y := by
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [boundarySevenReflectionCoordinates,
+    boundarySevenReflectionCoordinatesInverse] <;> ring
+
+public theorem boundarySevenReflectionCoordinatesInverse_smul
+    (c : ℝ) (y : EuclideanSpace ℝ (Fin 7)) (i : Fin 8) :
+    boundarySevenReflectionCoordinatesInverse (c • y) i =
+      c * boundarySevenReflectionCoordinatesInverse y i := by
+  fin_cases i <;> simp [boundarySevenReflectionCoordinatesInverse] <;> ring
+
+public theorem boundarySevenReflectionCoordinates_scaled_inverse
+    (c : ℝ) (y : EuclideanSpace ℝ (Fin 7)) :
+    boundarySevenReflectionCoordinates
+        (fun i ↦ c * boundarySevenReflectionCoordinatesInverse y i + (1 / 8 : ℝ)) =
+      c • y := by
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [boundarySevenReflectionCoordinates,
+    boundarySevenReflectionCoordinatesInverse] <;> ring
+
+public theorem boundarySevenReflectionCoordinatesInverse_coordinates
+    (w : Fin 8 → ℝ) (hw : ∑ i, w i = 1) (i : Fin 8) :
+    boundarySevenReflectionCoordinatesInverse
+        (boundarySevenReflectionCoordinates w) i = w i - (1 / 8 : ℝ) := by
+  norm_num [Fin.sum_univ_succ] at hw
+  change w 0 + (w 1 + (w 2 + (w 3 + (w 4 + (w 5 + (w 6 + w 7)))))) = 1 at hw
+  fin_cases i <;> simp [boundarySevenReflectionCoordinates,
+    boundarySevenReflectionCoordinatesInverse] <;> linarith
+
+public theorem boundarySevenReflectionCoordinates_injective_on_sum_one
+    {w z : Fin 8 → ℝ} (hw : ∑ i, w i = 1) (hz : ∑ i, z i = 1)
+    (h : boundarySevenReflectionCoordinates w = boundarySevenReflectionCoordinates z) :
+    w = z := by
+  funext i
+  have hiw := boundarySevenReflectionCoordinatesInverse_coordinates w hw i
+  have hiz := boundarySevenReflectionCoordinatesInverse_coordinates z hz i
+  rw [h] at hiw
+  linarith
+
+public theorem continuous_boundarySevenReflectionCoordinates :
+    Continuous (fun w : Fin 8 → ℝ ↦ boundarySevenReflectionCoordinates w) := by
+  rw [← (EuclideanSpace.equiv (Fin 7) ℝ).toHomeomorph.comp_continuous_iff]
+  apply continuous_pi
+  intro i
+  fin_cases i <;> simp [boundarySevenReflectionCoordinates] <;> fun_prop
+
+/-- Reflection coordinates do not vanish on the boundary of the simplex. -/
+public theorem boundarySevenReflectionCoordinates_ne_zero
+    (w : StandardSimplexBoundary 7) :
+    boundarySevenReflectionCoordinates (w.1 : Fin 8 → ℝ) ≠ 0 := by
+  intro hzero
+  obtain ⟨i, hi⟩ := w.2
+  have hsum : ∑ j, (w.1 : Fin 8 → ℝ) j = 1 := w.1.2.2
+  have hi' := boundarySevenReflectionCoordinatesInverse_coordinates
+    (w.1 : Fin 8 → ℝ) hsum i
+  rw [hzero] at hi'
+  simp [boundarySevenReflectionCoordinatesInverse] at hi'
+  rw [hi] at hi'
+  fin_cases i <;> norm_num [boundarySevenReflectionCoordinatesInverse] at hi'
+
+/-- The unnormalized reflection-coordinate map, bundled with its nonvanishing proof. -/
+public noncomputable def boundarySevenReflectionCoordinatesNonzero :
+    StandardSimplexBoundary 7 → ({0}ᶜ : Set (EuclideanSpace ℝ (Fin 7))) :=
+  fun w ↦ ⟨boundarySevenReflectionCoordinates (w.1 : Fin 8 → ℝ), by
+    simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using
+      boundarySevenReflectionCoordinates_ne_zero w⟩
+
+public theorem continuous_boundarySevenReflectionCoordinatesNonzero :
+    Continuous boundarySevenReflectionCoordinatesNonzero := by
+  apply Continuous.subtype_mk
+  exact continuous_boundarySevenReflectionCoordinates.comp
+    (continuous_subtype_val.comp continuous_subtype_val)
+
+/-- Radially normalize the explicit coordinates to the unit six-sphere. -/
+public noncomputable def boundarySevenReflectionRadialMap :
+    StandardSimplexBoundary 7 → SixSphere :=
+  fun w ↦ (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin 7))
+    (boundarySevenReflectionCoordinatesNonzero w)).1
+
+public theorem continuous_boundarySevenReflectionRadialMap :
+    Continuous boundarySevenReflectionRadialMap :=
+  continuous_fst.comp ((homeomorphUnitSphereProd
+    (EuclideanSpace ℝ (Fin 7))).continuous.comp
+      continuous_boundarySevenReflectionCoordinatesNonzero)
+
+@[simp]
+public theorem boundarySevenReflectionRadialMap_coe
+    (w : StandardSimplexBoundary 7) :
+    (boundarySevenReflectionRadialMap w : EuclideanSpace ℝ (Fin 7)) =
+      ‖boundarySevenReflectionCoordinates (w.1 : Fin 8 → ℝ)‖⁻¹ •
+        boundarySevenReflectionCoordinates (w.1 : Fin 8 → ℝ) := by
+  exact homeomorphUnitSphereProd_apply_fst_coe
+    (E := EuclideanSpace ℝ (Fin 7)) _
+
+public theorem boundarySevenReflectionCoordinates_permute
+    (w : Fin 8 → ℝ) :
+    boundarySevenReflectionCoordinates
+        (fun i ↦ w (boundarySevenReflectionPermutation.symm i)) =
+      sixSphereCoordinateReflectionAmbient
+        (boundarySevenReflectionCoordinates w) := by
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [boundarySevenReflectionCoordinates,
+    boundarySevenReflectionPermutation, sixSphereCoordinateReflectionAmbient,
+    Equiv.swap_apply_def]
+
+public theorem boundarySevenReflectionCoordinates_permute_norm
+    (w : Fin 8 → ℝ) :
+    ‖boundarySevenReflectionCoordinates
+        (fun i ↦ w (boundarySevenReflectionPermutation.symm i))‖ =
+      ‖boundarySevenReflectionCoordinates w‖ := by
+  rw [boundarySevenReflectionCoordinates_permute]
+  rw [← sixSphereAntipodalReflectionRotationAmbient_one,
+    sixSphereAntipodalReflectionRotationAmbient_norm]
+
+public theorem boundarySevenReflectionBoundaryPerm_val
+    (w : StandardSimplexBoundary 7) :
+    ((standardSimplexBoundaryPermHomeomorph
+        boundarySevenReflectionPermutation w).1 : Fin 8 → ℝ) =
+      fun i ↦ (w.1 : Fin 8 → ℝ) (boundarySevenReflectionPermutation.symm i) := by
+  funext i
+  exact stdSimplex_map_equiv_apply boundarySevenReflectionPermutation w.1 i
+
+public theorem boundarySevenReflectionRadialMap_equivariant
+    (w : StandardSimplexBoundary 7) :
+    boundarySevenReflectionRadialMap
+        (standardSimplexBoundaryPermHomeomorph
+          boundarySevenReflectionPermutation w) =
+      sixSphereCoordinateReflectionMap (boundarySevenReflectionRadialMap w) := by
+  apply Subtype.ext
+  rw [boundarySevenReflectionRadialMap_coe,
+    sixSphereCoordinateReflectionMap_apply,
+    boundarySevenReflectionRadialMap_coe]
+  rw [boundarySevenReflectionBoundaryPerm_val,
+    boundarySevenReflectionCoordinates_permute_norm,
+    boundarySevenReflectionCoordinates_permute]
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [sixSphereCoordinateReflectionAmbient]
+
+public theorem boundarySevenReflectionRadialMap_injective :
+    Function.Injective boundarySevenReflectionRadialMap := by
+  intro w z hwz
+  let vw := boundarySevenReflectionCoordinates (w.1 : Fin 8 → ℝ)
+  let vz := boundarySevenReflectionCoordinates (z.1 : Fin 8 → ℝ)
+  have hvw : vw ≠ 0 := boundarySevenReflectionCoordinates_ne_zero w
+  have hvz : vz ≠ 0 := boundarySevenReflectionCoordinates_ne_zero z
+  have hnw : 0 < ‖vw‖ := norm_pos_iff.mpr hvw
+  have hnz : 0 < ‖vz‖ := norm_pos_iff.mpr hvz
+  have hnormalized : ‖vw‖⁻¹ • vw = ‖vz‖⁻¹ • vz := by
+    have := congrArg Subtype.val hwz
+    simpa only [boundarySevenReflectionRadialMap_coe] using this
+  let c : ℝ := ‖vz‖ / ‖vw‖
+  have hc : 0 < c := div_pos hnz hnw
+  have hscaled : vz = c • vw := by
+    calc
+      vz = ‖vz‖ • (‖vz‖⁻¹ • vz) := by
+        rw [smul_smul]
+        simp [hnz.ne']
+      _ = ‖vz‖ • (‖vw‖⁻¹ • vw) := by rw [hnormalized]
+      _ = c • vw := by
+        rw [smul_smul]
+        congr 1
+  change boundarySevenReflectionCoordinates (z.1 : Fin 8 → ℝ) =
+    c • boundarySevenReflectionCoordinates (w.1 : Fin 8 → ℝ) at hscaled
+  have hcentered (i : Fin 8) :
+      (z.1 : Fin 8 → ℝ) i - (1 / 8 : ℝ) =
+        c * ((w.1 : Fin 8 → ℝ) i - (1 / 8 : ℝ)) := by
+    have hzcoord := boundarySevenReflectionCoordinatesInverse_coordinates
+      (z.1 : Fin 8 → ℝ) z.1.2.2 i
+    have hwcoord := boundarySevenReflectionCoordinatesInverse_coordinates
+      (w.1 : Fin 8 → ℝ) w.1.2.2 i
+    rw [hscaled, boundarySevenReflectionCoordinatesInverse_smul] at hzcoord
+    rw [hwcoord] at hzcoord
+    exact hzcoord.symm
+  obtain ⟨iw, hiw⟩ := w.2
+  obtain ⟨iz, hiz⟩ := z.2
+  have hcle : c ≤ 1 := by
+    have hznonneg := z.1.2.1 iw
+    change 0 ≤ (z.1 : Fin 8 → ℝ) iw at hznonneg
+    have h := hcentered iw
+    rw [hiw] at h
+    norm_num at h
+    linarith
+  have hge : 1 ≤ c := by
+    have hwnonneg := w.1.2.1 iz
+    change 0 ≤ (w.1 : Fin 8 → ℝ) iz at hwnonneg
+    have h := hcentered iz
+    rw [hiz] at h
+    norm_num at h
+    nlinarith [hc]
+  have hc_one : c = 1 := le_antisymm hcle hge
+  apply Subtype.ext
+  apply Subtype.ext
+  change (w.1 : Fin 8 → ℝ) = (z.1 : Fin 8 → ℝ)
+  exact boundarySevenReflectionCoordinates_injective_on_sum_one
+    w.1.2.2 z.1.2.2 (by simpa [hc_one] using hscaled.symm)
+
+public theorem boundarySevenReflectionRadialMap_surjective :
+    Function.Surjective boundarySevenReflectionRadialMap := by
+  intro y
+  let x : Fin 8 → ℝ := boundarySevenReflectionCoordinatesInverse y.1
+  have hxsum : ∑ j, x j = 0 :=
+    boundarySevenReflectionCoordinatesInverse_sum y.1
+  have hyne : y.1 ≠ 0 := by
+    intro hyzero
+    have hynorm : ‖y.1‖ = 1 := by
+      simpa only [mem_sphere_zero_iff_norm] using y.2
+    rw [hyzero, norm_zero] at hynorm
+    norm_num at hynorm
+  have hxne : x ≠ 0 := by
+    intro hxzero
+    have hreconstruct := boundarySevenReflectionCoordinates_inverse_apply y.1
+    have hcenter : (fun i : Fin 8 ↦ x i + (1 / 8 : ℝ)) =
+        fun _ ↦ (1 / 8 : ℝ) := by simp [hxzero]
+    rw [hcenter] at hreconstruct
+    have hcoordszero : boundarySevenReflectionCoordinates
+        (fun _ : Fin 8 ↦ (1 / 8 : ℝ)) = 0 := by
+      apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+      funext i
+      fin_cases i <;> norm_num [boundarySevenReflectionCoordinates]
+    exact hyne (hreconstruct ▸ hcoordszero)
+  obtain ⟨i, -, hi⟩ := Finset.exists_min_image Finset.univ x Finset.univ_nonempty
+  have hxi : x i < 0 := by
+    by_contra hnot
+    have hall : ∀ j ∈ Finset.univ, 0 ≤ x j := by
+      intro j hj
+      exact (le_of_not_gt hnot).trans (hi j hj)
+    have hallzero : ∀ j ∈ Finset.univ, x j = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg hall).mp hxsum
+    apply hxne
+    funext j
+    exact hallzero j (Finset.mem_univ j)
+  let c : ℝ := (1 / 8 : ℝ) / (-x i)
+  have hc : 0 < c := div_pos (by norm_num) (neg_pos.mpr hxi)
+  have hci : c * x i = -(1 / 8 : ℝ) := by
+    dsimp [c]
+    field_simp [hxi.ne]
+  let wf : Fin 8 → ℝ := fun j ↦ c * x j + (1 / 8 : ℝ)
+  have hw_nonneg (j : Fin 8) : 0 ≤ wf j := by
+    have hmin := hi j (Finset.mem_univ j)
+    dsimp [wf]
+    nlinarith
+  have hw_sum : ∑ j, wf j = 1 := by
+    simp only [wf, Finset.sum_add_distrib]
+    rw [← Finset.mul_sum, hxsum]
+    norm_num
+  let ws : stdSimplex ℝ (Fin 8) := ⟨wf, hw_nonneg, hw_sum⟩
+  have hwi : ws i = 0 := by
+    change wf i = 0
+    dsimp [wf]
+    linarith
+  let wb : StandardSimplexBoundary 7 := ⟨ws, ⟨i, hwi⟩⟩
+  refine ⟨wb, ?_⟩
+  apply Subtype.ext
+  rw [boundarySevenReflectionRadialMap_coe]
+  have hraw : boundarySevenReflectionCoordinates (wb.1 : Fin 8 → ℝ) = c • y.1 := by
+    exact boundarySevenReflectionCoordinates_scaled_inverse c y.1
+  rw [hraw]
+  have hynorm : ‖y.1‖ = 1 := by
+    simpa only [mem_sphere_zero_iff_norm] using y.2
+  simp [norm_smul, abs_of_pos hc, hynorm, hc.ne']
+
+public theorem boundarySevenReflectionRadialMap_bijective :
+    Function.Bijective boundarySevenReflectionRadialMap :=
+  ⟨boundarySevenReflectionRadialMap_injective,
+    boundarySevenReflectionRadialMap_surjective⟩
+
+/-- The vanishing-coordinate boundary is closed in the compact standard simplex. -/
+public theorem isClosed_standardSimplexBoundarySeven :
+    IsClosed {w : stdSimplex ℝ (Fin 8) | ∃ i, w i = 0} := by
+  have hset : {w : stdSimplex ℝ (Fin 8) | ∃ i, w i = 0} =
+      ⋃ i : Fin 8, {w : stdSimplex ℝ (Fin 8) | w i = 0} := by
+    ext w
+    simp
+  rw [hset]
+  apply isClosed_iUnion_of_finite
+  intro i
+  exact isClosed_eq
+    ((continuous_apply i).comp continuous_subtype_val) continuous_const
+
+/-- The explicit radial map, upgraded to a homeomorphism by compactness of the simplex boundary. -/
+public noncomputable def boundarySevenReflectionEquivariantHomeomorph :
+    StandardSimplexBoundary 7 ≃ₜ SixSphere := by
+  letI : CompactSpace (StandardSimplexBoundary 7) :=
+    isClosed_standardSimplexBoundarySeven.isClosedEmbedding_subtypeVal.compactSpace
+  exact Continuous.homeoOfEquivCompactToT2
+    (f := Equiv.ofBijective boundarySevenReflectionRadialMap
+      boundarySevenReflectionRadialMap_bijective)
+    continuous_boundarySevenReflectionRadialMap
+
+@[simp]
+public theorem boundarySevenReflectionEquivariantHomeomorph_apply
+    (w : StandardSimplexBoundary 7) :
+    boundarySevenReflectionEquivariantHomeomorph w =
+      boundarySevenReflectionRadialMap w :=
+  rfl
+
+/-- Swapping vertices zero and one is exactly coordinate-zero reflection under the explicit
+radial homeomorphism. -/
+public theorem boundarySevenReflectionEquivariantHomeomorph_equivariant :
+    BoundarySevenReflectionEquivariant
+      boundarySevenReflectionEquivariantHomeomorph := by
+  intro w
+  simp only [boundarySevenReflectionEquivariantHomeomorph_apply]
+  exact boundarySevenReflectionRadialMap_equivariant w
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereAntipodalDegree.lean
+++ b/SphereSixComplex/Topology/SixSphereAntipodalDegree.lean
@@ -1,0 +1,207 @@
+module
+
+public import SphereSixComplex.Topology.SimplicialSixSphereTopHomologyKernel
+public import SphereSixComplex.Topology.BoundarySevenRealizationInjective
+public import SphereSixComplex.Topology.SixSphereDegreeComparison
+public import Mathlib.GroupTheory.Perm.Fin
+
+/-!
+# The antipodal degree and the cyclic boundary model
+
+This file isolates the remaining geometric input in the degree calculation.  The cyclic
+permutation of the eight barycentric coordinates is an explicit self-homeomorphism of the
+ordinary boundary of the seven-simplex, and it is an odd permutation.  Conjugating it by the
+constructed boundary--sphere homeomorphism gives a completely concrete self-map of `S⁶`.
+
+The final theorem below shows that the desired assertion for every choice of top-homology
+orientation is equivalent to the orientation-free assertion that the analytic antipodal map
+induces negation on integral top homology.  It also gives the exact two-input reduction through
+the cyclic boundary model.  What is not available in Mathlib is the naturality theorem which
+identifies this unordered vertex permutation with its action on the ordered simplicial boundary;
+an arbitrary permutation of `Fin 8` is not a morphism of the representable simplicial set
+`Delta[7]`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Set Simplicial
+
+namespace SphereSixComplex
+
+/-- For a bijection of the vertex set, the induced affine map just reindexes barycentric
+coordinates. -/
+public theorem stdSimplex_map_equiv_apply
+    {n : ℕ} (sigma : Equiv.Perm (Fin n)) (w : stdSimplex ℝ (Fin n)) (j : Fin n) :
+    stdSimplex.map sigma w j = w (sigma.symm j) := by
+  classical
+  simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+  have hfiber : (Finset.univ.filter fun i : Fin n ↦ sigma i = j) =
+      {sigma.symm j} := by
+    ext i
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and,
+      Finset.mem_singleton]
+    exact sigma.eq_symm_apply.symm
+  rw [hfiber]
+  simp
+
+/-- A permutation of vertices acts affinely by a homeomorphism of the whole standard simplex. -/
+public noncomputable def stdSimplexPermHomeomorph
+    {n : ℕ} (sigma : Equiv.Perm (Fin n)) :
+    stdSimplex ℝ (Fin n) ≃ₜ stdSimplex ℝ (Fin n) where
+  toFun := stdSimplex.map sigma
+  invFun := stdSimplex.map sigma.symm
+  left_inv w := by
+    rw [stdSimplex.map_comp_apply]
+    simp only [Equiv.symm_comp_self, stdSimplex.map_id_apply]
+  right_inv w := by
+    rw [stdSimplex.map_comp_apply]
+    simp only [Equiv.self_comp_symm, stdSimplex.map_id_apply]
+  continuous_toFun := stdSimplex.continuous_map sigma
+  continuous_invFun := stdSimplex.continuous_map sigma.symm
+
+/-- The affine vertex-permutation homeomorphism preserves the topological boundary. -/
+public noncomputable def standardSimplexBoundaryPermHomeomorph
+    {n : ℕ} (sigma : Equiv.Perm (Fin (n + 1))) :
+    StandardSimplexBoundary n ≃ₜ StandardSimplexBoundary n :=
+  (stdSimplexPermHomeomorph sigma).subtype
+    (p := fun w : stdSimplex ℝ (Fin (n + 1)) ↦ ∃ i, w i = 0)
+    (q := fun w : stdSimplex ℝ (Fin (n + 1)) ↦ ∃ i, w i = 0)
+    (fun w ↦ by
+      constructor
+      · rintro ⟨i, hi⟩
+        refine ⟨sigma i, ?_⟩
+        change stdSimplex.map sigma w (sigma i) = 0
+        rw [stdSimplex_map_equiv_apply, sigma.symm_apply_apply]
+        exact hi
+      · rintro ⟨j, hj⟩
+        refine ⟨sigma.symm j, ?_⟩
+        change stdSimplex.map sigma w j = 0 at hj
+        rw [stdSimplex_map_equiv_apply] at hj
+        exact hj)
+
+/-- The eight-cycle `(0 1 ... 7)` acting on the ordinary boundary of the seven-simplex. -/
+public noncomputable def boundarySevenCyclicHomeomorph :
+    StandardSimplexBoundary 7 ≃ₜ StandardSimplexBoundary 7 :=
+  standardSimplexBoundaryPermHomeomorph (finRotate 8)
+
+/-- The cyclic boundary map, transported to the project's standard six-sphere. -/
+public noncomputable def cyclicBoundarySphereHomeomorph : SixSphere ≃ₜ SixSphere :=
+  standardSimplexBoundarySevenHomeomorphSixSphere.symm.trans
+    (boundarySevenCyclicHomeomorph.trans
+      standardSimplexBoundarySevenHomeomorphSixSphere)
+
+/-- The transported cyclic boundary homeomorphism as a bundled continuous map. -/
+public noncomputable def cyclicBoundarySphereMap : C(SixSphere, SixSphere) :=
+  ⟨cyclicBoundarySphereHomeomorph, cyclicBoundarySphereHomeomorph.continuous⟩
+
+/-- The eight-cycle has sign `-1`. -/
+public theorem boundarySevenCyclicPermutation_sign :
+    Equiv.Perm.sign (finRotate 8) = -1 := by
+  rw [sign_finRotate]
+  change ((-1 : ℤˣ) ^ 7) = -1
+  simp [pow_succ]
+
+/-- The orientation-free formulation of the missing antipodal calculation. -/
+public def SixSphereAntipodalActsByNegation : Prop :=
+  sixSphereTopIntegralHomologyMap
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun =
+    -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere)
+
+/-- Negation on top homology gives degree `-1` for every choice of generator. -/
+public theorem sixSphere_antipodalDegree_of_actsByNegation
+    (h : SixSphereAntipodalActsByNegation)
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1 := by
+  rw [sixSphereHomologicalDegree, h]
+  change orientation (-orientation.symm 1) = -1
+  rw [orientation.map_neg, orientation.apply_symm_apply]
+
+/-- Conversely, degree `-1` for one orientation forces the induced endomorphism itself to be
+negation.  Thus the antipodal input is independent of all choices of generator. -/
+public theorem sixSphere_antipodalActsByNegation_of_degree
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (hdegree : sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1) :
+    SixSphereAntipodalActsByNegation := by
+  let H := IntegralSingularHomology 6 SixSphere
+  let fH : H →+ H := sixSphereTopIntegralHomologyMap
+    OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun
+  let fZ : ℤ →+ ℤ := orientation.toAddMonoidHom.comp
+    (fH.comp orientation.symm.toAddMonoidHom)
+  have hf (z : ℤ) : orientation (fH (orientation.symm z)) = -z := by
+    change fZ z = -z
+    rw [intAddHom_apply_eq_mul_apply_one]
+    change z * sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -z
+    rw [hdegree]
+    simp
+  unfold SixSphereAntipodalActsByNegation
+  apply AddMonoidHom.ext
+  intro x
+  apply orientation.injective
+  have hx := hf (orientation x)
+  rw [orientation.symm_apply_apply] at hx
+  simpa using hx
+
+/-- The analytic antipodal map has degree `-1` for every orientation exactly when it acts by
+negation on top integral homology. -/
+public theorem sixSphere_antipodalDegree_iff_actsByNegation
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    (sixSphereHomologicalDegree orientation
+        OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1) ↔
+      SixSphereAntipodalActsByNegation := by
+  constructor
+  · intro h
+    exact sixSphere_antipodalActsByNegation_of_degree orientation h
+  · intro h
+    exact sixSphere_antipodalDegree_of_actsByNegation h orientation
+
+/-- It is enough to compute the antipodal degree using one generator: the answer `-1` is then
+forced for every other additive orientation. -/
+public theorem sixSphere_antipodalDegree_allOrientations_of_one
+    (orientation₀ : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (h₀ : sixSphereHomologicalDegree orientation₀
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1)
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1 :=
+  sixSphere_antipodalDegree_of_actsByNegation
+    (sixSphere_antipodalActsByNegation_of_degree orientation₀ h₀) orientation
+
+/-- Exact reduction through the explicit odd cyclic boundary homeomorphism.  The first input is
+the finite permutation action after comparison; the second is the geometric homotopy from the
+transported cyclic map to the analytic antipodal map. -/
+public theorem sixSphere_antipodalDegree_of_cyclicBoundaryModel
+    (hcyclic : sixSphereTopIntegralHomologyMap cyclicBoundarySphereMap =
+      -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere))
+    (hhomotopy :
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun.Homotopic
+        cyclicBoundarySphereMap)
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1 := by
+  apply sixSphere_antipodalDegree_of_actsByNegation
+  unfold SixSphereAntipodalActsByNegation
+  rw [sixSphereTopIntegralHomologyMap_eq_of_homotopic hhomotopy]
+  exact hcyclic
+
+/-- A calculation of the cyclic map on one transported generator, together with the explicit
+geometric homotopy, implies the antipodal result for every possible generator.  This is the form
+needed by `sixSphereDegreeTheory_of_boundaryComparison`. -/
+public theorem sixSphere_antipodalDegree_all_of_cyclicBoundaryDegree
+    (orientation₀ : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (hcyclic : sixSphereHomologicalDegree orientation₀
+      cyclicBoundarySphereMap = -1)
+    (hhomotopy :
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun.Homotopic
+        cyclicBoundarySphereMap)
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1 := by
+  apply sixSphere_antipodalDegree_allOrientations_of_one orientation₀
+  exact (sixSphereHomologicalDegree_eq_of_homotopic orientation₀ hhomotopy).trans hcyclic
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereAntipodalReflectionDegree.lean
+++ b/SphereSixComplex/Topology/SixSphereAntipodalReflectionDegree.lean
@@ -1,0 +1,67 @@
+module
+
+public import SphereSixComplex.Topology.SixSphereAntipodalDegree
+public import SphereSixComplex.Topology.SixSphereAntipodalReflectionHomotopy
+public import SphereSixComplex.Topology.SixSphereTopHomologyComputed
+
+/-!
+# Antipodal degree reduced to one coordinate reflection
+
+The explicit ambient rotation homotopy identifies the analytic antipodal map with reflection in
+coordinate zero.  Homotopy invariance of singular homology therefore reduces the remaining sign
+calculation to that elementary reflection, independently of any chosen top-homology generator.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+/-- The analytic antipodal map and coordinate reflection induce the same endomorphism of top
+integral homology. -/
+public theorem sixSphereTopIntegralHomologyMap_antipodal_eq_coordinateReflection :
+    sixSphereTopIntegralHomologyMap
+        OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun =
+      sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap :=
+  sixSphereTopIntegralHomologyMap_eq_of_homotopic
+    sixSphere_antipodal_homotopic_coordinateReflection
+
+/-- The orientation-free antipodal calculation is exactly the assertion that coordinate
+reflection acts by negation on top integral homology. -/
+public theorem sixSphereAntipodalActsByNegation_iff_coordinateReflection :
+    SixSphereAntipodalActsByNegation ↔
+      sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap =
+        -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere) := by
+  unfold SixSphereAntipodalActsByNegation
+  rw [sixSphereTopIntegralHomologyMap_antipodal_eq_coordinateReflection]
+
+/-- Negation for the coordinate-reflection action proves antipodal degree `-1` for any selected
+top-homology generator. -/
+public theorem sixSphere_antipodalDegree_of_coordinateReflection
+    (hreflection :
+      sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap =
+        -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere))
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1 :=
+  sixSphere_antipodalDegree_of_actsByNegation
+    (sixSphereAntipodalActsByNegation_iff_coordinateReflection.mpr hreflection)
+    orientation
+
+/-- The complete degree theory now has exactly two independent inputs: the canonical integral
+simplicial-to-singular comparison and the top-homology action of coordinate reflection. -/
+public theorem sixSphereDegreeTheory_of_comparison_coordinateReflection
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (hreflection :
+      sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap =
+        -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere)) :
+    Nonempty OrientedMarkedSmoothHomotopySixSphere.SixSphereDegreeTheory :=
+  sixSphereDegreeTheory_of_comparisonQuasiIsomorphism hcomparison
+    (sixSphere_antipodalDegree_of_coordinateReflection hreflection
+      (sixSphereTopHomologyAddEquivOfComparisonQuasiIsomorphism hcomparison))
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereAntipodalReflectionHomotopy.lean
+++ b/SphereSixComplex/Topology/SixSphereAntipodalReflectionHomotopy.lean
@@ -1,0 +1,157 @@
+module
+
+public import SphereSixComplex.Topology.OrientedSmoothHomotopySphere
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+
+/-!
+# An explicit reflection model for the six-sphere antipodal map
+
+In seven ambient coordinates, the antipodal map is homotopic through orthogonal maps to the
+reflection which negates only coordinate zero.  The other six signs are removed in three planar
+rotation blocks.  This is a concrete geometric reduction of the antipodal degree calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open ContinuousMap Set
+
+namespace SphereSixComplex
+
+/-- The ambient coordinate reflection which negates coordinate zero. -/
+public noncomputable def sixSphereCoordinateReflectionAmbient
+    (x : EuclideanSpace ℝ (Fin 7)) : EuclideanSpace ℝ (Fin 7) :=
+  WithLp.toLp 2 ![-x 0, x 1, x 2, x 3, x 4, x 5, x 6]
+
+/-- Simultaneously rotate the coordinate planes `(1,2)`, `(3,4)`, and `(5,6)`, while negating
+coordinate zero.  At angle `π` this is the antipodal map; at angle zero it is coordinate
+reflection. -/
+public noncomputable def sixSphereAntipodalReflectionRotationAmbient
+    (t : unitInterval) (x : EuclideanSpace ℝ (Fin 7)) :
+    EuclideanSpace ℝ (Fin 7) := by
+  let θ : ℝ := Real.pi * (1 - (t : ℝ))
+  exact WithLp.toLp 2 ![
+    -x 0,
+    Real.cos θ * x 1 - Real.sin θ * x 2,
+    Real.sin θ * x 1 + Real.cos θ * x 2,
+    Real.cos θ * x 3 - Real.sin θ * x 4,
+    Real.sin θ * x 3 + Real.cos θ * x 4,
+    Real.cos θ * x 5 - Real.sin θ * x 6,
+    Real.sin θ * x 5 + Real.cos θ * x 6]
+
+public theorem sixSphereAntipodalReflectionRotationAmbient_norm
+    (t : unitInterval) (x : EuclideanSpace ℝ (Fin 7)) :
+    ‖sixSphereAntipodalReflectionRotationAmbient t x‖ = ‖x‖ := by
+  rw [← sq_eq_sq₀ (norm_nonneg _) (norm_nonneg _),
+    EuclideanSpace.real_norm_sq_eq, EuclideanSpace.real_norm_sq_eq]
+  simp only [Fin.sum_univ_succ]
+  simp [sixSphereAntipodalReflectionRotationAmbient]
+  ring_nf
+  nlinarith [Real.sin_sq_add_cos_sq (Real.pi - Real.pi * (t : ℝ))]
+
+@[simp]
+public theorem sixSphereAntipodalReflectionRotationAmbient_zero
+    (x : EuclideanSpace ℝ (Fin 7)) :
+    sixSphereAntipodalReflectionRotationAmbient 0 x = -x := by
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [sixSphereAntipodalReflectionRotationAmbient]
+
+@[simp]
+public theorem sixSphereAntipodalReflectionRotationAmbient_one
+    (x : EuclideanSpace ℝ (Fin 7)) :
+    sixSphereAntipodalReflectionRotationAmbient 1 x =
+      sixSphereCoordinateReflectionAmbient x := by
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [sixSphereAntipodalReflectionRotationAmbient,
+    sixSphereCoordinateReflectionAmbient]
+
+public theorem continuous_sixSphereAntipodalReflectionRotationAmbient :
+    Continuous (fun p : unitInterval × EuclideanSpace ℝ (Fin 7) ↦
+      sixSphereAntipodalReflectionRotationAmbient p.1 p.2) := by
+  rw [← (EuclideanSpace.equiv (Fin 7) ℝ).toHomeomorph.comp_continuous_iff]
+  apply continuous_pi
+  intro i
+  fin_cases i <;> simp [sixSphereAntipodalReflectionRotationAmbient] <;> fun_prop
+
+/-- Coordinate reflection restricted to the unit six-sphere. -/
+public noncomputable def sixSphereCoordinateReflectionMap : C(SixSphere, SixSphere) where
+  toFun x := ⟨sixSphereCoordinateReflectionAmbient x.1, by
+    rw [Metric.mem_sphere, dist_zero_right]
+    rw [← sixSphereAntipodalReflectionRotationAmbient_one,
+      sixSphereAntipodalReflectionRotationAmbient_norm]
+    simpa only [Metric.mem_sphere, dist_zero_right] using x.2⟩
+  continuous_toFun := by
+    apply Continuous.subtype_mk
+    have h : Continuous (fun x : SixSphere ↦
+        sixSphereAntipodalReflectionRotationAmbient 1 x.1) :=
+      continuous_sixSphereAntipodalReflectionRotationAmbient.comp
+        ((continuous_const : Continuous (fun _ : SixSphere ↦ (1 : unitInterval))).prodMk
+          continuous_subtype_val)
+    exact h.congr fun x ↦
+      sixSphereAntipodalReflectionRotationAmbient_one x.1
+
+@[simp]
+public theorem sixSphereCoordinateReflectionMap_apply (x : SixSphere) :
+    (sixSphereCoordinateReflectionMap x : EuclideanSpace ℝ (Fin 7)) =
+      sixSphereCoordinateReflectionAmbient x.1 :=
+  rfl
+
+public theorem sixSphereCoordinateReflectionAmbient_involutive :
+    Function.Involutive sixSphereCoordinateReflectionAmbient := by
+  intro x
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [sixSphereCoordinateReflectionAmbient]
+
+/-- Coordinate reflection is a self-homeomorphism of the unit six-sphere. -/
+public noncomputable def sixSphereCoordinateReflectionHomeomorph :
+    SixSphere ≃ₜ SixSphere where
+  toFun := sixSphereCoordinateReflectionMap
+  invFun := sixSphereCoordinateReflectionMap
+  left_inv x := by
+    apply Subtype.ext
+    exact sixSphereCoordinateReflectionAmbient_involutive x.1
+  right_inv x := by
+    apply Subtype.ext
+    exact sixSphereCoordinateReflectionAmbient_involutive x.1
+  continuous_toFun := sixSphereCoordinateReflectionMap.continuous
+  continuous_invFun := sixSphereCoordinateReflectionMap.continuous
+
+@[simp]
+public theorem sixSphereCoordinateReflectionHomeomorph_apply (x : SixSphere) :
+    sixSphereCoordinateReflectionHomeomorph x =
+      sixSphereCoordinateReflectionMap x :=
+  rfl
+
+/-- The analytic antipodal map is explicitly homotopic, through norm-preserving ambient
+rotations, to reflection in coordinate zero. -/
+public noncomputable def sixSphereAntipodalHomotopyToCoordinateReflection :
+    ContinuousMap.Homotopy
+      OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun
+      sixSphereCoordinateReflectionMap where
+  toFun p := ⟨sixSphereAntipodalReflectionRotationAmbient p.1 p.2.1, by
+    rw [Metric.mem_sphere, dist_zero_right]
+    rw [sixSphereAntipodalReflectionRotationAmbient_norm]
+    simpa only [Metric.mem_sphere, dist_zero_right] using p.2.2⟩
+  continuous_toFun := by
+    apply Continuous.subtype_mk
+    exact continuous_sixSphereAntipodalReflectionRotationAmbient.comp
+      (continuous_fst.prodMk (continuous_subtype_val.comp continuous_snd))
+  map_zero_left x := by
+    apply Subtype.ext
+    simp
+  map_one_left x := by
+    apply Subtype.ext
+    simp
+
+/-- The corresponding proposition-level homotopy, ready for homology invariance. -/
+public theorem sixSphere_antipodal_homotopic_coordinateReflection :
+    OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun.Homotopic
+      sixSphereCoordinateReflectionMap :=
+  ⟨sixSphereAntipodalHomotopyToCoordinateReflection⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereCoordinateReflectionHomology.lean
+++ b/SphereSixComplex/Topology/SixSphereCoordinateReflectionHomology.lean
@@ -1,0 +1,219 @@
+module
+
+public import SphereSixComplex.Topology.SixSphereCoordinateReflectionLinear
+public import SphereSixComplex.Topology.SixSphereAntipodalReflectionDegree
+public import SphereSixComplex.Topology.SixSphereTopHomologyComputed
+public import Mathlib.AlgebraicTopology.SimplicialSet.Subdivision
+public import Mathlib.GroupTheory.Perm.Sign
+
+/-!
+# Coordinate reflection on top homology
+
+The barycentric subdivision of the boundary of a simplex has a permutation-equivariant model:
+the nerve of the poset of its nonempty proper vertex subsets.  This file constructs that poset
+model and its action by every permutation of the eight vertices.  In particular the transposition
+of vertices zero and one is an honest order automorphism after subdivision and has sign `-1`.
+
+Mathlib currently defines `SSet.sd`, and identifies subdivision of a representable simplex with
+the nerve of nonempty chains, but deliberately leaves as a TODO the natural comparison from
+`SSet.sd.obj X` to the nerve of the poset of nondegenerate simplices of a general `X`.  Thus it
+does not yet identify `SSet.sd.obj (boundary (Delta[7]))` with the proper-face nerve below.  The
+last theorem isolates the missing result as a uniform vertex-permutation degree formula plus an
+equivariant boundary--sphere model; it does not assume the desired coordinate-reflection sign.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Simplicial
+
+namespace SphereSixComplex
+
+/-- The vertices of the barycentric subdivision of the boundary of the seven-simplex: nonempty
+proper subsets of its eight vertices, ordered by inclusion. -/
+public abbrev BoundarySevenProperFace :=
+  {s : Finset (Fin 8) // s.Nonempty ∧ s ≠ Finset.univ}
+
+/-- A permutation of the eight original vertices sends proper faces to proper faces. -/
+public noncomputable def boundarySevenProperFacePerm
+    (sigma : Equiv.Perm (Fin 8)) (s : BoundarySevenProperFace) :
+    BoundarySevenProperFace := by
+  refine ⟨s.1.map sigma.toEmbedding, Finset.map_nonempty.mpr s.2.1, ?_⟩
+  intro hfull
+  apply s.2.2
+  apply Finset.eq_univ_iff_forall.mpr
+  intro i
+  have hi : sigma i ∈ s.1.map sigma.toEmbedding := by
+    rw [hfull]
+    exact Finset.mem_univ _
+  exact (Finset.mem_map' sigma.toEmbedding).mp hi
+
+@[simp]
+public theorem boundarySevenProperFacePerm_val
+    (sigma : Equiv.Perm (Fin 8)) (s : BoundarySevenProperFace) :
+    (boundarySevenProperFacePerm sigma s).1 = s.1.map sigma.toEmbedding :=
+  rfl
+
+@[simp]
+public theorem boundarySevenProperFacePerm_mem
+    (sigma : Equiv.Perm (Fin 8)) (s : BoundarySevenProperFace) (i : Fin 8) :
+    i ∈ (boundarySevenProperFacePerm sigma s).1 ↔ sigma.symm i ∈ s.1 := by
+  exact Finset.mem_map_equiv
+
+/-- Permuting vertices is an order automorphism of the proper-face poset. -/
+public noncomputable def boundarySevenProperFacePermOrderIso
+    (sigma : Equiv.Perm (Fin 8)) :
+    BoundarySevenProperFace ≃o BoundarySevenProperFace where
+  toFun := boundarySevenProperFacePerm sigma
+  invFun := boundarySevenProperFacePerm sigma.symm
+  left_inv s := by
+    apply Subtype.ext
+    ext i
+    simp
+  right_inv s := by
+    apply Subtype.ext
+    ext i
+    simp
+  map_rel_iff' := by
+    intro s t
+    change s.1.map sigma.toEmbedding ⊆ t.1.map sigma.toEmbedding ↔ s.1 ⊆ t.1
+    exact Finset.map_subset_map
+
+/-- The proper-face order complex, the expected barycentric subdivision model of `boundary
+(Delta[7])`. -/
+public abbrev BoundarySevenProperFaceNerve : SSet.{0} :=
+  PartOrd.nerveFunctor.obj (PartOrd.of BoundarySevenProperFace)
+
+/-- Mathlib's available representable case: subdivision of the full standard seven-simplex is
+the nerve of its nonempty finite chains. -/
+public noncomputable def standardSevenSubdivisionNerveIso :
+    SSet.sd.obj (Δ[7] : SSet.{0}) ≅
+      SimplexCategory.sd.obj (SimplexCategory.mk 7) :=
+  SSet.stdSimplex.sdIso.app (SimplexCategory.mk 7)
+
+/-- The exact boundary case not presently supplied by `SSet.sd`: subdivision of the simplicial
+boundary should be the order complex of nonempty proper faces.  The representable isomorphism
+above does not restrict automatically because Mathlib has no general subdivision-to-
+nondegenerate-simplex-poset comparison yet. -/
+public def BoundarySevenSubdivisionProperFaceNerveComparison : Prop :=
+  Nonempty (SSet.sd.obj (∂Δ[7] : SSet.{0}) ≅ BoundarySevenProperFaceNerve)
+
+/-- Every vertex permutation is an honest simplicial automorphism of the proper-face nerve. -/
+public noncomputable def boundarySevenProperFaceNervePermIso
+    (sigma : Equiv.Perm (Fin 8)) :
+    BoundarySevenProperFaceNerve ≅ BoundarySevenProperFaceNerve :=
+  PartOrd.nerveFunctor.mapIso
+    (PartOrd.Iso.mk (boundarySevenProperFacePermOrderIso sigma))
+
+/-- The transposition corresponding to an orientation-reversing simplex symmetry. -/
+public def boundarySevenReflectionPermutation : Equiv.Perm (Fin 8) :=
+  Equiv.swap 0 1
+
+/-- The reflection permutation is odd. -/
+public theorem boundarySevenReflectionPermutation_sign :
+    Equiv.Perm.sign boundarySevenReflectionPermutation = -1 := by
+  apply Equiv.Perm.sign_swap
+  decide
+
+/-- Its action on the proper-face nerve is a concrete simplicial automorphism. -/
+public noncomputable def boundarySevenProperFaceNerveReflectionIso :
+    BoundarySevenProperFaceNerve ≅ BoundarySevenProperFaceNerve :=
+  boundarySevenProperFaceNervePermIso boundarySevenReflectionPermutation
+
+/-- The affine action of a vertex permutation on the ordinary simplex boundary, conjugated by a
+chosen boundary--sphere homeomorphism. -/
+public noncomputable def boundarySevenPermutationSphereMap
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere)
+    (sigma : Equiv.Perm (Fin 8)) : C(SixSphere, SixSphere) :=
+  ⟨e.symm.trans ((standardSimplexBoundaryPermHomeomorph sigma).trans e),
+    (e.symm.trans ((standardSimplexBoundaryPermHomeomorph sigma).trans e)).continuous⟩
+
+/-- An equivariant boundary model identifies the vertex transposition with the analytic
+coordinate reflection. -/
+public def BoundarySevenReflectionEquivariant (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    Prop :=
+  ∀ x : StandardSimplexBoundary 7,
+    e (standardSimplexBoundaryPermHomeomorph
+        boundarySevenReflectionPermutation x) =
+      sixSphereCoordinateReflectionMap (e x)
+
+/-- Use the canonical realization-to-boundary homeomorphism, a specified boundary--sphere model,
+and the completed finite top-cycle orientation to transport the comparison generator to `S⁶`. -/
+public noncomputable def sixSphereTopHomologyAddEquivOfStandardBoundaryComparison
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    IntegralSingularHomology 6 SixSphere ≃+ ℤ :=
+  sixSphereTopHomologyAddEquivOfBoundaryComparison hcomparison
+    ((boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+      boundarySevenRealizationToBoundary_injective).trans e)
+    (Classical.choice boundarySevenSimplicialTopHomologyOrientation)
+
+/-- The uniform comparison theorem that barycentric subdivision is expected to supply: every
+vertex permutation acts on the transported top generator by its ordinary permutation sign.
+Unlike the desired reflection assertion, this statement is formulated for the explicit affine
+action of every permutation and records the missing equivariant simplicial--singular naturality. -/
+public def BoundarySevenVertexPermutationDegreeFormula
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) : Prop :=
+  ∀ sigma : Equiv.Perm (Fin 8),
+    sixSphereHomologicalDegree
+        (sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison e)
+        (boundarySevenPermutationSphereMap e sigma) =
+      ((Equiv.Perm.sign sigma : ℤˣ) : ℤ)
+
+/-- On an infinite-cyclic top homology group, degree `-1` for any self-map forces its induced
+endomorphism to be literal negation. -/
+public theorem sixSphereTopIntegralHomologyMap_eq_neg_of_degree_eq_neg_one
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (f : C(SixSphere, SixSphere))
+    (hdegree : sixSphereHomologicalDegree orientation f = -1) :
+    sixSphereTopIntegralHomologyMap f =
+      -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere) := by
+  let H := IntegralSingularHomology 6 SixSphere
+  let fH : H →+ H := sixSphereTopIntegralHomologyMap f
+  let fZ : ℤ →+ ℤ := orientation.toAddMonoidHom.comp
+    (fH.comp orientation.symm.toAddMonoidHom)
+  have hf (z : ℤ) : orientation (fH (orientation.symm z)) = -z := by
+    change fZ z = -z
+    rw [intAddHom_apply_eq_mul_apply_one]
+    change z * sixSphereHomologicalDegree orientation f = -z
+    rw [hdegree]
+    simp
+  apply AddMonoidHom.ext
+  intro x
+  apply orientation.injective
+  have hx := hf (orientation x)
+  rw [orientation.symm_apply_apply] at hx
+  simpa using hx
+
+/-- The strongest current reduction.  The canonical integral comparison may be supplied as an
+explicit hypothesis.  A permutation-equivariant subdivision comparison and an equivariant
+boundary model then force coordinate reflection to induce `-id` on `H₆`; no reflection sign is
+assumed. -/
+public theorem sixSphereCoordinateReflection_homology_of_boundarySubdivision
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere)
+    (hequivariant : BoundarySevenReflectionEquivariant e)
+    (hpermutations : BoundarySevenVertexPermutationDegreeFormula hcomparison e) :
+    sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap =
+      -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere) := by
+  let orientation :=
+    sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison e
+  have hreflectionMap : boundarySevenPermutationSphereMap e
+      boundarySevenReflectionPermutation = sixSphereCoordinateReflectionMap := by
+    apply ContinuousMap.ext
+    intro x
+    change e (standardSimplexBoundaryPermHomeomorph
+      boundarySevenReflectionPermutation (e.symm x)) = _
+    rw [hequivariant (e.symm x), e.apply_symm_apply]
+  apply sixSphereTopIntegralHomologyMap_eq_neg_of_degree_eq_neg_one orientation
+  rw [← hreflectionMap]
+  rw [hpermutations boundarySevenReflectionPermutation,
+    boundarySevenReflectionPermutation_sign]
+  rfl
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereCoordinateReflectionLinear.lean
+++ b/SphereSixComplex/Topology/SixSphereCoordinateReflectionLinear.lean
@@ -1,0 +1,77 @@
+module
+
+public import SphereSixComplex.Topology.SixSphereAntipodalReflectionHomotopy
+public import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
+
+/-!
+# The coordinate reflection as an orthogonal linear reflection
+
+This identifies the concrete reflection used in the antipodal homotopy with reflection in the
+codimension-one coordinate hyperplane and computes its ambient determinant.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Module Submodule
+
+namespace SphereSixComplex
+
+/-- The first standard unit vector in seven-dimensional Euclidean space. -/
+public noncomputable def sixSphereFirstCoordinateVector :
+    EuclideanSpace ℝ (Fin 7) :=
+  EuclideanSpace.single 0 1
+
+/-- The hyperplane perpendicular to the first standard unit vector. -/
+public noncomputable def sixSphereCoordinateReflectionHyperplane :
+    Submodule ℝ (EuclideanSpace ℝ (Fin 7)) :=
+  (ℝ ∙ sixSphereFirstCoordinateVector)ᗮ
+
+/-- Orthogonal reflection in the first-coordinate hyperplane. -/
+public noncomputable def sixSphereCoordinateReflectionLinearIsometry :
+    EuclideanSpace ℝ (Fin 7) ≃ₗᵢ[ℝ] EuclideanSpace ℝ (Fin 7) :=
+  sixSphereCoordinateReflectionHyperplane.reflection
+
+public theorem sixSphereFirstCoordinateVector_norm :
+    ‖sixSphereFirstCoordinateVector‖ = 1 := by
+  simp [sixSphereFirstCoordinateVector]
+
+public theorem sixSphereFirstCoordinateVector_ne_zero :
+    sixSphereFirstCoordinateVector ≠ 0 := by
+  intro h
+  have := congrArg (fun x : EuclideanSpace ℝ (Fin 7) ↦ x 0) h
+  simpa [sixSphereFirstCoordinateVector] using this
+
+/-- The abstract orthogonal reflection agrees coordinatewise with the concrete map. -/
+public theorem sixSphereCoordinateReflectionLinearIsometry_apply
+    (x : EuclideanSpace ℝ (Fin 7)) :
+    sixSphereCoordinateReflectionLinearIsometry x =
+      sixSphereCoordinateReflectionAmbient x := by
+  change ((ℝ ∙ sixSphereFirstCoordinateVector)ᗮ).reflection x =
+    sixSphereCoordinateReflectionAmbient x
+  rw [Submodule.reflection_orthogonal_apply,
+    Submodule.reflection_singleton_apply,
+    sixSphereFirstCoordinateVector_norm]
+  apply (EuclideanSpace.equiv (Fin 7) ℝ).injective
+  funext i
+  fin_cases i <;> simp [sixSphereFirstCoordinateVector,
+    sixSphereCoordinateReflectionAmbient, EuclideanSpace.inner_single_left] <;> ring
+
+/-- The ambient linear reflection has determinant `-1`. -/
+public theorem sixSphereCoordinateReflectionLinearIsometry_det :
+    sixSphereCoordinateReflectionLinearIsometry.toLinearEquiv.det = -1 := by
+  rw [sixSphereCoordinateReflectionLinearIsometry,
+    Submodule.linearEquiv_det_reflection]
+  have hclosure : (ℝ ∙ sixSphereFirstCoordinateVector :
+      Submodule ℝ (EuclideanSpace ℝ (Fin 7))).topologicalClosure =
+        ℝ ∙ sixSphereFirstCoordinateVector := by
+    exact (ℝ ∙ sixSphereFirstCoordinateVector :
+      Submodule ℝ (EuclideanSpace ℝ (Fin 7))).closed_of_finiteDimensional
+        |>.submodule_topologicalClosure_eq
+  rw [sixSphereCoordinateReflectionHyperplane,
+    Submodule.orthogonal_orthogonal_eq_closure, hclosure,
+    finrank_span_singleton sixSphereFirstCoordinateVector_ne_zero]
+  norm_num
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereTopHomologyComputed.lean
+++ b/SphereSixComplex/Topology/SixSphereTopHomologyComputed.lean
@@ -1,0 +1,55 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenRealizationInjective
+public import SphereSixComplex.Topology.SimplicialSixSphereTopHomologyKernel
+
+/-!
+# The standard six-sphere's top-homology orientation
+
+The finite normalized-chain calculation and the explicit realization homeomorphism are now
+complete.  This file combines them with the sole remaining comparison input, producing a
+specific additive orientation of singular top homology.  The degree-theory endpoint then exposes
+only the sign of the analytic antipodal map.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory Simplicial
+
+namespace SphereSixComplex
+
+/-- Once the integral simplicial-to-singular comparison is a quasi-isomorphism, the completed
+finite calculation and realization homeomorphism give a specific additive orientation of
+`H₆(S⁶;ℤ)`. -/
+public noncomputable def sixSphereTopHomologyAddEquivOfComparisonQuasiIsomorphism
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) :
+    IntegralSingularHomology 6 SixSphere ≃+ ℤ := by
+  let e := Classical.choice boundarySevenRealizationHomeomorphSixSphere
+  let orientation := Classical.choice boundarySevenSimplicialTopHomologyOrientation
+  exact sixSphereTopHomologyAddEquivOfBoundaryComparison hcomparison e orientation
+
+/-- The comparison quasi-isomorphism is therefore the only remaining input for the existence of
+an additive top-homology orientation. -/
+public theorem sixSphereTopHomologyOrientation_of_comparisonQuasiIsomorphism
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) :
+    Nonempty (IntegralSingularHomology 6 SixSphere ≃+ ℤ) :=
+  ⟨sixSphereTopHomologyAddEquivOfComparisonQuasiIsomorphism hcomparison⟩
+
+/-- For the now-explicitly selected top-homology orientation, the antipodal sign is the sole
+remaining field needed for the complete degree theory used by oriented markings. -/
+public theorem sixSphereDegreeTheory_of_comparisonQuasiIsomorphism
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (hantipodal : sixSphereHomologicalDegree
+        (sixSphereTopHomologyAddEquivOfComparisonQuasiIsomorphism hcomparison)
+        OrientedMarkedSmoothHomotopySixSphere.antipodalMarking.toFun = -1) :
+    Nonempty OrientedMarkedSmoothHomotopySixSphere.SixSphereDegreeTheory :=
+  ⟨SixSphereTopHomologyOrientation.toDegreeTheory
+    ⟨sixSphereTopHomologyAddEquivOfComparisonQuasiIsomorphism hcomparison,
+      hantipodal⟩⟩
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- transport the computed top-homology orientation through the canonical comparison
- homotope the analytic antipodal map to coordinate reflection
- identify coordinate reflection with an orthogonal linear reflection of determinant minus one
- construct an explicit reflection-equivariant homeomorphism from the boundary of the seven-simplex to S6

This is PR 2 of 7 in the boundary-seven degree-transport stack, stacked on #66.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenReflectionEquivariantModel
- Build completed successfully: 3061 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- endpoint axiom audit: only propext, Classical.choice, and Quot.sound