### PR TITLE
Compare the boundary generator under subdivision

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenReflectionDegreeFromSubdivision.lean
+++ b/SphereSixComplex/Topology/BoundarySevenReflectionDegreeFromSubdivision.lean
@@ -1,0 +1,407 @@
+module
+
+public import SphereSixComplex.Topology.SubdivisionVertexPermutationFundamentalChain
+public import SphereSixComplex.Topology.BoundarySevenReflectionEquivariantModel
+
+/-!
+# The reflection sign on the subdivided boundary fundamental chain
+
+The boundary of the signed maximal-flag fundamental chain of the subdivided seven-simplex is
+an explicit degree-six cycle supported on its proper faces.  This file proves, without any
+topological comparison assumption, that reindexing the eight vertices acts on that boundary
+chain by the ordinary permutation sign.  In particular the transposition of vertices zero and
+one negates it.
+
+The final definitions isolate only the remaining transport statement: that this explicit
+subdivided boundary cycle represents the already selected generator used by the canonical
+simplicial-to-singular comparison.  Once that naturality statement is supplied, the equivariant
+radial homeomorphism turns the chain calculation into degree `-1` and literal negation on
+`H₆(S⁶; ℤ)`.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- The explicit boundary fundamental chain in the nonempty-face nerve model of the
+barycentrically subdivided seven-simplex. -/
+public noncomputable def subdividedSevenBoundaryFundamentalChain :
+    AddCommGrpCat.of ℤ ⟶
+      ((SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7)).chainComplex
+        (AddCommGrpCat.of ℤ)).X 6 :=
+  subdividedSimplexFundamentalChain 7 ≫
+    ((SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7)).chainComplex
+      (AddCommGrpCat.of ℤ)).d 7 6
+
+/-- Every vertex permutation acts on the explicit subdivided boundary fundamental chain by its
+ordinary sign.  This is the boundary restriction of the top-dimensional maximal-flag formula. -/
+public theorem subdividedSevenBoundaryFundamentalChain_vertexPerm
+    (sigma : Equiv.Perm (Fin 8)) :
+    subdividedSevenBoundaryFundamentalChain ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+          (AddCommGrpCat.of ℤ)).f 6 =
+      permutationSignInteger sigma • subdividedSevenBoundaryFundamentalChain := by
+  let F := SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+    (AddCommGrpCat.of ℤ)
+  change (subdividedSimplexFundamentalChain 7 ≫ _) ≫ F.f 6 = _
+  rw [Category.assoc]
+  rw [← F.comm 7 6]
+  rw [← Category.assoc, subdividedSimplexFundamentalChain_vertexPerm]
+  simp only [Preadditive.zsmul_comp]
+  rfl
+
+/-- The vertex transposition `(0 1)` negates the explicit subdivided boundary fundamental
+chain. -/
+public theorem subdividedSevenBoundaryFundamentalChain_reflection :
+    subdividedSevenBoundaryFundamentalChain ≫
+        (SSet.chainComplexMap
+          (simplexSubdivisionVertexPermMap boundarySevenReflectionPermutation)
+          (AddCommGrpCat.of ℤ)).f 6 =
+      -subdividedSevenBoundaryFundamentalChain := by
+  rw [subdividedSevenBoundaryFundamentalChain_vertexPerm,
+    permutationSignInteger, boundarySevenReflectionPermutation_sign]
+  norm_num
+
+/-- The explicit boundary fundamental chain is a cycle. -/
+public theorem subdividedSevenBoundaryFundamentalChain_isCycle :
+    subdividedSevenBoundaryFundamentalChain ≫
+        ((SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7)).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 = 0 := by
+  change (subdividedSimplexFundamentalChain 7 ≫ _) ≫ _ = 0
+  rw [Category.assoc]
+  simp
+
+/-- The boundary chain is exactly the alternating sum of the subdivided codimension-one faces.
+In particular this identifies the chain-level restriction to the proper faces of the
+seven-simplex, without appealing to a general subdivision-of-a-subcomplex theorem. -/
+public theorem subdividedSevenBoundaryFundamentalChain_eq_alternatingProperFaces :
+    subdividedSevenBoundaryFundamentalChain =
+      subdividedSimplexAlternatingFaceChain 6 := by
+  exact barycentricFundamentalBoundaryIdentity 6
+
+/-- Regard a nonempty subset of the vertices of a facet as a proper face of the ambient
+seven-simplex. -/
+public noncomputable def subdividedFacetToBoundarySevenProperFace
+    (p : Fin 8)
+    (s : NonemptyFiniteChains (ULift.{0} (Fin 7))) :
+    BoundarySevenProperFace := by
+  let t : Finset (Fin 8) :=
+    s.finset.image (fun i ↦ p.succAbove i.down)
+  refine ⟨t, Finset.image_nonempty.mpr s.nonempty, ?_⟩
+  intro ht
+  have hp : p ∈ t := by rw [ht]; simp
+  obtain ⟨i, -, hi⟩ := Finset.mem_image.mp hp
+  exact (Fin.succAbove_ne p i.down) hi
+
+@[simp]
+public theorem subdividedFacetToBoundarySevenProperFace_val
+    (p : Fin 8)
+    (s : NonemptyFiniteChains (ULift.{0} (Fin 7))) :
+    (subdividedFacetToBoundarySevenProperFace p s).1 =
+      s.finset.image (fun i ↦ p.succAbove i.down) :=
+  rfl
+
+/-- The monotone facet-to-proper-face map underlying the subdivision restriction. -/
+public noncomputable def subdividedFacetToBoundarySevenProperFaceHom
+    (p : Fin 8) :
+    PartOrd.of (NonemptyFiniteChains (ULift.{0} (Fin 7))) ⟶
+      PartOrd.of BoundarySevenProperFace :=
+  PartOrd.ofHom
+    { toFun := subdividedFacetToBoundarySevenProperFace p
+      monotone' := by
+        intro s t hst
+        change s.finset.image (fun i ↦ p.succAbove i.down) ⊆
+          t.finset.image (fun i ↦ p.succAbove i.down)
+        exact Finset.image_mono _ hst }
+
+/-- Include the proper-face poset into the full nonempty-face poset. -/
+public noncomputable def boundarySevenProperFaceToNonemptyFiniteChain
+    (s : BoundarySevenProperFace) :
+    NonemptyFiniteChains (ULift.{0} (Fin 8)) where
+  finset := s.1.image ULift.up
+  nonempty := Finset.image_nonempty.mpr s.2.1
+  comparable := fun _ _ ↦ le_total _ _
+
+/-- The monotone inclusion of proper faces into all nonempty faces. -/
+public noncomputable def boundarySevenProperFaceInclusionHom :
+    PartOrd.of BoundarySevenProperFace ⟶
+      PartOrd.of (NonemptyFiniteChains (ULift.{0} (Fin 8))) :=
+  PartOrd.ofHom
+    { toFun := boundarySevenProperFaceToNonemptyFiniteChain
+      monotone' := by
+        intro s t hst
+        change s.1.image ULift.up ⊆ t.1.image ULift.up
+        exact Finset.image_mono _ hst }
+
+/-- A subdivided facet maps into the proper-face nerve. -/
+public noncomputable def subdividedFacetToBoundarySevenProperFaceNerveMap
+    (p : Fin 8) :
+    SimplexCategory.sd.{0}.obj (SimplexCategory.mk 6) ⟶
+      BoundarySevenProperFaceNerve :=
+  PartOrd.nerveFunctor.map (subdividedFacetToBoundarySevenProperFaceHom p)
+
+/-- The simplicial inclusion of the proper-face nerve into the full subdivision nerve. -/
+public noncomputable def boundarySevenProperFaceNerveInclusion :
+    BoundarySevenProperFaceNerve ⟶
+      SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7) :=
+  PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom
+
+/-- Reindexing proper faces and then including them agrees with first including them and then
+reindexing all nonempty faces. -/
+public theorem boundarySevenProperFacePerm_comp_inclusionHom
+    (sigma : Equiv.Perm (Fin 8)) :
+    (PartOrd.Iso.mk (boundarySevenProperFacePermOrderIso sigma)).hom ≫
+        boundarySevenProperFaceInclusionHom =
+      boundarySevenProperFaceInclusionHom ≫
+        (PartOrd.Iso.mk
+          (nonemptyFiniteChainsVertexPermOrderIso sigma)).hom := by
+  apply PartOrd.ext
+  intro s
+  apply NonemptyFiniteChains.ext
+  ext i
+  rcases i with ⟨i⟩
+  simp [boundarySevenProperFaceInclusionHom,
+    boundarySevenProperFaceToNonemptyFiniteChain,
+    boundarySevenProperFacePermOrderIso,
+    boundarySevenProperFacePerm,
+    nonemptyFiniteChainsVertexPermOrderIso,
+    nonemptyFiniteChainsVertexPerm]
+  constructor
+  · intro hi
+    exact ⟨sigma.symm i, hi, sigma.apply_symm_apply i⟩
+  · rintro ⟨a, ha, hai⟩
+    have haeq : a = sigma.symm i := by
+      apply sigma.injective
+      simpa using hai
+    simpa [haeq] using ha
+
+/-- The proper-face nerve inclusion is equivariant for every vertex permutation. -/
+public theorem boundarySevenProperFaceNerveInclusion_equivariant
+    (sigma : Equiv.Perm (Fin 8)) :
+    (boundarySevenProperFaceNervePermIso sigma).hom ≫
+        boundarySevenProperFaceNerveInclusion =
+      boundarySevenProperFaceNerveInclusion ≫
+        simplexSubdivisionVertexPermMap sigma := by
+  change
+    PartOrd.nerveFunctor.map
+        (PartOrd.Iso.mk (boundarySevenProperFacePermOrderIso sigma)).hom ≫
+      PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom =
+    PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom ≫
+      PartOrd.nerveFunctor.map
+        (PartOrd.Iso.mk
+          (nonemptyFiniteChainsVertexPermOrderIso sigma)).hom
+  rw [← Functor.map_comp, ← Functor.map_comp,
+    boundarySevenProperFacePerm_comp_inclusionHom]
+
+/-- Facet inclusion followed by the proper-face inclusion is the usual subdivision of the
+monotone face map. -/
+public theorem subdividedFacetToBoundarySevenProperFaceNerveMap_comp_inclusion
+    (p : Fin 8) :
+    subdividedFacetToBoundarySevenProperFaceNerveMap p ≫
+        boundarySevenProperFaceNerveInclusion =
+      SimplexCategory.sd.{0}.map (SimplexCategory.δ p) := by
+  change PartOrd.nerveFunctor.map (subdividedFacetToBoundarySevenProperFaceHom p) ≫
+      PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom =
+    PartOrd.nerveFunctor.map
+      (PartOrd.nonemptyFiniteChainsFunctor.map
+        (SimplexCategory.toPartOrd.map (SimplexCategory.δ p)))
+  rw [← Functor.map_comp]
+  apply congrArg PartOrd.nerveFunctor.map
+  apply PartOrd.ext
+  intro s
+  have hface (j : ULift.{0} (Fin 7)) :
+      (SimplexCategory.toPartOrd.map (SimplexCategory.δ p)).hom j =
+        ULift.up (p.succAbove j.down) := by
+    rcases j with ⟨j⟩
+    rfl
+  apply NonemptyFiniteChains.ext
+  ext i
+  rcases i with ⟨i⟩
+  simp [subdividedFacetToBoundarySevenProperFaceHom,
+    boundarySevenProperFaceInclusionHom,
+    boundarySevenProperFaceToNonemptyFiniteChain,
+    subdividedFacetToBoundarySevenProperFace,
+    PartOrd.nonemptyFiniteChainsFunctor,
+    NonemptyFiniteChains.map]
+  constructor
+  · rintro ⟨x, hx, hxi⟩
+    refine ⟨x, hx, ?_⟩
+    subst i
+    rfl
+  · rintro ⟨x, hx, hxi⟩
+    refine ⟨x, hx, ?_⟩
+    exact congrArg ULift.down hxi
+
+/-- The boundary fundamental chain written intrinsically in the proper-face nerve. -/
+public noncomputable def boundarySevenProperFaceFundamentalChain :
+    AddCommGrpCat.of ℤ ⟶
+      (BoundarySevenProperFaceNerve.chainComplex (AddCommGrpCat.of ℤ)).X 6 :=
+  ∑ p : Fin 8, (-1 : ℤ) ^ p.val •
+    (subdividedSimplexFundamentalChain 6 ≫
+      (SSet.chainComplexMap
+        (subdividedFacetToBoundarySevenProperFaceNerveMap p)
+        (AddCommGrpCat.of ℤ)).f 6)
+
+/-- Inclusion of the intrinsic proper-face fundamental chain is the explicit boundary of the
+subdivided seven-simplex. -/
+public theorem boundarySevenProperFaceFundamentalChain_comp_inclusion :
+    boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 =
+      subdividedSevenBoundaryFundamentalChain := by
+  rw [subdividedSevenBoundaryFundamentalChain_eq_alternatingProperFaces,
+    boundarySevenProperFaceFundamentalChain,
+    subdividedSimplexAlternatingFaceChain, Preadditive.sum_comp]
+  apply Finset.sum_congr rfl
+  intro p hp
+  simp only [Preadditive.zsmul_comp, Category.assoc]
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  have hmap := F.congr_map
+    (subdividedFacetToBoundarySevenProperFaceNerveMap_comp_inclusion p)
+  rw [Functor.map_comp] at hmap
+  have hn := congrArg (fun k ↦ k.f 6) hmap
+  change
+    (SSet.chainComplexMap (subdividedFacetToBoundarySevenProperFaceNerveMap p)
+      (AddCommGrpCat.of ℤ)).f 6 ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 =
+      (SSet.chainComplexMap (SimplexCategory.sd.map (SimplexCategory.δ p))
+        (AddCommGrpCat.of ℤ)).f 6 at hn
+  rw [hn]
+
+/-- The intrinsic proper-face fundamental chain has the expected permutation action after the
+literal proper-face inclusion.  Thus no support or face-restriction compatibility remains in
+the degree calculation. -/
+public theorem boundarySevenProperFaceFundamentalChain_vertexPerm_after_inclusion
+    (sigma : Equiv.Perm (Fin 8)) :
+    (boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap (boundarySevenProperFaceNervePermIso sigma).hom
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 =
+      (permutationSignInteger sigma •
+        boundarySevenProperFaceFundamentalChain) ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  have hmap := F.congr_map
+    (boundarySevenProperFaceNerveInclusion_equivariant sigma)
+  rw [Functor.map_comp, Functor.map_comp] at hmap
+  have hn := congrArg (fun k ↦ k.f 6) hmap
+  change
+    (SSet.chainComplexMap (boundarySevenProperFaceNervePermIso sigma).hom
+      (AddCommGrpCat.of ℤ)).f 6 ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 =
+      (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+        (AddCommGrpCat.of ℤ)).f 6 ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+          (AddCommGrpCat.of ℤ)).f 6 at hn
+  calc
+    _ = (boundarySevenProperFaceFundamentalChain ≫
+          (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+            (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+          (AddCommGrpCat.of ℤ)).f 6 := by
+      simp only [Category.assoc]
+      rw [hn]
+    _ = subdividedSevenBoundaryFundamentalChain ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+          (AddCommGrpCat.of ℤ)).f 6 := by
+      rw [boundarySevenProperFaceFundamentalChain_comp_inclusion]
+    _ = permutationSignInteger sigma •
+        subdividedSevenBoundaryFundamentalChain :=
+      subdividedSevenBoundaryFundamentalChain_vertexPerm sigma
+    _ = _ := by
+      rw [Preadditive.zsmul_comp,
+        boundarySevenProperFaceFundamentalChain_comp_inclusion]
+
+/-- For the reflection, the intrinsic proper-face fundamental chain is negated after inclusion
+in the full subdivision nerve. -/
+public theorem boundarySevenProperFaceFundamentalChain_reflection_after_inclusion :
+    (boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveReflectionIso.hom
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 =
+      (-boundarySevenProperFaceFundamentalChain) ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 := by
+  simpa [boundarySevenProperFaceNerveReflectionIso, permutationSignInteger,
+    boundarySevenReflectionPermutation_sign] using
+    boundarySevenProperFaceFundamentalChain_vertexPerm_after_inclusion
+      boundarySevenReflectionPermutation
+
+/-- Exact remaining bridge from the unconditional subdivision calculation to the degree
+formula used by the project.  It asks only that the chosen comparison orientation transport the
+explicit signed subdivided boundary generator with the permutation action computed above. -/
+public def BoundarySevenSubdivisionGeneratorDegreeTransport
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) : Prop :=
+  ∀ (sigma : Equiv.Perm (Fin 8)) (z : ℤ),
+    subdividedSevenBoundaryFundamentalChain ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+          (AddCommGrpCat.of ℤ)).f 6 =
+      z • subdividedSevenBoundaryFundamentalChain →
+    sixSphereHomologicalDegree
+        (sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison e)
+        (boundarySevenPermutationSphereMap e sigma) = z
+
+/-- The subdivision-generator transport statement is exactly strong enough to discharge the
+uniform vertex-permutation degree formula; the sign conversion is purely algebraic. -/
+public theorem boundarySevenVertexPermutationDegreeFormula_of_subdivisionGeneratorTransport
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere)
+    (htransport : BoundarySevenSubdivisionGeneratorDegreeTransport hcomparison e) :
+    BoundarySevenVertexPermutationDegreeFormula hcomparison e := by
+  intro sigma
+  rw [htransport sigma (permutationSignInteger sigma)
+    (subdividedSevenBoundaryFundamentalChain_vertexPerm sigma)]
+  rfl
+
+/-- For the explicit reflection-equivariant radial model, the remaining generator-transport
+statement implies that coordinate reflection has homological degree `-1`. -/
+public theorem sixSphereCoordinateReflection_degree_neg_one_of_subdivisionGeneratorTransport
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (htransport : BoundarySevenSubdivisionGeneratorDegreeTransport hcomparison
+      boundarySevenReflectionEquivariantHomeomorph) :
+    sixSphereHomologicalDegree
+        (sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison
+          boundarySevenReflectionEquivariantHomeomorph)
+        sixSphereCoordinateReflectionMap = -1 := by
+  let e := boundarySevenReflectionEquivariantHomeomorph
+  have hreflectionMap : boundarySevenPermutationSphereMap e
+      boundarySevenReflectionPermutation = sixSphereCoordinateReflectionMap := by
+    apply ContinuousMap.ext
+    intro x
+    change e (standardSimplexBoundaryPermHomeomorph
+      boundarySevenReflectionPermutation (e.symm x)) = _
+    rw [boundarySevenReflectionEquivariantHomeomorph_equivariant (e.symm x),
+      e.apply_symm_apply]
+  rw [← hreflectionMap]
+  exact htransport boundarySevenReflectionPermutation (-1)
+    (by simpa using subdividedSevenBoundaryFundamentalChain_reflection)
+
+/-- Consequently, the same exact transport statement makes coordinate reflection literal
+negation on top integral homology. -/
+public theorem sixSphereCoordinateReflection_homology_negation_of_subdivisionGeneratorTransport
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (htransport : BoundarySevenSubdivisionGeneratorDegreeTransport hcomparison
+      boundarySevenReflectionEquivariantHomeomorph) :
+    sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap =
+      -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere) := by
+  apply sixSphereTopIntegralHomologyMap_eq_neg_of_degree_eq_neg_one
+    (sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison
+      boundarySevenReflectionEquivariantHomeomorph)
+  exact sixSphereCoordinateReflection_degree_neg_one_of_subdivisionGeneratorTransport
+    hcomparison htransport
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenSubdivisionGeneratorComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenSubdivisionGeneratorComparison.lean
@@ -1,0 +1,213 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenReflectionDegreeFromSubdivision
+public import SphereSixComplex.Topology.SimplicialSixSphereTopHomologyKernel
+public import SphereSixComplex.Topology.SingularSubdivisionIteration
+public import SphereSixComplex.Topology.SimplicialSingularComparison
+
+/-!
+# The boundary-seven generator and barycentric subdivision
+
+This file records the algebraic part of the comparison between the generator used in the
+normalized-chain computation of `H₆(∂Δ[7]; ℤ)` and the explicit maximal-flag chain in the
+barycentric subdivision.  No geometric proper-face realization is used here.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The chain represented by the unique top simplex of the standard seven-simplex. -/
+public noncomputable def standardSevenTopSimplexChain :
+    AddCommGrpCat.of ℤ ⟶
+      ((Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).X 7 :=
+  (Δ[7] : SSet.{0}).ιChainComplex (standardSimplexTopSimplex 7)
+
+/-- Its ordinary simplicial boundary.  This is the unnormalized representative of the
+generator from which `standardSevenTopCyclesIsoInt`, and hence the boundary orientation, is
+constructed. -/
+public noncomputable def standardSevenOriginalBoundaryChain :
+    AddCommGrpCat.of ℤ ⟶
+      ((Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).X 6 :=
+  standardSevenTopSimplexChain ≫
+    ((Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).d 7 6
+
+/-- The same alternating boundary, formed intrinsically in `∂Δ[7]` from its eight facet
+inclusions. -/
+public noncomputable def boundarySevenOriginalFundamentalChain :
+    AddCommGrpCat.of ℤ ⟶
+      ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).X 6 :=
+  ∑ i : Fin 8, (-1 : ℤ) ^ i.val •
+    ((Δ[6] : SSet.{0}).ιChainComplex (standardSimplexTopSimplex 6) ≫
+      (SSet.chainComplexMap (SSet.boundary.ι i)
+        (AddCommGrpCat.of ℤ)).f 6)
+
+/-- The intrinsic alternating-face chain becomes the ordinary boundary of the unique
+seven-simplex after applying the boundary inclusion. -/
+public theorem boundarySevenOriginalFundamentalChain_comp_boundaryInclusion :
+    boundarySevenOriginalFundamentalChain ≫
+        (SSet.chainComplexMap
+          ((SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι)
+          (AddCommGrpCat.of ℤ)).f 6 =
+      standardSevenOriginalBoundaryChain := by
+  rw [boundarySevenOriginalFundamentalChain, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp, Category.assoc]
+  rw [standardSevenOriginalBoundaryChain, standardSevenTopSimplexChain,
+    SSet.ιChainComplex_d]
+  apply Finset.sum_congr rfl
+  intro i hi
+  congr 1
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  have hcomp := congrArg (fun k ↦ k.f 6)
+    (F.map_comp (SSet.boundary.ι i)
+      ((SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι))
+  have hface := congrArg
+    (fun f ↦ f.app (Opposite.op (SimplexCategory.mk 6))
+      (standardSimplexTopSimplex 6))
+    (yonedaEquiv_symm_standardSimplexTopSimplex_delta 6 i)
+  calc
+    _ = (Δ[6] : SSet.{0}).ιChainComplex (standardSimplexTopSimplex 6) ≫
+        (F.map (SSet.boundary.ι i ≫
+          (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι)).f 6 := by
+      exact congrArg
+        (fun k ↦ (Δ[6] : SSet.{0}).ιChainComplex
+          (standardSimplexTopSimplex 6) ≫ k) hcomp.symm
+    _ = (Δ[6] : SSet.{0}).ιChainComplex (standardSimplexTopSimplex 6) ≫
+        (F.map (SSet.stdSimplex.δ i)).f 6 := by rw [SSet.boundary.ι_ι]
+    _ = _ := by
+      rw [SSet.ι_chainComplexMap_f]
+      congr 1
+
+/-- Canonical barycentric subdivision sends the universal top simplex to the transported
+maximal-flag fundamental chain. -/
+public theorem standardSevenTopSimplexChain_barycentricSubdivision :
+    standardSevenTopSimplexChain ≫
+        (barycentricSubdivisionChainMapCanonical (Δ[7] : SSet.{0})).f 7 =
+      subdividedStandardSimplexFundamentalChain 7 := by
+  rw [standardSevenTopSimplexChain,
+    barycentricSubdivisionChainMapCanonical_f,
+    iota_barycentricSubdivisionComponent]
+  unfold barycentricSubdivisionSimplexChain
+  have hid : SSet.yonedaEquiv.symm (standardSimplexTopSimplex 7) =
+      𝟙 (Δ[7] : SSet.{0}) := by
+    apply SSet.yonedaEquiv.injective
+    change standardSimplexTopSimplex 7 = SSet.yonedaEquiv (𝟙 (Δ[7] : SSet.{0}))
+    rfl
+  rw [hid]
+  simp
+
+/-- Subdivision carries the original boundary of the unique seven-simplex to the boundary of
+the explicit maximal-flag chain in Mathlib's left-Kan-extension model of `sd Δ[7]`. -/
+public theorem standardSevenOriginalBoundaryChain_barycentricSubdivision :
+    standardSevenOriginalBoundaryChain ≫
+        (barycentricSubdivisionChainMapCanonical (Δ[7] : SSet.{0})).f 6 =
+      subdividedSevenBoundaryFundamentalChain ≫
+        (SSet.chainComplexMap
+          (SSet.stdSimplex.sdIso.inv.app (SimplexCategory.mk 7))
+          (AddCommGrpCat.of ℤ)).f 6 := by
+  let F := barycentricSubdivisionChainMapCanonical (Δ[7] : SSet.{0})
+  let G := SSet.chainComplexMap
+    (SSet.stdSimplex.sdIso.inv.app (SimplexCategory.mk 7))
+    (AddCommGrpCat.of ℤ)
+  change (standardSevenTopSimplexChain ≫ _) ≫ F.f 6 =
+    (subdividedSimplexFundamentalChain 7 ≫ _) ≫ G.f 6
+  rw [Category.assoc, ← F.comm 7 6, ← Category.assoc,
+    standardSevenTopSimplexChain_barycentricSubdivision]
+  change (subdividedSimplexFundamentalChain 7 ≫ G.f 7) ≫ _ = _
+  have hcomm := G.comm 7 6
+  rw [Category.assoc]
+  exact congrArg (fun k ↦ subdividedSimplexFundamentalChain 7 ≫ k) hcomm
+
+/-- The intrinsic boundary chain has the promised explicit subdivision after including
+`sd (∂Δ[7])` into `sd Δ[7]`.  Thus no subcomplex-realization theorem is needed for the
+chain-level generator comparison. -/
+public theorem boundarySevenOriginalFundamentalChain_barycentricSubdivision_comp_inclusion :
+    (boundarySevenOriginalFundamentalChain ≫
+        (barycentricSubdivisionChainMapCanonical (∂Δ[7] : SSet.{0})).f 6) ≫
+      (SSet.chainComplexMap
+        (SSet.sd.map
+          ((SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι))
+        (AddCommGrpCat.of ℤ)).f 6 =
+      subdividedSevenBoundaryFundamentalChain ≫
+        (SSet.chainComplexMap
+          (SSet.stdSimplex.sdIso.inv.app (SimplexCategory.mk 7))
+          (AddCommGrpCat.of ℤ)).f 6 := by
+  let j := (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+  have hnat := congrArg (fun k ↦ k.f 6)
+    (barycentricSubdivisionChainMapCanonical_naturality j)
+  calc
+    _ = boundarySevenOriginalFundamentalChain ≫
+        ((barycentricSubdivisionChainMapCanonical (∂Δ[7] : SSet.{0})).f 6 ≫
+          (SSet.chainComplexMap (SSet.sd.map j)
+            (AddCommGrpCat.of ℤ)).f 6) := Category.assoc _ _ _
+    _ = boundarySevenOriginalFundamentalChain ≫
+        ((SSet.chainComplexMap j (AddCommGrpCat.of ℤ)).f 6 ≫
+          (barycentricSubdivisionChainMapCanonical (Δ[7] : SSet.{0})).f 6) := by
+      exact congrArg (fun k ↦ boundarySevenOriginalFundamentalChain ≫ k) hnat.symm
+    _ = (boundarySevenOriginalFundamentalChain ≫
+          (SSet.chainComplexMap j (AddCommGrpCat.of ℤ)).f 6) ≫
+        (barycentricSubdivisionChainMapCanonical (Δ[7] : SSet.{0})).f 6 :=
+      (Category.assoc _ _ _).symm
+    _ = standardSevenOriginalBoundaryChain ≫
+        (barycentricSubdivisionChainMapCanonical (Δ[7] : SSet.{0})).f 6 := by
+      rw [boundarySevenOriginalFundamentalChain_comp_boundaryInclusion]
+    _ = _ := standardSevenOriginalBoundaryChain_barycentricSubdivision
+
+/-- The generator actually used by `boundarySevenNormalizedTopCyclesOrientation`: first take
+the generator of the unique normalized seven-simplex, apply its boundary (the exactness
+isomorphism), then transport that cycle back from `Δ[7]` to `∂Δ[7]`. -/
+public noncomputable def boundarySevenNormalizedOrientationGenerator :
+    AddCommGrpCat.of ℤ ⟶
+      kernel (BoundarySevenNormalizedIntegralChains.d 6 5) :=
+  standardSevenNormalizedChainsXSevenIsoInt.inv ≫
+    standardSevenNormalizedChainsXSevenIsoTopCycles.hom ≫
+      boundarySevenTopCyclesIsoStandardSevenTopCycles.inv
+
+/-- The preceding map is precisely the inverse of the top-cycle orientation equivalence used
+in the proof of `boundarySevenSimplicialTopHomologyOrientation`. -/
+public theorem boundarySevenNormalizedOrientationGenerator_eq_orientation_inv :
+    boundarySevenNormalizedOrientationGenerator =
+      (boundarySevenTopCyclesIsoStandardSevenTopCycles ≪≫
+        standardSevenTopCyclesIsoInt).inv := by
+  rfl
+
+/-- Barycentric subdivision followed by the maximum-last-vertex map induces the identity on
+integral homology, in every degree. -/
+public theorem barycentricSubdivision_lastVertex_homologyMap
+    (X : SSet.{0}) (n : ℕ) :
+    HomologicalComplex.homologyMap
+        (barycentricSubdivisionChainMapCanonical X) n ≫
+      HomologicalComplex.homologyMap (subdivisionLastVertexChainMap X) n =
+        𝟙 ((X.chainComplex (AddCommGrpCat.of ℤ)).homology n) := by
+  rw [← HomologicalComplex.homologyMap_comp]
+  change HomologicalComplex.homologyMap (barycentricSubdivisionEndomorphism X) n = _
+  simpa [barycentricSubdivisionEndomorphismIterate] using
+    barycentricSubdivisionEndomorphismIterate_homologyMap X 1 n
+
+/-- The canonical simplicial-to-realization-singular comparison is natural. -/
+public theorem simplicialToRealizationSingularChainMap_naturality
+    {K L : SSet.{0}} (f : K ⟶ L) (R : AddCommGrpCat) :
+    SSet.chainComplexMap f R ≫ simplicialToRealizationSingularChainMap L R =
+      simplicialToRealizationSingularChainMap K R ≫
+        SSet.chainComplexMap
+          (TopCat.toSSet.map (SSet.toTop.map f)) R := by
+  unfold simplicialToRealizationSingularChainMap
+  rw [← Functor.map_comp, ← Functor.map_comp]
+  exact (SSet.chainComplexFunctor AddCommGrpCat).obj R |>.congr_map
+    (sSetTopAdj.unit.naturality f)
+
+/-- The exact remaining geometric assertion after the algebraic comparison in this file.  It
+is deliberately kept equal to the previously isolated transport proposition: what remains is
+to show that realization followed by the chosen radial sphere equivalence takes this generator
+to degree `+1`. -/
+public def BoundarySevenSubdivisionGeneratorGeometricCompatibility
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) : Prop :=
+  BoundarySevenSubdivisionGeneratorDegreeTransport hcomparison e
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SubdivisionVertexPermutationFundamentalChain.lean
+++ b/SphereSixComplex/Topology/SubdivisionVertexPermutationFundamentalChain.lean
@@ -1,0 +1,158 @@
+module
+
+public import SphereSixComplex.Topology.SingularBarycentricOuterFaces
+public import Mathlib.GroupTheory.Perm.Sign
+
+/-!
+# Vertex permutations and barycentric fundamental chains
+
+An arbitrary permutation of the vertices of an ordered simplex is not a morphism of the
+representable simplicial set.  After barycentric subdivision it is, however, an order
+automorphism of the poset of nonempty vertex subsets.  This file constructs that automorphism
+directly in Mathlib's `SimplexCategory.sd` model and computes its action on the explicit signed
+maximal-flag fundamental chain.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- Reindex a nonempty finite subset of the vertices by an arbitrary permutation. -/
+public noncomputable def nonemptyFiniteChainsVertexPerm {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1)))
+    (s : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) :
+    NonemptyFiniteChains (ULift.{0} (Fin (n + 1))) where
+  finset := s.finset.image (fun i ↦ ULift.up (σ i.down))
+  nonempty := Finset.image_nonempty.mpr s.nonempty
+  comparable := fun _ _ ↦ le_total _ _
+
+@[simp]
+public theorem nonemptyFiniteChainsVertexPerm_finset {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1)))
+    (s : NonemptyFiniteChains (ULift.{0} (Fin (n + 1)))) :
+    (nonemptyFiniteChainsVertexPerm σ s).finset =
+      s.finset.image (fun i ↦ ULift.up (σ i.down)) :=
+  rfl
+
+/-- Vertex reindexing is an order automorphism of the nonempty-subset poset. -/
+public noncomputable def nonemptyFiniteChainsVertexPermOrderIso {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1))) :
+    NonemptyFiniteChains (ULift.{0} (Fin (n + 1))) ≃o
+      NonemptyFiniteChains (ULift.{0} (Fin (n + 1))) where
+  toFun := nonemptyFiniteChainsVertexPerm σ
+  invFun := nonemptyFiniteChainsVertexPerm σ.symm
+  left_inv s := by
+    apply NonemptyFiniteChains.ext
+    ext i
+    rcases i with ⟨i⟩
+    simp [nonemptyFiniteChainsVertexPerm]
+  right_inv s := by
+    apply NonemptyFiniteChains.ext
+    ext i
+    rcases i with ⟨i⟩
+    simp [nonemptyFiniteChainsVertexPerm]
+  map_rel_iff' := by
+    intro s t
+    change s.finset.image (fun i ↦ ULift.up (σ i.down)) ⊆
+        t.finset.image (fun i ↦ ULift.up (σ i.down)) ↔
+      s.finset ⊆ t.finset
+    constructor
+    · intro h i hi
+      have himage : ULift.up (σ i.down) ∈
+          t.finset.image (fun j ↦ ULift.up (σ j.down)) :=
+        h (Finset.mem_image.mpr ⟨i, hi, rfl⟩)
+      obtain ⟨j, hj, hji⟩ := Finset.mem_image.mp himage
+      have hdown : j.down = i.down := σ.injective (ULift.ext_iff.mp hji)
+      have hji' : j = i := by
+        apply ULift.ext
+        exact hdown
+      simpa [hji'] using hj
+    · intro h
+      exact Finset.image_mono _ h
+
+/-- The induced simplicial automorphism of Mathlib's explicit subdivision model. -/
+public noncomputable def simplexSubdivisionVertexPermIso {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1))) :
+    SimplexCategory.sd.{0}.obj (SimplexCategory.mk n) ≅
+      SimplexCategory.sd.{0}.obj (SimplexCategory.mk n) :=
+  PartOrd.nerveFunctor.mapIso
+    (PartOrd.Iso.mk (nonemptyFiniteChainsVertexPermOrderIso σ))
+
+/-- The forward simplicial map underlying vertex reindexing. -/
+public noncomputable def simplexSubdivisionVertexPermMap {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1))) :
+    SimplexCategory.sd.{0}.obj (SimplexCategory.mk n) ⟶
+      SimplexCategory.sd.{0}.obj (SimplexCategory.mk n) :=
+  (simplexSubdivisionVertexPermIso σ).hom
+
+/-- Reindexing a prefix subset agrees with left multiplication of its vertex ordering. -/
+public theorem nonemptyFiniteChainsVertexPerm_permutationPrefixChain {n : ℕ}
+    (σ τ : Equiv.Perm (Fin (n + 1))) (k : Fin (n + 1)) :
+    nonemptyFiniteChainsVertexPerm σ (permutationPrefixChain τ k) =
+      permutationPrefixChain (σ * τ) k := by
+  apply NonemptyFiniteChains.ext
+  change (permutationPrefixFinset τ k).image
+      (fun i ↦ ULift.up (σ i.down)) =
+    permutationPrefixFinset (σ * τ) k
+  unfold permutationPrefixFinset
+  rw [Finset.image_image]
+  rfl
+
+/-- The subdivision automorphism sends a maximal flag to the left-reindexed maximal flag. -/
+public theorem simplexSubdivisionVertexPermMap_permutationMaximalFlagSimplex {n : ℕ}
+    (σ τ : Equiv.Perm (Fin (n + 1))) :
+    (simplexSubdivisionVertexPermMap σ).app
+        (Opposite.op (SimplexCategory.mk n))
+        (permutationMaximalFlagSimplex τ) =
+      permutationMaximalFlagSimplex (σ * τ) := by
+  refine ComposableArrows.ext (fun k ↦ ?_) (fun k hk ↦ ?_)
+  · change nonemptyFiniteChainsVertexPerm σ (permutationPrefixChain τ k) =
+      permutationPrefixChain (σ * τ) k
+    exact nonemptyFiniteChainsVertexPerm_permutationPrefixChain σ τ k
+  · apply Subsingleton.elim
+
+/-- The induced chain map multiplies the barycentric fundamental chain by the ordinary sign of
+the vertex permutation. -/
+public theorem subdividedSimplexFundamentalChain_vertexPerm {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1))) :
+    subdividedSimplexFundamentalChain n ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap σ)
+          (AddCommGrpCat.of ℤ)).f n =
+      permutationSignInteger σ • subdividedSimplexFundamentalChain n := by
+  rw [subdividedSimplexFundamentalChain, Preadditive.sum_comp]
+  simp only [Preadditive.zsmul_comp, SSet.ι_chainComplexMap_f,
+    simplexSubdivisionVertexPermMap_permutationMaximalFlagSimplex,
+    Finset.smul_sum, smul_smul]
+  rw [← Equiv.sum_comp (Equiv.mulLeft σ.symm)]
+  apply Finset.sum_congr rfl
+  intro τ hτ
+  change permutationSignInteger (σ.symm * τ) •
+      (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).ιChainComplex
+        (permutationMaximalFlagSimplex (σ * (σ.symm * τ))) =
+    (permutationSignInteger σ * permutationSignInteger τ) •
+      (SimplexCategory.sd.{0}.obj (SimplexCategory.mk n)).ιChainComplex
+        (permutationMaximalFlagSimplex τ)
+  have hcancel : σ * (σ.symm * τ) = τ := by
+    apply Equiv.ext
+    intro i
+    exact σ.apply_symm_apply (τ i)
+  rw [hcancel]
+  rw [permutationSignInteger, permutationSignInteger, permutationSignInteger,
+    Equiv.Perm.sign_mul, Equiv.Perm.sign_symm]
+  norm_num
+
+/-- In particular an odd vertex permutation negates the barycentric fundamental chain. -/
+public theorem subdividedSimplexFundamentalChain_vertexPerm_of_sign_neg {n : ℕ}
+    (σ : Equiv.Perm (Fin (n + 1))) (hσ : Equiv.Perm.sign σ = -1) :
+    subdividedSimplexFundamentalChain n ≫
+        (SSet.chainComplexMap (simplexSubdivisionVertexPermMap σ)
+          (AddCommGrpCat.of ℤ)).f n =
+      -subdividedSimplexFundamentalChain n := by
+  rw [subdividedSimplexFundamentalChain_vertexPerm, permutationSignInteger, hσ]
+  norm_num
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- construct the signed maximal-flag fundamental chain for barycentric subdivision
- prove vertex permutations act by their ordinary sign
- identify subdivision of the alternating boundary cycle
- compare the normalized boundary generator with the canonical orientation generator

This is PR 3 of 7 in the boundary-seven degree-transport stack, stacked on #67.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorComparison
- Build completed successfully: 3065 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- audited comparison theorems use only propext, Classical.choice, and Quot.sound