### PR TITLE
Develop proper-face affine realization coordinates

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenFlagRealizationCommonFace.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFlagRealizationCommonFace.lean
@@ -1,0 +1,70 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealization
+
+/-!
+# Common faces in the proper-face realization
+
+This module isolates the categorical half of overlap uniqueness.  If two flag simplices have a
+common restriction and two simplex points are obtained from the same point of that restriction,
+then their images in geometric realization are equal.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Opposite Simplicial
+
+namespace SphereSixComplex
+
+/-- Two representatives induced from the same point of a common flag restriction define the
+same point of the geometric realization. -/
+public theorem boundarySevenFlagRealization_eq_of_commonRestriction
+    {r k l : ℕ}
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace l)
+    (f : SimplexCategory.mk r ⟶ SimplexCategory.mk k)
+    (g : SimplexCategory.mk r ⟶ SimplexCategory.mk l)
+    (hfg : BoundarySevenProperFaceNerve.map f.op F =
+      BoundarySevenProperFaceNerve.map g.op G)
+    (u : stdSimplex ℝ (Fin (r + 1))) :
+    SSet.toTop.map ((SSet.yonedaEquiv
+      (X := BoundarySevenProperFaceNerve)).symm F)
+        ((SimplexCategory.toTopHomeo (SimplexCategory.mk k)).symm
+          (stdSimplex.map f u)) =
+      SSet.toTop.map ((SSet.yonedaEquiv
+        (X := BoundarySevenProperFaceNerve)).symm G)
+        ((SimplexCategory.toTopHomeo (SimplexCategory.mk l)).symm
+          (stdSimplex.map g u)) := by
+  have hmaps :
+      SSet.stdSimplex.map f ≫ (SSet.yonedaEquiv
+        (X := BoundarySevenProperFaceNerve)).symm F =
+        SSet.stdSimplex.map g ≫ (SSet.yonedaEquiv
+          (X := BoundarySevenProperFaceNerve)).symm G := by
+    apply (SSet.yonedaEquiv
+      (X := BoundarySevenProperFaceNerve)).injective
+    rw [← SSet.yonedaEquiv_naturality,
+      ← SSet.yonedaEquiv_naturality]
+    have hF : (SSet.yonedaEquiv
+        (X := BoundarySevenProperFaceNerve))
+          ((SSet.yonedaEquiv
+            (X := BoundarySevenProperFaceNerve)).symm F) = F :=
+      (SSet.yonedaEquiv
+        (X := BoundarySevenProperFaceNerve)).apply_symm_apply F
+    have hG : (SSet.yonedaEquiv
+        (X := BoundarySevenProperFaceNerve))
+          ((SSet.yonedaEquiv
+            (X := BoundarySevenProperFaceNerve)).symm G) = G :=
+      (SSet.yonedaEquiv
+        (X := BoundarySevenProperFaceNerve)).apply_symm_apply G
+    exact (congrArg (fun z ↦ BoundarySevenProperFaceNerve.map f.op z) hF).trans
+      (hfg.trans
+        (congrArg (fun z ↦ BoundarySevenProperFaceNerve.map g.op z) hG).symm)
+  rw [SimplexCategory.toTopHomeo_symm_naturality_apply,
+    SimplexCategory.toTopHomeo_symm_naturality_apply]
+  rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply,
+    ← SSet.toTop.map_comp, ← SSet.toTop.map_comp]
+  rw [hmaps]
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenOrderedCoordinateFlag.lean
+++ b/SphereSixComplex/Topology/BoundarySevenOrderedCoordinateFlag.lean
@@ -1,0 +1,257 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealization
+public import Mathlib.Data.Fin.Tuple.Sort
+
+/-!
+# Ordered-coordinate flags in the boundary of the seven-simplex
+
+Sorting the eight barycentric coordinates of a boundary point gives seven nonempty proper
+suffixes.  Read in reverse order, these suffixes form a strict flag.  Consecutive coordinate
+differences, multiplied by the size of the corresponding suffix, are its simplex weights.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Finset PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- A permutation which puts the barycentric coordinates in increasing order. -/
+public noncomputable def boundarySevenCoordinateSort
+    (w : StandardSimplexBoundary 7) : Equiv.Perm (Fin 8) :=
+  Tuple.sort (fun i ↦ (w.1 : Fin 8 → ℝ) i)
+
+public theorem boundarySevenCoordinateSort_monotone
+    (w : StandardSimplexBoundary 7) :
+    Monotone (fun i ↦ w.1 (boundarySevenCoordinateSort w i)) :=
+  Tuple.monotone_sort _
+
+/-- The positions bounding the `j`th suffix.  They are respectively `7-j` and `6-j`. -/
+public def boundarySevenOrderedFacePosition (j : Fin 7) : Fin 8 :=
+  Fin.rev j.castSucc
+
+public def boundarySevenOrderedFacePreviousPosition (j : Fin 7) : Fin 8 :=
+  Fin.rev j.succ
+
+public theorem boundarySevenOrderedFacePreviousPosition_lt (j : Fin 7) :
+    boundarySevenOrderedFacePreviousPosition j < boundarySevenOrderedFacePosition j := by
+  simp [boundarySevenOrderedFacePreviousPosition, boundarySevenOrderedFacePosition]
+
+/-- The suffix of sorted vertices beginning at position `7-j`. -/
+public noncomputable def boundarySevenOrderedFaceFinset
+    (w : StandardSimplexBoundary 7) (j : Fin 7) : Finset (Fin 8) :=
+  (Finset.Ici (boundarySevenOrderedFacePosition j)).map
+    (boundarySevenCoordinateSort w).toEmbedding
+
+public theorem boundarySevenOrderedFaceFinset_nonempty
+    (w : StandardSimplexBoundary 7) (j : Fin 7) :
+    (boundarySevenOrderedFaceFinset w j).Nonempty := by
+  refine ⟨boundarySevenCoordinateSort w (boundarySevenOrderedFacePosition j), ?_⟩
+  simp [boundarySevenOrderedFaceFinset]
+
+public theorem boundarySevenOrderedFaceFinset_ne_univ
+    (w : StandardSimplexBoundary 7) (j : Fin 7) :
+    boundarySevenOrderedFaceFinset w j ≠ Finset.univ := by
+  intro h
+  have hz : boundarySevenCoordinateSort w 0 ∈
+      boundarySevenOrderedFaceFinset w j := by rw [h]; simp
+  simp only [boundarySevenOrderedFaceFinset, Finset.mem_map] at hz
+  obtain ⟨k, hk, heq⟩ := hz
+  have hk0 : k = 0 := (boundarySevenCoordinateSort w).injective heq
+  subst k
+  have hpos : 0 < boundarySevenOrderedFacePosition j := by
+    apply Fin.pos_iff_ne_zero.mpr
+    intro hzero
+    have hv := congrArg Fin.val hzero
+    simp [boundarySevenOrderedFacePosition, Fin.rev] at hv
+    omega
+  have hk' := Finset.mem_Ici.mp hk
+  exact (not_le_of_gt hpos) hk'
+
+/-- The `j`th suffix as a nonempty proper face. -/
+public noncomputable def boundarySevenOrderedFace
+    (w : StandardSimplexBoundary 7) (j : Fin 7) : BoundarySevenProperFace :=
+  ⟨boundarySevenOrderedFaceFinset w j,
+    boundarySevenOrderedFaceFinset_nonempty w j,
+    boundarySevenOrderedFaceFinset_ne_univ w j⟩
+
+@[simp]
+public theorem boundarySevenOrderedFace_card
+    (w : StandardSimplexBoundary 7) (j : Fin 7) :
+    (boundarySevenOrderedFace w j).1.card = j.val + 1 := by
+  simp only [boundarySevenOrderedFace, boundarySevenOrderedFaceFinset,
+    Finset.card_map, Fin.card_Ici, boundarySevenOrderedFacePosition]
+  rw [Fin.val_rev, Fin.val_castSucc]
+  omega
+
+@[simp]
+public theorem boundarySevenCoordinateSort_mem_orderedFace_iff
+    (w : StandardSimplexBoundary 7) (j : Fin 7) (i : Fin 8) :
+    boundarySevenCoordinateSort w i ∈ (boundarySevenOrderedFace w j).1 ↔
+      boundarySevenOrderedFacePosition j ≤ i := by
+  simp [boundarySevenOrderedFace, boundarySevenOrderedFaceFinset]
+
+/-- The ordered suffix faces are strictly nested. -/
+public theorem boundarySevenOrderedFace_strictMono
+    (w : StandardSimplexBoundary 7) :
+    StrictMono (boundarySevenOrderedFace w) := by
+  intro j k hjk
+  change boundarySevenOrderedFaceFinset w j < boundarySevenOrderedFaceFinset w k
+  rw [Finset.ssubset_iff_subset_ne]
+  constructor
+  · intro i hi
+    simp only [boundarySevenOrderedFaceFinset,
+      Finset.mem_map] at hi ⊢
+    obtain ⟨p, hp, rfl⟩ := hi
+    refine ⟨p, ?_, rfl⟩
+    apply Finset.mem_Ici.mpr
+    have hpos : boundarySevenOrderedFacePosition k ≤
+        boundarySevenOrderedFacePosition j := by
+      simp only [boundarySevenOrderedFacePosition, Fin.rev_le_rev]
+      exact Fin.castSucc_le_castSucc_iff.mpr hjk.le
+    exact hpos.trans (Finset.mem_Ici.mp hp)
+  · intro heq
+    let p := boundarySevenOrderedFacePosition k
+    have hmemk : boundarySevenCoordinateSort w p ∈
+        boundarySevenOrderedFaceFinset w k := by
+      simp [boundarySevenOrderedFaceFinset, p]
+    have hmemj : boundarySevenCoordinateSort w p ∈
+        boundarySevenOrderedFaceFinset w j := by rwa [heq]
+    simp only [boundarySevenOrderedFaceFinset, Finset.mem_map] at hmemj
+    obtain ⟨q, hq, heqp⟩ := hmemj
+    have hqp : q = p := (boundarySevenCoordinateSort w).injective heqp
+    subst q
+    have hrev : boundarySevenOrderedFacePosition k <
+        boundarySevenOrderedFacePosition j := by
+      simp only [boundarySevenOrderedFacePosition, Fin.rev_lt_rev]
+      exact Fin.castSucc_lt_castSucc_iff.mpr hjk
+    exact (not_le_of_gt hrev) (Finset.mem_Ici.mp hq)
+
+/-- The seven strictly nested suffixes, packaged as a six-simplex of the proper-face nerve. -/
+public noncomputable def boundarySevenOrderedFlag
+    (w : StandardSimplexBoundary 7) :
+    ComposableArrows BoundarySevenProperFace 6 where
+  obj := boundarySevenOrderedFace w
+  map f := homOfLE ((boundarySevenOrderedFace_strictMono w).monotone (leOfHom f))
+  map_id _ := Subsingleton.elim _ _
+  map_comp _ _ := Subsingleton.elim _ _
+
+@[simp]
+public theorem boundarySevenOrderedFlag_obj
+    (w : StandardSimplexBoundary 7) (j : Fin 7) :
+    (boundarySevenOrderedFlag w).obj j = boundarySevenOrderedFace w j :=
+  rfl
+
+public theorem boundarySevenOrderedFlag_strictMono
+    (w : StandardSimplexBoundary 7) :
+    StrictMono (boundarySevenOrderedFlag w).obj :=
+  boundarySevenOrderedFace_strictMono w
+
+/-- Consecutive-difference weight of the `j`th suffix face. -/
+public noncomputable def boundarySevenOrderedWeight
+    (w : StandardSimplexBoundary 7) (j : Fin 7) : ℝ :=
+  (j.val + 1 : ℝ) *
+    (w.1 (boundarySevenCoordinateSort w (boundarySevenOrderedFacePosition j)) -
+      w.1 (boundarySevenCoordinateSort w
+        (boundarySevenOrderedFacePreviousPosition j)))
+
+public theorem boundarySevenOrderedWeight_nonneg
+    (w : StandardSimplexBoundary 7) (j : Fin 7) :
+    0 ≤ boundarySevenOrderedWeight w j := by
+  apply mul_nonneg (by positivity)
+  exact sub_nonneg.mpr (boundarySevenCoordinateSort_monotone w
+    (boundarySevenOrderedFacePreviousPosition_lt j).le)
+
+/-- The least sorted coordinate vanishes because the point lies in the simplex boundary. -/
+public theorem boundarySevenCoordinateSort_zero
+    (w : StandardSimplexBoundary 7) :
+    w.1 (boundarySevenCoordinateSort w 0) = 0 := by
+  obtain ⟨i, hi⟩ := w.2
+  let p : Fin 8 := (boundarySevenCoordinateSort w).symm i
+  have hle := boundarySevenCoordinateSort_monotone w (Fin.zero_le p)
+  have hp : boundarySevenCoordinateSort w p = i := by
+    simp [p]
+  change w.1 (boundarySevenCoordinateSort w 0) ≤
+      w.1 (boundarySevenCoordinateSort w p) at hle
+  rw [hp, hi] at hle
+  exact le_antisymm hle (w.1.2.1 _)
+
+/-- The seven consecutive-difference coefficients have total mass one. -/
+public theorem boundarySevenOrderedWeight_sum
+    (w : StandardSimplexBoundary 7) :
+    ∑ j : Fin 7, boundarySevenOrderedWeight w j = 1 := by
+  have hsum : ∑ i : Fin 8, w.1 (boundarySevenCoordinateSort w i) = 1 := by
+    calc
+      _ = ∑ i : Fin 8, w.1 i :=
+        Equiv.sum_comp (boundarySevenCoordinateSort w) (fun i ↦ w.1 i)
+      _ = 1 := w.1.2.2
+  have hzero := boundarySevenCoordinateSort_zero w
+  simp only [boundarySevenOrderedWeight, boundarySevenOrderedFacePosition,
+    boundarySevenOrderedFacePreviousPosition, Fin.sum_univ_succ,
+    Fin.val_zero, Nat.cast_zero, Nat.cast_add, Nat.cast_one,
+    zero_add, Fin.rev, Fin.castSucc, Fin.succ] at hsum ⊢
+  norm_num at hsum ⊢
+  linarith
+
+/-- The ordered-coordinate differences as a point of the coefficient simplex. -/
+public noncomputable def boundarySevenOrderedWeights
+    (w : StandardSimplexBoundary 7) : stdSimplex ℝ (Fin 7) :=
+  ⟨boundarySevenOrderedWeight w,
+    boundarySevenOrderedWeight_nonneg w,
+    boundarySevenOrderedWeight_sum w⟩
+
+@[simp]
+public theorem boundarySevenOrderedWeights_apply
+    (w : StandardSimplexBoundary 7) (j : Fin 7) :
+    boundarySevenOrderedWeights w j = boundarySevenOrderedWeight w j :=
+  rfl
+
+/-- Coordinatewise layer-cake reconstruction, stated at a sorted vertex. -/
+public theorem boundarySevenOrderedAffineCombination_apply_sorted
+    (w : StandardSimplexBoundary 7) (i : Fin 8) :
+    stdSimplexAffineCombination
+        (fun j ↦ boundarySevenProperFaceBarycenter
+          (boundarySevenOrderedFace w j))
+        (boundarySevenOrderedWeights w)
+        (boundarySevenCoordinateSort w i) =
+      w.1 (boundarySevenCoordinateSort w i) := by
+  rw [stdSimplexAffineCombination_apply]
+  simp only [boundarySevenOrderedWeights_apply,
+    boundarySevenProperFaceBarycenter_apply,
+    boundarySevenCoordinateSort_mem_orderedFace_iff,
+    boundarySevenOrderedFace_card]
+  have hzero := boundarySevenCoordinateSort_zero w
+  fin_cases i <;>
+    simp [boundarySevenOrderedWeight,
+      boundarySevenOrderedFacePosition,
+      boundarySevenOrderedFacePreviousPosition, Fin.sum_univ_succ,
+      Fin.rev, Fin.castSucc, Fin.succ, hzero] <;>
+    ring
+
+/-- Every boundary point is the affine combination of the barycenters in its explicit strict
+ordered-coordinate flag. -/
+public theorem boundarySevenOrderedAffineCombination_eq
+    (w : StandardSimplexBoundary 7) :
+    stdSimplexAffineCombination
+        (fun j ↦ boundarySevenProperFaceBarycenter
+          (boundarySevenOrderedFace w j))
+        (boundarySevenOrderedWeights w) = w.1 := by
+  ext x
+  let i : Fin 8 := (boundarySevenCoordinateSort w).symm x
+  have hxi : boundarySevenCoordinateSort w i = x := by simp [i]
+  rw [← hxi]
+  exact boundarySevenOrderedAffineCombination_apply_sorted w i
+
+/-- Endpoint form: the affine realization of the explicit strict flag at its explicit simplex
+weights is the original boundary point. -/
+public theorem boundarySevenProperFaceAffineFlagMap_orderedFlag
+    (w : StandardSimplexBoundary 7) :
+    boundarySevenProperFaceAffineFlagMap 6
+        (boundarySevenOrderedFlag w) (boundarySevenOrderedWeights w) = w := by
+  apply Subtype.ext
+  exact boundarySevenOrderedAffineCombination_eq w
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceRealization.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceRealization.lean
@@ -1,0 +1,343 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenReflectionDegreeFromSubdivision
+public import SphereSixComplex.Topology.SingularAffineSubdivision
+
+/-!
+# Affine realization of the proper-face nerve
+
+Every vertex of the proper-face nerve is sent to the barycenter of the corresponding face of
+the standard seven-simplex.  On a flag of faces we extend affinely.  Because all faces in a flag
+are contained in its largest (proper) face, this affine simplex lands in the ordinary boundary.
+The resulting compatible family of singular simplices gives a canonical continuous map from the
+geometric realization of the proper-face nerve to the standard simplex boundary.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ContinuousMap Opposite PartialOrder Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The barycenter of a proper face, regarded as a point of the ambient standard simplex. -/
+public noncomputable def boundarySevenProperFaceBarycenter
+    (s : BoundarySevenProperFace) : stdSimplex ℝ (Fin 8) :=
+  nonemptyFiniteChainBarycenter
+    (boundarySevenProperFaceToNonemptyFiniteChain s)
+
+@[simp]
+public theorem boundarySevenProperFaceBarycenter_apply
+    (s : BoundarySevenProperFace) (i : Fin 8) :
+    boundarySevenProperFaceBarycenter s i =
+      if i ∈ s.1 then (s.1.card : ℝ)⁻¹ else 0 := by
+  rw [boundarySevenProperFaceBarycenter,
+    nonemptyFiniteChainBarycenter_apply]
+  have hcard : (s.1.image ULift.up).card = s.1.card :=
+    Finset.card_image_of_injective s.1 ULift.up_injective
+  have hcardReal : ((s.1.image ULift.up).card : ℝ) = (s.1.card : ℝ) :=
+    congrArg Nat.cast hcard
+  simp only [boundarySevenProperFaceToNonemptyFiniteChain,
+    Finset.mem_image, ULift.up_inj, exists_eq_right]
+  rw [hcardReal]
+
+/-- Barycenters of proper faces are natural under every permutation of the eight vertices. -/
+public theorem boundarySevenProperFaceBarycenter_permute
+    (sigma : Equiv.Perm (Fin 8)) (s : BoundarySevenProperFace) :
+    boundarySevenProperFaceBarycenter
+        (boundarySevenProperFacePerm sigma s) =
+      stdSimplex.map sigma (boundarySevenProperFaceBarycenter s) := by
+  ext i
+  rw [boundarySevenProperFaceBarycenter_apply,
+    stdSimplex_map_equiv_apply,
+    boundarySevenProperFaceBarycenter_apply]
+  have hcard : (s.1.map sigma.toEmbedding).card = s.1.card :=
+    Finset.card_map sigma.toEmbedding
+  simp [boundarySevenProperFacePerm, hcard]
+
+/-- The affine vertex-permutation homeomorphism of the ordinary boundary as a morphism in
+`TopCat`. -/
+public noncomputable def standardSimplexBoundaryPermTopMap
+    (sigma : Equiv.Perm (Fin 8)) :
+    TopCat.of (StandardSimplexBoundary 7) ⟶
+      TopCat.of (StandardSimplexBoundary 7) :=
+  TopCat.ofHom
+    ⟨standardSimplexBoundaryPermHomeomorph sigma,
+      (standardSimplexBoundaryPermHomeomorph sigma).continuous⟩
+
+/-- The affine extension of the face barycenters along a flag, with codomain the ambient
+standard simplex. -/
+public noncomputable def boundarySevenProperFaceAffineFlagAmbientMap
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k) :
+    C(stdSimplex ℝ (Fin (k + 1)), stdSimplex ℝ (Fin 8)) :=
+  ⟨stdSimplexAffineCombination
+      (fun j ↦ boundarySevenProperFaceBarycenter (F.obj j)),
+    continuous_stdSimplexAffineCombination _⟩
+
+/-- Every affine flag simplex is supported in its largest proper face and therefore lands in
+the boundary. -/
+public theorem boundarySevenProperFaceAffineFlagAmbientMap_mem_boundary
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    ∃ i, boundarySevenProperFaceAffineFlagAmbientMap k F w i = 0 := by
+  have hproper := (F.obj (Fin.last k)).2.2
+  have hex : ∃ i, i ∉ (F.obj (Fin.last k)).1 := by
+    by_contra h
+    apply hproper
+    apply Finset.eq_univ_iff_forall.mpr
+    intro i
+    by_contra hi
+    exact h ⟨i, hi⟩
+  obtain ⟨i, hi⟩ := hex
+  refine ⟨i, ?_⟩
+  change (∑ j, w j * boundarySevenProperFaceBarycenter (F.obj j) i) = 0
+  apply Finset.sum_eq_zero
+  intro j hj
+  have hjle : F.obj j ≤ F.obj (Fin.last k) :=
+    leOfHom (F.map (homOfLE (Fin.le_last j)))
+  have hij : i ∉ (F.obj j).1 := fun hij ↦ hi (hjle hij)
+  rw [boundarySevenProperFaceBarycenter_apply, if_neg hij, mul_zero]
+
+/-- The affine flag simplex, intrinsically valued in the ordinary simplex boundary. -/
+public noncomputable def boundarySevenProperFaceAffineFlagMap
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k) :
+    C(stdSimplex ℝ (Fin (k + 1)), StandardSimplexBoundary 7) :=
+  ⟨fun w ↦ ⟨boundarySevenProperFaceAffineFlagAmbientMap k F w,
+      boundarySevenProperFaceAffineFlagAmbientMap_mem_boundary k F w⟩,
+    (boundarySevenProperFaceAffineFlagAmbientMap k F).continuous.subtype_mk _⟩
+
+@[simp]
+public theorem boundarySevenProperFaceAffineFlagMap_val
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    (boundarySevenProperFaceAffineFlagMap k F w : stdSimplex ℝ (Fin 8)) =
+      boundarySevenProperFaceAffineFlagAmbientMap k F w :=
+  rfl
+
+/-- Restricting a flag along a simplex-category morphism agrees with restricting its affine
+simplex along the corresponding affine map. -/
+public theorem boundarySevenProperFaceAffineFlagMap_naturality
+    {n m : SimplexCategory} (f : n ⟶ m)
+    (F : ComposableArrows BoundarySevenProperFace m.len) :
+    boundarySevenProperFaceAffineFlagMap n.len
+        (F.whiskerLeft (SimplexCategory.toCat.map f).toFunctor) =
+      (boundarySevenProperFaceAffineFlagMap m.len F).comp
+        ⟨stdSimplex.map f, by continuity⟩ := by
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  change stdSimplexAffineCombination
+      (fun j ↦ boundarySevenProperFaceBarycenter
+        ((F.whiskerLeft (SimplexCategory.toCat.map f).toFunctor).obj j)) w =
+    stdSimplexAffineCombination
+      (fun j ↦ boundarySevenProperFaceBarycenter (F.obj j))
+        (stdSimplex.map f w)
+  rw [stdSimplexAffineCombination_map]
+  rfl
+
+/-- Affine realization of flags commutes with every permutation of the original vertices. -/
+public theorem boundarySevenProperFaceAffineFlagMap_permute
+    (sigma : Equiv.Perm (Fin 8)) (k : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k) :
+    boundarySevenProperFaceAffineFlagMap k
+        ((boundarySevenProperFaceNervePermIso sigma).hom.app
+          (Opposite.op (SimplexCategory.mk k)) F) =
+      (⟨standardSimplexBoundaryPermHomeomorph sigma,
+        (standardSimplexBoundaryPermHomeomorph sigma).continuous⟩ :
+          C(StandardSimplexBoundary 7, StandardSimplexBoundary 7)).comp
+          (boundarySevenProperFaceAffineFlagMap k F) := by
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  change stdSimplexAffineCombination
+      (fun j ↦ boundarySevenProperFaceBarycenter
+        (boundarySevenProperFacePerm sigma (F.obj j))) w =
+    stdSimplex.map sigma
+      (stdSimplexAffineCombination
+        (fun j ↦ boundarySevenProperFaceBarycenter (F.obj j)) w)
+  rw [stdSimplex_map_affineCombination]
+  apply congrArg (fun p ↦ stdSimplexAffineCombination p w)
+  funext j
+  exact boundarySevenProperFaceBarycenter_permute sigma (F.obj j)
+
+/-- A flag of proper faces as a singular simplex of the ordinary boundary. -/
+public noncomputable def boundarySevenProperFaceAffineSingularSimplex
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k) :
+    (TopCat.toSSet.obj (TopCat.of (StandardSimplexBoundary 7))).obj
+      (Opposite.op (SimplexCategory.mk k)) :=
+  (TopCat.toSSetObjEquiv _ _).symm
+    (boundarySevenProperFaceAffineFlagMap k F)
+
+/-- The affine flag construction is a morphism from the proper-face nerve to the singular
+simplicial set of the ordinary boundary. -/
+public noncomputable def boundarySevenProperFaceAffineSingularMap :
+    BoundarySevenProperFaceNerve ⟶
+      TopCat.toSSet.obj (TopCat.of (StandardSimplexBoundary 7)) where
+  app n := ↾fun F ↦ boundarySevenProperFaceAffineSingularSimplex n.unop.len F
+  naturality n m f := by
+    ext F
+    apply (TopCat.toSSetObjEquiv _ _).injective
+    exact boundarySevenProperFaceAffineFlagMap_naturality f.unop F
+
+/-- The affine singular map is equivariant for every vertex permutation. -/
+public theorem boundarySevenProperFaceAffineSingularMap_equivariant
+    (sigma : Equiv.Perm (Fin 8)) :
+    (boundarySevenProperFaceNervePermIso sigma).hom ≫
+        boundarySevenProperFaceAffineSingularMap =
+      boundarySevenProperFaceAffineSingularMap ≫
+        TopCat.toSSet.map (standardSimplexBoundaryPermTopMap sigma) := by
+  ext n F
+  apply (TopCat.toSSetObjEquiv _ _).injective
+  exact boundarySevenProperFaceAffineFlagMap_permute sigma n.unop.len F
+
+/-- The continuous affine-barycentric realization map, obtained from the compatible singular
+simplices by the geometric-realization/singular-set adjunction. -/
+public noncomputable def boundarySevenProperFaceRealizationMap :
+    SSet.toTop.obj BoundarySevenProperFaceNerve ⟶
+      TopCat.of (StandardSimplexBoundary 7) :=
+  (sSetTopAdj.homEquiv BoundarySevenProperFaceNerve
+    (TopCat.of (StandardSimplexBoundary 7))).symm
+      boundarySevenProperFaceAffineSingularMap
+
+/-- By construction, the adjoint of the affine realization map is the explicit affine singular
+map on flags. -/
+public theorem boundarySevenProperFaceRealizationMap_adjunct :
+    sSetTopAdj.unit.app BoundarySevenProperFaceNerve ≫
+        TopCat.toSSet.map boundarySevenProperFaceRealizationMap =
+      boundarySevenProperFaceAffineSingularMap := by
+  change (sSetTopAdj.homEquiv BoundarySevenProperFaceNerve
+      (TopCat.of (StandardSimplexBoundary 7)))
+        boundarySevenProperFaceRealizationMap =
+    boundarySevenProperFaceAffineSingularMap
+  exact Equiv.apply_symm_apply _ boundarySevenProperFaceAffineSingularMap
+
+/-- The same adjunction identity in `homEquiv` form. -/
+public theorem boundarySevenProperFaceRealizationMap_homEquiv :
+    (sSetTopAdj.homEquiv BoundarySevenProperFaceNerve
+      (TopCat.of (StandardSimplexBoundary 7)))
+        boundarySevenProperFaceRealizationMap =
+      boundarySevenProperFaceAffineSingularMap :=
+  Equiv.apply_symm_apply _ boundarySevenProperFaceAffineSingularMap
+
+/-- The canonical simplicial-to-singular comparison followed by the singular chain map of the
+affine realization is exactly the explicit affine flag chain map. -/
+public theorem boundarySevenProperFaceCanonicalComparison_comp_realizationChainMap :
+    simplicialToRealizationSingularChainMap BoundarySevenProperFaceNerve
+        (AddCommGrpCat.of ℤ) ≫
+      SSet.chainComplexMap
+        (TopCat.toSSet.map boundarySevenProperFaceRealizationMap)
+        (AddCommGrpCat.of ℤ) =
+    SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+      (AddCommGrpCat.of ℤ) := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+  have h := F.congr_map boundarySevenProperFaceRealizationMap_adjunct
+  rw [Functor.map_comp] at h
+  exact h
+
+/-- The intrinsic proper-face fundamental chain transported by the canonical comparison and
+the realization map is the explicit affine singular fundamental chain. -/
+public theorem boundarySevenProperFaceFundamentalChain_comparison_realization :
+    (boundarySevenProperFaceFundamentalChain ≫
+      (simplicialToRealizationSingularChainMap BoundarySevenProperFaceNerve
+        (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map boundarySevenProperFaceRealizationMap)
+          (AddCommGrpCat.of ℤ)).f 6 =
+      boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+          (AddCommGrpCat.of ℤ)).f 6 := by
+  simp only [Category.assoc]
+  have h := congrArg (fun f ↦ f.f 6)
+    boundarySevenProperFaceCanonicalComparison_comp_realizationChainMap
+  change
+    (simplicialToRealizationSingularChainMap BoundarySevenProperFaceNerve
+      (AddCommGrpCat.of ℤ)).f 6 ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map boundarySevenProperFaceRealizationMap)
+          (AddCommGrpCat.of ℤ)).f 6 =
+      (SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+        (AddCommGrpCat.of ℤ)).f 6 at h
+  rw [h]
+
+/-- The remaining point-set statement needed to promote the explicit affine realization map to
+a homeomorphism.  It contains no chain-level or equivariance condition. -/
+public def BoundarySevenProperFaceAffineRealizationHomeomorphismInput : Prop :=
+  IsCompact (Set.univ : Set
+      (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) ∧
+    Function.Bijective boundarySevenProperFaceRealizationMap
+
+/-- Compactness of the finite order-complex realization and bijectivity of the affine map promote
+it to the desired explicit homeomorphism. -/
+public noncomputable def boundarySevenProperFaceRealizationHomeomorph_of_input
+    (h : BoundarySevenProperFaceAffineRealizationHomeomorphismInput) :
+    (SSet.toTop.obj BoundarySevenProperFaceNerve : Type) ≃ₜ
+      StandardSimplexBoundary 7 := by
+  letI : CompactSpace (SSet.toTop.obj BoundarySevenProperFaceNerve : Type) :=
+    isCompact_univ_iff.mp h.1
+  exact Continuous.homeoOfEquivCompactToT2
+    (f := Equiv.ofBijective boundarySevenProperFaceRealizationMap h.2)
+    boundarySevenProperFaceRealizationMap.hom.continuous
+
+@[simp]
+public theorem boundarySevenProperFaceRealizationHomeomorph_of_input_apply
+    (h : BoundarySevenProperFaceAffineRealizationHomeomorphismInput)
+    (x : (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) :
+    boundarySevenProperFaceRealizationHomeomorph_of_input h x =
+      boundarySevenProperFaceRealizationMap x :=
+  rfl
+
+/-- The continuous affine realization map is equivariant for every vertex permutation. -/
+public theorem boundarySevenProperFaceRealizationMap_equivariant
+    (sigma : Equiv.Perm (Fin 8)) :
+    SSet.toTop.map (boundarySevenProperFaceNervePermIso sigma).hom ≫
+        boundarySevenProperFaceRealizationMap =
+      boundarySevenProperFaceRealizationMap ≫
+        standardSimplexBoundaryPermTopMap sigma := by
+  apply (sSetTopAdj.homEquiv BoundarySevenProperFaceNerve
+    (TopCat.of (StandardSimplexBoundary 7))).injective
+  rw [sSetTopAdj.homEquiv_naturality_left,
+    sSetTopAdj.homEquiv_naturality_right,
+    boundarySevenProperFaceRealizationMap_homEquiv]
+  exact boundarySevenProperFaceAffineSingularMap_equivariant sigma
+
+/-- In particular the affine realization intertwines the proper-face transposition with the
+explicit affine reflection of the ordinary simplex boundary. -/
+public theorem boundarySevenProperFaceRealizationMap_reflection_equivariant :
+    SSet.toTop.map boundarySevenProperFaceNerveReflectionIso.hom ≫
+        boundarySevenProperFaceRealizationMap =
+      boundarySevenProperFaceRealizationMap ≫
+        standardSimplexBoundaryPermTopMap boundarySevenReflectionPermutation := by
+  exact boundarySevenProperFaceRealizationMap_equivariant
+    boundarySevenReflectionPermutation
+
+/-- Once the sole point-set triangulation input is supplied, the resulting explicit
+homeomorphism is equivariant for every vertex permutation. -/
+public theorem boundarySevenProperFaceRealizationHomeomorph_of_input_equivariant
+    (h : BoundarySevenProperFaceAffineRealizationHomeomorphismInput)
+    (sigma : Equiv.Perm (Fin 8))
+    (x : (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) :
+    boundarySevenProperFaceRealizationHomeomorph_of_input h
+        (SSet.toTop.map (boundarySevenProperFaceNervePermIso sigma).hom x) =
+      standardSimplexBoundaryPermHomeomorph sigma
+        (boundarySevenProperFaceRealizationHomeomorph_of_input h x) := by
+  change boundarySevenProperFaceRealizationMap
+      (SSet.toTop.map (boundarySevenProperFaceNervePermIso sigma).hom x) =
+    standardSimplexBoundaryPermHomeomorph sigma
+      (boundarySevenProperFaceRealizationMap x)
+  exact ConcreteCategory.congr_hom
+    (boundarySevenProperFaceRealizationMap_equivariant sigma) x
+
+/-- Reflection equivariance of the conditional explicit homeomorphism. -/
+public theorem
+    boundarySevenProperFaceRealizationHomeomorph_of_input_reflection_equivariant
+    (h : BoundarySevenProperFaceAffineRealizationHomeomorphismInput)
+    (x : (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) :
+    boundarySevenProperFaceRealizationHomeomorph_of_input h
+        (SSet.toTop.map boundarySevenProperFaceNerveReflectionIso.hom x) =
+      standardSimplexBoundaryPermHomeomorph boundarySevenReflectionPermutation
+        (boundarySevenProperFaceRealizationHomeomorph_of_input h x) :=
+  boundarySevenProperFaceRealizationHomeomorph_of_input_equivariant h
+    boundarySevenReflectionPermutation x
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenStrictFlagAffineInjective.lean
+++ b/SphereSixComplex/Topology/BoundarySevenStrictFlagAffineInjective.lean
@@ -1,0 +1,155 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealization
+
+/-!
+# Injectivity of affine barycentric coordinates on a strict flag
+
+The barycenters of a strictly nested flag of nonempty faces are affinely independent.  Here we
+prove the precise point-set consequence needed for the proper-face realization: the affine map
+on each nondegenerate flag simplex is injective.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory ContinuousMap PartialOrder Set Simplicial
+
+namespace SphereSixComplex
+
+/-- Every level of a strict flag has a vertex which first appears at exactly that level. -/
+private theorem boundarySevenStrictFlag_exists_levelVertex
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (hF : StrictMono F.obj) (j : Fin (k + 1)) :
+    ∃ a : Fin 8, ∀ l : Fin (k + 1),
+      (a ∈ (F.obj l).1 ↔ j ≤ l) := by
+  refine Fin.cases ?_ (fun i ↦ ?_) j
+  · obtain ⟨a, ha⟩ := (F.obj (0 : Fin (k + 1))).2.1
+    refine ⟨a, fun l ↦ ⟨fun _ ↦ Fin.zero_le l, fun _ ↦ ?_⟩⟩
+    have hle : F.obj (0 : Fin (k + 1)) ≤ F.obj l :=
+      leOfHom (F.map (homOfLE (Fin.zero_le l)))
+    exact hle ha
+  · have hlt : F.obj i.castSucc < F.obj i.succ :=
+      hF i.castSucc_lt_succ
+    have hsub : (F.obj i.castSucc).1 ⊆ (F.obj i.succ).1 := hlt.le
+    have hex : ∃ a, a ∈ (F.obj i.succ).1 ∧ a ∉ (F.obj i.castSucc).1 := by
+      by_contra h
+      push Not at h
+      apply hlt.ne
+      apply Subtype.ext
+      apply Finset.Subset.antisymm hsub
+      intro a ha
+      exact h a ha
+    obtain ⟨a, haNow, haBefore⟩ := hex
+    refine ⟨a, fun l ↦ ⟨?_, ?_⟩⟩
+    · intro hal
+      by_contra hle
+      have hli : l ≤ i.castSucc := by
+        change ¬ (i.val + 1 ≤ l.val) at hle
+        change l.val ≤ i.val
+        omega
+      have hfaces : F.obj l ≤ F.obj i.castSucc :=
+        leOfHom (F.map (homOfLE hli))
+      exact haBefore (hfaces hal)
+    · intro hil
+      have hfaces : F.obj i.succ ≤ F.obj l :=
+        leOfHom (F.map (homOfLE hil))
+      exact hfaces haNow
+
+/-- A strict flag has unique barycentric coefficients. -/
+public theorem boundarySevenProperFaceAffineFlagMap_injective_of_strictMono
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (hF : StrictMono F.obj) :
+    Function.Injective (boundarySevenProperFaceAffineFlagMap k F) := by
+  intro w v hwv
+  apply Subtype.ext
+  funext j
+  let P : Fin (k + 1) → Prop := fun i ↦
+    ∀ l, i ≤ l → w l = v l
+  have hP : ∀ i, P i := by
+    intro i
+    induction i using Fin.reverseInduction with
+    | last =>
+        intro l hil
+        have hli : l = Fin.last k := Fin.le_antisymm (Fin.le_last l) hil
+        subst l
+        obtain ⟨a, ha⟩ :=
+          boundarySevenStrictFlag_exists_levelVertex k F hF (Fin.last k)
+        have hcoord := congrArg
+          (fun z : StandardSimplexBoundary 7 ↦ (z.1 : stdSimplex ℝ (Fin 8)) a) hwv
+        change (∑ l, w l * boundarySevenProperFaceBarycenter (F.obj l) a) =
+          ∑ l, v l * boundarySevenProperFaceBarycenter (F.obj l) a at hcoord
+        simp only [boundarySevenProperFaceBarycenter_apply, ha,
+          Fin.last_le_iff, mul_ite, mul_zero] at hcoord
+        rw [← Finset.sum_filter, ← Finset.sum_filter] at hcoord
+        simp only [Finset.filter_eq', Finset.mem_univ, ↓reduceIte,
+          Finset.sum_singleton] at hcoord
+        have hcard : (((F.obj (Fin.last k)).1.card : ℝ)⁻¹) ≠ 0 := by
+          apply inv_ne_zero
+          exact_mod_cast (F.obj (Fin.last k)).2.1.card_ne_zero
+        exact mul_right_cancel₀ hcard hcoord
+    | cast i ih =>
+        intro l hil
+        by_cases hli : l = i.castSucc
+        · subst l
+          obtain ⟨a, ha⟩ :=
+            boundarySevenStrictFlag_exists_levelVertex k F hF i.castSucc
+          have hcoord := congrArg
+            (fun z : StandardSimplexBoundary 7 ↦ (z.1 : stdSimplex ℝ (Fin 8)) a) hwv
+          change (∑ l, w l * boundarySevenProperFaceBarycenter (F.obj l) a) =
+            ∑ l, v l * boundarySevenProperFaceBarycenter (F.obj l) a at hcoord
+          simp only [boundarySevenProperFaceBarycenter_apply, ha,
+            mul_ite, mul_zero] at hcoord
+          rw [← Finset.sum_filter, ← Finset.sum_filter] at hcoord
+          let s := Finset.univ.filter (fun l : Fin (k + 1) ↦ i.castSucc ≤ l)
+          change Finset.sum s
+              (fun l ↦ w l * ((F.obj l).1.card : ℝ)⁻¹) =
+            Finset.sum s
+              (fun l ↦ v l * ((F.obj l).1.card : ℝ)⁻¹) at hcoord
+          have hi : i.castSucc ∈ s := by simp [s]
+          rw [← Finset.sum_erase_add s _ hi,
+            ← Finset.sum_erase_add s _ hi] at hcoord
+          have htail :
+              Finset.sum (s.erase i.castSucc)
+                  (fun l ↦ w l * ((F.obj l).1.card : ℝ)⁻¹) =
+                Finset.sum (s.erase i.castSucc)
+                  (fun l ↦ v l * ((F.obj l).1.card : ℝ)⁻¹) := by
+            apply Finset.sum_congr rfl
+            intro m hm
+            have hms : m ∈ s := Finset.mem_of_mem_erase hm
+            have hmle : i.castSucc ≤ m := (Finset.mem_filter.mp hms).2
+            have hmne : m ≠ i.castSucc := Finset.ne_of_mem_erase hm
+            have hsucc : i.succ ≤ m := by
+              change i.val ≤ m.val at hmle
+              have hmne' : m.val ≠ i.val := by
+                intro hval
+                apply hmne
+                apply Fin.ext
+                exact hval
+              change i.val + 1 ≤ m.val
+              omega
+            rw [ih m hsucc]
+          rw [htail] at hcoord
+          have hterm :
+              w i.castSucc * ((F.obj i.castSucc).1.card : ℝ)⁻¹ =
+                v i.castSucc * ((F.obj i.castSucc).1.card : ℝ)⁻¹ :=
+            add_left_cancel hcoord
+          have hcard : (((F.obj i.castSucc).1.card : ℝ)⁻¹) ≠ 0 := by
+            apply inv_ne_zero
+            exact_mod_cast (F.obj i.castSucc).2.1.card_ne_zero
+          exact mul_right_cancel₀ hcard hterm
+        · have hsucc : i.succ ≤ l := by
+            change i.val ≤ l.val at hil
+            have hli' : l.val ≠ i.val := by
+              intro hval
+              apply hli
+              apply Fin.ext
+              exact hval
+            change i.val + 1 ≤ l.val
+            omega
+          exact ih l hsucc
+  change w j = v j
+  exact (show P j from hP j) j j.le_refl
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- realize proper faces by their barycenters and extend affinely over flags
- prove the affine flag map is permutation equivariant
- sort boundary coordinates into strict proper-face flags with exact reconstruction weights
- prove affine injectivity on strict flags and compatibility under common restrictions

This is PR 4 of 7 in the boundary-seven degree-transport stack, stacked on #68.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenOrderedCoordinateFlag SphereSixComplex.Topology.BoundarySevenStrictFlagAffineInjective SphereSixComplex.Topology.BoundarySevenFlagRealizationCommonFace
- Build completed successfully: 3069 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- audited endpoints use only propext, Classical.choice, and Quot.sound