### PR TITLE
Prove the proper-face realization is a homeomorphism

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenProperFaceRealizationBijective.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceRealizationBijective.lean
@@ -1,0 +1,97 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealizationCompact
+public import SphereSixComplex.Topology.BoundarySevenOrderedCoordinateFlag
+public import SphereSixComplex.Topology.BoundarySevenStrictFlagAffineInjective
+
+/-!
+# Point-set properties of the proper-face affine realization
+
+This file records the evaluation of the affine realization on each flag simplex and develops
+the point-set part of the barycentric triangulation of the boundary of the seven-simplex.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits ContinuousMap Opposite Set Simplicial
+
+namespace SphereSixComplex
+
+private theorem toTopSimplex_inv_apply_up_eq_toTopHomeo_symm
+    (n : SimplexCategory) (w : stdSimplex ℝ (Fin (n.len + 1))) :
+    SSet.toTopSimplex.inv.app n (ULift.up w) = n.toTopHomeo.symm w := by
+  rfl
+
+/-- On the realization simplex represented by a flag, the adjointly defined realization map is
+the explicit affine combination of the barycenters of the faces in that flag. -/
+public theorem boundarySevenProperFaceRealizationMap_flag
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    boundarySevenProperFaceRealizationMap
+        (SSet.toTop.map (SSet.yonedaEquiv.symm F)
+          ((SimplexCategory.toTopHomeo (SimplexCategory.mk k)).symm w)) =
+      boundarySevenProperFaceAffineFlagMap k F w := by
+  have h := boundarySevenProperFaceRealizationMap_adjunct
+  have h' := congrArg (fun η ↦ η.app (Opposite.op (SimplexCategory.mk k)) F) h
+  have h'' := congrArg
+    (fun s ↦ (TopCat.toSSetObjEquiv (TopCat.of (StandardSimplexBoundary 7))
+      (Opposite.op (SimplexCategory.mk k))) s) h'
+  have hw := congrArg (fun f ↦ f w) h''
+  change boundarySevenProperFaceRealizationMap
+      (((sSetTopAdj.unit.app BoundarySevenProperFaceNerve).app
+        (Opposite.op (SimplexCategory.mk k)) F).down.hom (ULift.up w)) =
+    boundarySevenProperFaceAffineFlagMap k F w at hw
+  have hunit := sSetTopAdj_unit_app_app_down BoundarySevenProperFaceNerve
+    (Opposite.op (SimplexCategory.mk k)) F
+  have hpoint := ConcreteCategory.congr_hom hunit (ULift.up w)
+  change (((sSetTopAdj.unit.app BoundarySevenProperFaceNerve).app
+      (Opposite.op (SimplexCategory.mk k)) F).down.hom (ULift.up w)) =
+    SSet.toTop.map (SSet.yonedaEquiv.symm F)
+      (SSet.toTopSimplex.inv.app (SimplexCategory.mk k) (ULift.up w)) at hpoint
+  rw [toTopSimplex_inv_apply_up_eq_toTopHomeo_symm] at hpoint
+  rw [hpoint.symm]
+  exact hw
+
+/-- Every point of the proper-face realization is represented on the realization of a
+nondegenerate flag simplex.  This is the point-set covering statement supplied by the
+nonsingular-simplex colimit. -/
+public theorem boundarySevenProperFaceRealization_nondegenerateFlagCovered
+    (x : (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) :
+    ∃ (s : BoundarySevenProperFaceNerve.N)
+      (y : SSet.toTop.obj
+        (SSet.stdSimplex.obj (SimplexCategory.mk s.dim))),
+      SSet.toTop.map (SSet.yonedaEquiv.symm s.simplex) y = x := by
+  letI : BoundarySevenProperFaceNerve.Nonsingular :=
+    boundarySevenProperFaceNerve_nonsingular
+  let cTop := SSet.toTop.mapCocone BoundarySevenProperFaceNerve.coconeN'
+  have hcTop : IsColimit cTop :=
+    isColimitOfPreserves SSet.toTop
+      BoundarySevenProperFaceNerve.isColimitCoconeN'
+  have hcType : IsColimit ((forget TopCat).mapCocone cTop) :=
+    isColimitOfPreserves (forget TopCat) hcTop
+  obtain ⟨s, y, hy⟩ := Types.jointly_surjective_of_isColimit hcType x
+  exact ⟨s, y, hy⟩
+
+/-- The explicit ordered-coordinate flag supplies a preimage of every boundary point. -/
+public theorem boundarySevenProperFaceRealizationMap_surjective :
+    Function.Surjective boundarySevenProperFaceRealizationMap := by
+  intro w
+  refine ⟨SSet.toTop.map
+      (SSet.yonedaEquiv.symm (boundarySevenOrderedFlag w))
+      ((SimplexCategory.toTopHomeo (SimplexCategory.mk 6)).symm
+        (boundarySevenOrderedWeights w)), ?_⟩
+  rw [boundarySevenProperFaceRealizationMap_flag]
+  exact boundarySevenProperFaceAffineFlagMap_orderedFlag w
+
+/-- On every nondegenerate realization simplex, the affine realization has unique simplex
+coordinates. -/
+public theorem boundarySevenProperFaceAffineFlagMap_injective_nondegenerate
+    (s : BoundarySevenProperFaceNerve.N) :
+    Function.Injective
+      (boundarySevenProperFaceAffineFlagMap s.dim s.simplex) := by
+  apply boundarySevenProperFaceAffineFlagMap_injective_of_strictMono
+  exact (PartialOrder.mem_nerve_nonDegenerate_iff_strictMono s.simplex).mp s.2
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceRealizationCompact.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceRealizationCompact.lean
@@ -1,0 +1,53 @@
+module
+
+public import SphereSixComplex.Topology.FiniteSimplicialRealizationCompact
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealization
+
+/-!
+# Compactness of the proper-face realization
+
+The proper-face nerve is the nerve of a finite partial order.  Its realization is therefore
+compact by the finite nonsingular-realization theorem.  This discharges the compactness half of
+the point-set input for the affine barycentric realization.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Simplicial
+
+namespace SphereSixComplex
+
+/-- The proper-face nerve is nonsingular because it is the nerve of a partial order. -/
+public theorem boundarySevenProperFaceNerve_nonsingular :
+    BoundarySevenProperFaceNerve.Nonsingular := by
+  change (CategoryTheory.nerve BoundarySevenProperFace).Nonsingular
+  infer_instance
+
+/-- The proper-face nerve has only finitely many nondegenerate flags. -/
+public theorem boundarySevenProperFaceNerve_finite :
+    BoundarySevenProperFaceNerve.Finite := by
+  change (CategoryTheory.nerve BoundarySevenProperFace).Finite
+  exact finitePartialOrderNerve_finite BoundarySevenProperFace
+
+set_option linter.style.haveILetI false in
+/-- The realization of the finite proper-face nerve is compact. -/
+public theorem boundarySevenProperFaceRealization_isCompact :
+    IsCompact (Set.univ : Set
+      (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) := by
+  letI : BoundarySevenProperFaceNerve.Finite :=
+    boundarySevenProperFaceNerve_finite
+  letI : BoundarySevenProperFaceNerve.Nonsingular :=
+    boundarySevenProperFaceNerve_nonsingular
+  exact finiteNonsingularSSet_realization_isCompact BoundarySevenProperFaceNerve
+
+/-- After compactness is discharged, bijectivity of the explicit affine map is the sole
+remaining point-set input for the proper-face realization homeomorphism. -/
+public theorem boundarySevenProperFaceAffineRealizationHomeomorphismInput_iff_bijective :
+    BoundarySevenProperFaceAffineRealizationHomeomorphismInput ↔
+      Function.Bijective boundarySevenProperFaceRealizationMap := by
+  simp only [BoundarySevenProperFaceAffineRealizationHomeomorphismInput,
+    boundarySevenProperFaceRealization_isCompact, true_and]
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceRealizationInjective.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceRealizationInjective.lean
@@ -1,0 +1,115 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealizationBijective
+public import SphereSixComplex.Topology.BoundarySevenStrictFlagCommonRestrictionProof
+public import SphereSixComplex.Topology.BoundarySevenFlagRealizationCommonFace
+
+/-!
+# Global injectivity of the proper-face affine realization
+
+Nondegenerate flag simplices cover the realization.  Equal affine images of two such
+representatives have a common positive-face restriction, and functoriality of geometric
+realization identifies the two representatives.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory Opposite PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- The affine realization of the proper-face nerve is globally injective. -/
+public theorem boundarySevenProperFaceRealizationMap_injective :
+    Function.Injective boundarySevenProperFaceRealizationMap := by
+  intro x y hxy
+  obtain ⟨s, xs, hxs⟩ :=
+    boundarySevenProperFaceRealization_nondegenerateFlagCovered x
+  obtain ⟨t, yt, hyt⟩ :=
+    boundarySevenProperFaceRealization_nondegenerateFlagCovered y
+  let w : stdSimplex ℝ (Fin (s.dim + 1)) :=
+    SimplexCategory.toTopHomeo (SimplexCategory.mk s.dim) xs
+  let v : stdSimplex ℝ (Fin (t.dim + 1)) :=
+    SimplexCategory.toTopHomeo (SimplexCategory.mk t.dim) yt
+  have hw : (SimplexCategory.toTopHomeo (SimplexCategory.mk s.dim)).symm w = xs :=
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk s.dim)).symm_apply_apply xs
+  have hv : (SimplexCategory.toTopHomeo (SimplexCategory.mk t.dim)).symm v = yt :=
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk t.dim)).symm_apply_apply yt
+  have hF : StrictMono s.simplex.obj :=
+    (PartialOrder.mem_nerve_nonDegenerate_iff_strictMono s.simplex).mp s.2
+  have hG : StrictMono t.simplex.obj :=
+    (PartialOrder.mem_nerve_nonDegenerate_iff_strictMono t.simplex).mp t.2
+  have haffine :
+      boundarySevenProperFaceAffineFlagMap s.dim s.simplex w =
+        boundarySevenProperFaceAffineFlagMap t.dim t.simplex v := by
+    calc
+      boundarySevenProperFaceAffineFlagMap s.dim s.simplex w =
+          boundarySevenProperFaceRealizationMap
+            (SSet.toTop.map (SSet.yonedaEquiv.symm s.simplex)
+              ((SimplexCategory.toTopHomeo
+                (SimplexCategory.mk s.dim)).symm w)) :=
+        (boundarySevenProperFaceRealizationMap_flag s.dim s.simplex w).symm
+      _ = boundarySevenProperFaceRealizationMap
+            (SSet.toTop.map (SSet.yonedaEquiv.symm s.simplex) xs) := by rw [hw]
+      _ = boundarySevenProperFaceRealizationMap x := congrArg
+        boundarySevenProperFaceRealizationMap hxs
+      _ = boundarySevenProperFaceRealizationMap y := hxy
+      _ = boundarySevenProperFaceRealizationMap
+            (SSet.toTop.map (SSet.yonedaEquiv.symm t.simplex) yt) :=
+        congrArg boundarySevenProperFaceRealizationMap hyt.symm
+      _ = boundarySevenProperFaceRealizationMap
+            (SSet.toTop.map (SSet.yonedaEquiv.symm t.simplex)
+              ((SimplexCategory.toTopHomeo
+                (SimplexCategory.mk t.dim)).symm v)) := by rw [hv]
+      _ = boundarySevenProperFaceAffineFlagMap t.dim t.simplex v :=
+        boundarySevenProperFaceRealizationMap_flag t.dim t.simplex v
+  obtain ⟨r, f, g, u, hfu, hgu, hflags⟩ :=
+    boundarySevenStrictFlagCommonRestriction
+      s.dim t.dim s.simplex t.simplex w v hF hG haffine
+  have hrepresentatives := boundarySevenFlagRealization_eq_of_commonRestriction
+    s.simplex t.simplex f g hflags u
+  rw [hfu, hgu, hw, hv] at hrepresentatives
+  exact hxs.symm.trans (hrepresentatives.trans hyt)
+
+/-- The affine realization of the proper-face nerve is bijective. -/
+public theorem boundarySevenProperFaceRealizationMap_bijective :
+    Function.Bijective boundarySevenProperFaceRealizationMap :=
+  ⟨boundarySevenProperFaceRealizationMap_injective,
+    boundarySevenProperFaceRealizationMap_surjective⟩
+
+/-- The compactness-and-bijectivity input for the affine realization homeomorphism is proved
+without additional assumptions. -/
+public theorem boundarySevenProperFaceAffineRealizationHomeomorphismInput_proof :
+    BoundarySevenProperFaceAffineRealizationHomeomorphismInput :=
+  ⟨boundarySevenProperFaceRealization_isCompact,
+    boundarySevenProperFaceRealizationMap_bijective⟩
+
+/-- The unconditional affine barycentric homeomorphism from the proper-face realization to the
+ordinary boundary of the seven-simplex. -/
+public noncomputable def boundarySevenProperFaceRealizationHomeomorph :
+    (SSet.toTop.obj BoundarySevenProperFaceNerve : Type) ≃ₜ
+      StandardSimplexBoundary 7 :=
+  boundarySevenProperFaceRealizationHomeomorph_of_input
+    boundarySevenProperFaceAffineRealizationHomeomorphismInput_proof
+
+@[simp]
+public theorem boundarySevenProperFaceRealizationHomeomorph_apply
+    (x : (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) :
+    boundarySevenProperFaceRealizationHomeomorph x =
+      boundarySevenProperFaceRealizationMap x :=
+  rfl
+
+/-- The unconditional affine barycentric homeomorphism is equivariant for every permutation of
+the eight vertices. -/
+public theorem boundarySevenProperFaceRealizationHomeomorph_equivariant
+    (sigma : Equiv.Perm (Fin 8))
+    (x : (SSet.toTop.obj BoundarySevenProperFaceNerve : Type)) :
+    boundarySevenProperFaceRealizationHomeomorph
+        (SSet.toTop.map (boundarySevenProperFaceNervePermIso sigma).hom x) =
+      standardSimplexBoundaryPermHomeomorph sigma
+        (boundarySevenProperFaceRealizationHomeomorph x) :=
+  boundarySevenProperFaceRealizationHomeomorph_of_input_equivariant
+    boundarySevenProperFaceAffineRealizationHomeomorphismInput_proof sigma x
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenStrictFlagCommonRestrictionProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenStrictFlagCommonRestrictionProof.lean
@@ -1,0 +1,163 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenStrictFlagOverlap
+public import SphereSixComplex.Topology.StandardSimplexPositiveSupport
+
+/-!
+# Common restrictions for equal strict-flag affine presentations
+
+Positive faces are recovered intrinsically from the represented boundary point.  This file
+packages that recovery into an order isomorphism of positive levels and then into a common
+simplicial restriction of the two flag representatives.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- The positive level of `G` whose face equals a specified positive level of `F`. -/
+public noncomputable def boundarySevenStrictFlagPositiveFaceMatch
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (hF : StrictMono F.obj) (hG : StrictMono G.obj)
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v)
+    (j : {j : Fin (k + 1) // 0 < w j}) :
+    {l : Fin (m + 1) // 0 < v l} :=
+  ⟨(boundarySevenStrictFlag_overlap_exists_positive_face_eq
+      k m F G w v hF hG h j.1 j.2).choose,
+    (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+      k m F G w v hF hG h j.1 j.2).choose_spec.1⟩
+
+@[simp]
+public theorem boundarySevenStrictFlagPositiveFaceMatch_face
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (hF : StrictMono F.obj) (hG : StrictMono G.obj)
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v)
+    (j : {j : Fin (k + 1) // 0 < w j}) :
+    F.obj j.1 = G.obj
+      (boundarySevenStrictFlagPositiveFaceMatch k m F G w v hF hG h j).1 :=
+  (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+    k m F G w v hF hG h j.1 j.2).choose_spec.2
+
+/-- Equal strict-flag affine presentations have canonically matched ordered positive levels. -/
+public noncomputable def boundarySevenStrictFlagPositiveFaceOrderIso
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (hF : StrictMono F.obj) (hG : StrictMono G.obj)
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v) :
+    {j : Fin (k + 1) // 0 < w j} ≃o
+      {l : Fin (m + 1) // 0 < v l} where
+  toFun := boundarySevenStrictFlagPositiveFaceMatch k m F G w v hF hG h
+  invFun := boundarySevenStrictFlagPositiveFaceMatch m k G F v w hG hF h.symm
+  left_inv j := by
+    apply Subtype.ext
+    apply hF.injective
+    have hforward := boundarySevenStrictFlagPositiveFaceMatch_face
+      k m F G w v hF hG h j
+    have hbackward := boundarySevenStrictFlagPositiveFaceMatch_face
+      m k G F v w hG hF h.symm
+        (boundarySevenStrictFlagPositiveFaceMatch k m F G w v hF hG h j)
+    exact (hforward.trans hbackward).symm
+  right_inv l := by
+    apply Subtype.ext
+    apply hG.injective
+    have hbackward := boundarySevenStrictFlagPositiveFaceMatch_face
+      m k G F v w hG hF h.symm l
+    have hforward := boundarySevenStrictFlagPositiveFaceMatch_face
+      k m F G w v hF hG h
+        (boundarySevenStrictFlagPositiveFaceMatch m k G F v w hG hF h.symm l)
+    exact (hbackward.trans hforward).symm
+  map_rel_iff' {i j} := by
+    let e := boundarySevenStrictFlagPositiveFaceMatch k m F G w v hF hG h
+    change (e i).1 ≤ (e j).1 ↔ i.1 ≤ j.1
+    calc
+      (e i).1 ≤ (e j).1 ↔ G.obj (e i).1 ≤ G.obj (e j).1 :=
+        hG.le_iff_le.symm
+      _ ↔ F.obj i.1 ≤ F.obj j.1 := by
+        rw [boundarySevenStrictFlagPositiveFaceMatch_face
+          k m F G w v hF hG h i,
+          boundarySevenStrictFlagPositiveFaceMatch_face
+            k m F G w v hF hG h j]
+      _ ↔ i.1 ≤ j.1 := hF.le_iff_le
+
+/-- The proposition-level positive-face matching interface is unconditional. -/
+public theorem boundarySevenStrictFlagPositiveFaceOrderMatching_proof :
+    BoundarySevenStrictFlagPositiveFaceOrderMatching := by
+  intro k m F G w v hF hG h
+  let e := boundarySevenStrictFlagPositiveFaceOrderIso
+    k m F G w v hF hG h
+  refine ⟨e, ?_⟩
+  intro j
+  exact boundarySevenStrictFlagPositiveFaceMatch_face k m F G w v hF hG h j
+
+/-- Equal strict-flag affine presentations are induced from one common positive-face simplex. -/
+public theorem boundarySevenStrictFlagCommonRestriction :
+    BoundarySevenStrictFlagCommonRestriction := by
+  intro k m F G w v hF hG h
+  let r := standardSimplexPositiveSupportDimension w
+  let fw : Fin (r + 1) ↪o Fin (k + 1) :=
+    standardSimplexPositiveSupportIndex w
+  let e := boundarySevenStrictFlagPositiveFaceOrderIso
+    k m F G w v hF hG h
+  let gwFun : Fin (r + 1) → Fin (m + 1) := fun j ↦
+    (e ⟨fw j, standardSimplexPositiveSupportIndex_mem w j⟩).1
+  have hgwFun : StrictMono gwFun := by
+    intro i j hij
+    change (e ⟨fw i, standardSimplexPositiveSupportIndex_mem w i⟩).1 <
+      (e ⟨fw j, standardSimplexPositiveSupportIndex_mem w j⟩).1
+    exact e.strictMono (fw.strictMono hij)
+  let gw : Fin (r + 1) ↪o Fin (m + 1) :=
+    OrderEmbedding.ofStrictMono gwFun hgwFun
+  let f : SimplexCategory.mk r ⟶ SimplexCategory.mk k :=
+    SimplexCategory.mkHom fw.toOrderHom
+  let g : SimplexCategory.mk r ⟶ SimplexCategory.mk m :=
+    SimplexCategory.mkHom gw.toOrderHom
+  let u : stdSimplex ℝ (Fin (r + 1)) :=
+    standardSimplexPositiveSupportCompressed w
+  have hfg : BoundarySevenProperFaceNerve.map f.op F =
+      BoundarySevenProperFaceNerve.map g.op G := by
+    refine ComposableArrows.ext (fun i ↦ ?_) (fun i hi ↦ ?_)
+    · change F.obj (fw i) = G.obj (gw i)
+      exact boundarySevenStrictFlagPositiveFaceMatch_face
+        k m F G w v hF hG h
+          ⟨fw i, standardSimplexPositiveSupportIndex_mem w i⟩
+    · apply Subsingleton.elim
+  have hmapf : stdSimplex.map f u = w := by
+    exact standardSimplex_map_positiveSupportCompressed w
+  have hnatF := congrArg
+    (fun q : C(stdSimplex ℝ (Fin (r + 1)), StandardSimplexBoundary 7) ↦ q u)
+    (boundarySevenProperFaceAffineFlagMap_naturality f F)
+  have hnatG := congrArg
+    (fun q : C(stdSimplex ℝ (Fin (r + 1)), StandardSimplexBoundary 7) ↦ q u)
+    (boundarySevenProperFaceAffineFlagMap_naturality g G)
+  have hmapg : stdSimplex.map g u = v := by
+    apply boundarySevenProperFaceAffineFlagMap_injective_of_strictMono m G hG
+    calc
+      boundarySevenProperFaceAffineFlagMap m G (stdSimplex.map g u) =
+          boundarySevenProperFaceAffineFlagMap r
+            (BoundarySevenProperFaceNerve.map g.op G) u := hnatG.symm
+      _ = boundarySevenProperFaceAffineFlagMap r
+            (BoundarySevenProperFaceNerve.map f.op F) u := by rw [hfg]
+      _ = boundarySevenProperFaceAffineFlagMap k F (stdSimplex.map f u) := hnatF
+      _ = boundarySevenProperFaceAffineFlagMap k F w := by rw [hmapf]
+      _ = boundarySevenProperFaceAffineFlagMap m G v := h
+  exact ⟨r, f, g, u, hmapf, hmapg, hfg⟩
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenStrictFlagOverlap.lean
+++ b/SphereSixComplex/Topology/BoundarySevenStrictFlagOverlap.lean
@@ -1,0 +1,469 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenStrictFlagAffineInjective
+
+/-!
+# Overlap invariants for strict proper-face flags
+
+A positive coefficient at a face in a strict flag produces a genuine gap in the eight affine
+coordinates.  Consequently that face can be recovered from the represented boundary point as
+a superlevel set.  This is the main algebraic uniqueness input for comparing two flag charts.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory ContinuousMap Finset PartialOrder Set Simplicial
+
+namespace SphereSixComplex
+
+/-- Every level of a strict flag has a vertex which first occurs at that level. -/
+public theorem boundarySevenStrictFlag_exists_levelVertex'
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (hF : StrictMono F.obj) (j : Fin (k + 1)) :
+    ∃ a : Fin 8, ∀ l : Fin (k + 1),
+      (a ∈ (F.obj l).1 ↔ j ≤ l) := by
+  refine Fin.cases ?_ (fun i ↦ ?_) j
+  · obtain ⟨a, ha⟩ := (F.obj (0 : Fin (k + 1))).2.1
+    refine ⟨a, fun l ↦ ⟨fun _ ↦ Fin.zero_le l, fun _ ↦ ?_⟩⟩
+    exact leOfHom (F.map (homOfLE (Fin.zero_le l))) ha
+  · have hlt : F.obj i.castSucc < F.obj i.succ := hF i.castSucc_lt_succ
+    have hsub : (F.obj i.castSucc).1 ⊆ (F.obj i.succ).1 := hlt.le
+    have hex : ∃ a, a ∈ (F.obj i.succ).1 ∧ a ∉ (F.obj i.castSucc).1 := by
+      by_contra h
+      push Not at h
+      apply hlt.ne
+      apply Subtype.ext
+      exact Finset.Subset.antisymm hsub (fun a ha ↦ h a ha)
+    obtain ⟨a, haNow, haBefore⟩ := hex
+    refine ⟨a, fun l ↦ ⟨?_, ?_⟩⟩
+    · intro hal
+      by_contra hle
+      have hli : l ≤ i.castSucc := by
+        change ¬ (i.val + 1 ≤ l.val) at hle
+        change l.val ≤ i.val
+        omega
+      exact haBefore (leOfHom (F.map (homOfLE hli)) hal)
+    · intro hil
+      exact leOfHom (F.map (homOfLE hil)) haNow
+
+/-- The contribution at and above a level of a flag. -/
+public noncomputable def boundarySevenStrictFlagTail
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (j : Fin (k + 1)) : ℝ :=
+  ∑ l : Fin (k + 1), if j ≤ l then
+    w l * (((F.obj l).1.card : ℝ)⁻¹) else 0
+
+/-- Coordinate expansion of an affine flag point. -/
+public theorem boundarySevenProperFaceAffineFlagMap_apply_eq_sum
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (a : Fin 8) :
+    (boundarySevenProperFaceAffineFlagMap k F w).1 a =
+      ∑ l : Fin (k + 1),
+        w l * (if a ∈ (F.obj l).1 then
+          (((F.obj l).1.card : ℝ)⁻¹) else 0) := by
+  change (∑ l, w l * boundarySevenProperFaceBarycenter (F.obj l) a) = _
+  simp only [boundarySevenProperFaceBarycenter_apply]
+
+/-- A vertex which first occurs at level `j` has coordinate equal to the tail at `j`. -/
+public theorem boundarySevenStrictFlag_levelVertex_coordinate
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (j : Fin (k + 1))
+    (a : Fin 8) (ha : ∀ l : Fin (k + 1), (a ∈ (F.obj l).1 ↔ j ≤ l)) :
+    (boundarySevenProperFaceAffineFlagMap k F w).1 a =
+      boundarySevenStrictFlagTail k F w j := by
+  rw [boundarySevenProperFaceAffineFlagMap_apply_eq_sum,
+    boundarySevenStrictFlagTail]
+  apply Finset.sum_congr rfl
+  intro l hl
+  by_cases hjl : j ≤ l
+  · simp [hjl, (ha l).mpr hjl]
+  · have hal : a ∉ (F.obj l).1 := fun hal ↦ hjl ((ha l).mp hal)
+    simp [hjl, hal]
+
+/-- Membership in a flag is monotone with the level. -/
+public theorem boundarySevenStrictFlag_obj_mono
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    {i j : Fin (k + 1)} (hij : i ≤ j) :
+    (F.obj i).1 ⊆ (F.obj j).1 :=
+  leOfHom (F.map (homOfLE hij))
+
+/-- If `a` already belongs at level `j`, its coordinate is at least the `j`-tail. -/
+public theorem boundarySevenStrictFlagTail_le_coordinate_of_mem
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (j : Fin (k + 1))
+    (a : Fin 8) (ha : a ∈ (F.obj j).1) :
+    boundarySevenStrictFlagTail k F w j ≤
+      (boundarySevenProperFaceAffineFlagMap k F w).1 a := by
+  rw [boundarySevenStrictFlagTail,
+    boundarySevenProperFaceAffineFlagMap_apply_eq_sum]
+  apply Finset.sum_le_sum
+  intro l hl
+  by_cases hjl : j ≤ l
+  · have hal : a ∈ (F.obj l).1 :=
+      boundarySevenStrictFlag_obj_mono k F hjl ha
+    simp [hjl, hal]
+  · simp only [if_neg hjl]
+    exact mul_nonneg (w.2.1 l) (by positivity)
+
+/-- Outside the level-`j` face the coordinate is strictly below the `j`-tail whenever its
+coefficient is positive. -/
+public theorem boundarySevenStrictFlag_coordinate_lt_tail_of_not_mem
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (j : Fin (k + 1))
+    (a : Fin 8) (ha : a ∉ (F.obj j).1) (hw : 0 < w j) :
+    (boundarySevenProperFaceAffineFlagMap k F w).1 a <
+      boundarySevenStrictFlagTail k F w j := by
+  rw [boundarySevenStrictFlagTail,
+    boundarySevenProperFaceAffineFlagMap_apply_eq_sum]
+  apply Finset.sum_lt_sum
+  · intro l hl
+    by_cases hal : a ∈ (F.obj l).1
+    · have hjl : j ≤ l := by
+        by_contra h
+        have hlj : l ≤ j := le_of_not_ge h
+        exact ha (boundarySevenStrictFlag_obj_mono k F hlj hal)
+      simp [hal, hjl]
+    · by_cases hjl : j ≤ l
+      · simp only [if_neg hal, if_pos hjl, mul_zero]
+        exact mul_nonneg (w.2.1 l) (by positivity)
+      · simp [hal, hjl]
+  · refine ⟨j, Finset.mem_univ _, ?_⟩
+    rw [if_neg ha, if_pos le_rfl]
+    simp only [mul_zero]
+    have hcard : 0 < (((F.obj j).1.card : ℝ)⁻¹) := by
+      apply inv_pos.mpr
+      exact_mod_cast (F.obj j).2.1.card_pos
+    exact mul_pos hw hcard
+
+/-- A positive-weight face is recovered intrinsically as a superlevel set of the represented
+point. -/
+public theorem boundarySevenStrictFlag_face_eq_superlevel
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (j : Fin (k + 1))
+    (hw : 0 < w j) :
+    (F.obj j).1 = Finset.univ.filter (fun a : Fin 8 ↦
+      boundarySevenStrictFlagTail k F w j ≤
+        (boundarySevenProperFaceAffineFlagMap k F w).1 a) := by
+  ext a
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  constructor
+  · exact boundarySevenStrictFlagTail_le_coordinate_of_mem k F w j a
+  · intro hcoord
+    by_contra ha
+    exact (not_lt_of_ge hcoord)
+      (boundarySevenStrictFlag_coordinate_lt_tail_of_not_mem k F w j a ha hw)
+
+/-- A positive coefficient makes its tail strictly positive. -/
+public theorem boundarySevenStrictFlagTail_pos
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) (j : Fin (k + 1))
+    (hw : 0 < w j) :
+    0 < boundarySevenStrictFlagTail k F w j := by
+  rw [boundarySevenStrictFlagTail]
+  apply (Finset.sum_pos_iff_of_nonneg (s := Finset.univ) ?_).mpr
+  · refine ⟨j, Finset.mem_univ _, ?_⟩
+    rw [if_pos le_rfl]
+    apply mul_pos hw
+    apply inv_pos.mpr
+    exact_mod_cast (F.obj j).2.1.card_pos
+  · intro l hl
+    split_ifs
+    · exact mul_nonneg (w.2.1 l) (by positivity)
+    · exact le_rfl
+
+/-- A positive face in one strict presentation occurs as a positive face in any other equal
+strict presentation.  Zero coefficients in the second flag are skipped by taking the first
+positive level at or above the first occurrence of a suitable level vertex. -/
+public theorem boundarySevenStrictFlag_overlap_exists_positive_face_eq
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (hF : StrictMono F.obj) (_hG : StrictMono G.obj)
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v)
+    (j : Fin (k + 1)) (hj : 0 < w j) :
+    ∃ l : Fin (m + 1), 0 < v l ∧ F.obj j = G.obj l := by
+  obtain ⟨a, haF⟩ := boundarySevenStrictFlag_exists_levelVertex' k F hF j
+  have haFcoord := boundarySevenStrictFlag_levelVertex_coordinate k F w j a haF
+  have hcoord :
+      (boundarySevenProperFaceAffineFlagMap m G v).1 a =
+        boundarySevenStrictFlagTail k F w j := by
+    rw [← haFcoord]
+    exact congrArg (fun z : StandardSimplexBoundary 7 ↦ z.1 a) h.symm
+  have hcoordpos : 0 < (boundarySevenProperFaceAffineFlagMap m G v).1 a := by
+    rw [hcoord]
+    exact boundarySevenStrictFlagTail_pos k F w j hj
+  let s : Finset (Fin (m + 1)) :=
+    Finset.univ.filter (fun l ↦ a ∈ (G.obj l).1)
+  have hs : s.Nonempty := by
+    by_contra hs0
+    have hnone : ∀ l : Fin (m + 1), a ∉ (G.obj l).1 := by
+      intro l hal
+      apply hs0
+      exact ⟨l, by simp [s, hal]⟩
+    rw [boundarySevenProperFaceAffineFlagMap_apply_eq_sum] at hcoordpos
+    simp [hnone] at hcoordpos
+  let q : Fin (m + 1) := s.min' hs
+  have hqmem : a ∈ (G.obj q).1 := by
+    have := s.min'_mem hs
+    simpa [s, q] using this
+  have haG : ∀ l : Fin (m + 1), (a ∈ (G.obj l).1 ↔ q ≤ l) := by
+    intro l
+    constructor
+    · intro hal
+      apply Finset.min'_le s l
+      simp [s, hal]
+    · intro hql
+      exact boundarySevenStrictFlag_obj_mono m G hql hqmem
+  have hqcoord := boundarySevenStrictFlag_levelVertex_coordinate m G v q a haG
+  have htailqpos : 0 < boundarySevenStrictFlagTail m G v q := by
+    rw [← hqcoord]
+    exact hcoordpos
+  let pset : Finset (Fin (m + 1)) :=
+    Finset.univ.filter (fun l ↦ q ≤ l ∧ 0 < v l)
+  have hpset : pset.Nonempty := by
+    rw [boundarySevenStrictFlagTail] at htailqpos
+    have hex := (Finset.sum_pos_iff_of_nonneg (s := Finset.univ) (fun l hl ↦ by
+      split_ifs
+      · exact mul_nonneg (v.2.1 l)
+          (inv_nonneg.mpr (Nat.cast_nonneg _))
+      · exact le_rfl)).mp htailqpos
+    obtain ⟨l, hl, hlpos⟩ := hex
+    have hql : q ≤ l := by
+      by_contra hql
+      simp [hql] at hlpos
+    have hvl : 0 < v l := by
+      rw [if_pos hql] at hlpos
+      rcases mul_pos_iff.mp hlpos with hpos | hneg
+      · exact hpos.1
+      · exact (not_lt_of_ge (v.2.1 l) hneg.1).elim
+    exact ⟨l, by simp [pset, hql, hvl]⟩
+  let p : Fin (m + 1) := pset.min' hpset
+  have hpdata : q ≤ p ∧ 0 < v p := by
+    have := pset.min'_mem hpset
+    simpa [pset, p] using this
+  have htailqp : boundarySevenStrictFlagTail m G v q =
+      boundarySevenStrictFlagTail m G v p := by
+    rw [boundarySevenStrictFlagTail, boundarySevenStrictFlagTail]
+    apply Finset.sum_congr rfl
+    intro l hl
+    by_cases hpl : p ≤ l
+    · simp [hpl, hpdata.1.trans hpl]
+    · by_cases hql : q ≤ l
+      · have hvlnpos : ¬ 0 < v l := by
+          intro hvl
+          have hlmem : l ∈ pset := by simp [pset, hql, hvl]
+          exact hpl (Finset.min'_le pset l hlmem)
+        have hvl0 : v l = 0 := le_antisymm (le_of_not_gt hvlnpos) (v.2.1 l)
+        simp [hql, hpl, hvl0]
+      · simp [hql, hpl]
+  refine ⟨p, hpdata.2, ?_⟩
+  apply Subtype.ext
+  have htails : boundarySevenStrictFlagTail k F w j =
+      boundarySevenStrictFlagTail m G v p := by
+    rw [← htailqp, ← hqcoord, hcoord]
+  rw [boundarySevenStrictFlag_face_eq_superlevel k F w j hj,
+    boundarySevenStrictFlag_face_eq_superlevel m G v p hpdata.2]
+  apply Finset.filter_congr
+  intro x hx
+  rw [htails]
+  rw [congrArg (fun z : StandardSimplexBoundary 7 ↦ z.1 x) h]
+
+/-- Cross-flag invariant: under equality of affine points, every positive face of either flag is
+literally a coordinate superlevel set of the common point. -/
+public theorem boundarySevenStrictFlag_overlap_positive_faces_superlevel
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v) :
+    (∀ j, 0 < w j →
+      (F.obj j).1 = Finset.univ.filter (fun a : Fin 8 ↦
+        boundarySevenStrictFlagTail k F w j ≤
+          (boundarySevenProperFaceAffineFlagMap m G v).1 a)) ∧
+    (∀ l, 0 < v l →
+      (G.obj l).1 = Finset.univ.filter (fun a : Fin 8 ↦
+        boundarySevenStrictFlagTail m G v l ≤
+          (boundarySevenProperFaceAffineFlagMap k F w).1 a)) := by
+  constructor
+  · intro j hj
+    rw [boundarySevenStrictFlag_face_eq_superlevel k F w j hj, h]
+  · intro l hl
+    rw [boundarySevenStrictFlag_face_eq_superlevel m G v l hl, ← h]
+
+/-- Positive faces occurring in two equal affine strict-flag presentations are comparable.
+This proves that their union is again a chain, the finite-order fact needed to construct a
+common refinement. -/
+public theorem boundarySevenStrictFlag_overlap_positive_faces_comparable
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v)
+    (j : Fin (k + 1)) (l : Fin (m + 1))
+    (hj : 0 < w j) (hl : 0 < v l) :
+    F.obj j ≤ G.obj l ∨ G.obj l ≤ F.obj j := by
+  have hF := boundarySevenStrictFlag_face_eq_superlevel k F w j hj
+  have hG := boundarySevenStrictFlag_face_eq_superlevel m G v l hl
+  have hcoord (a : Fin 8) :
+      (boundarySevenProperFaceAffineFlagMap k F w).1 a =
+        (boundarySevenProperFaceAffineFlagMap m G v).1 a :=
+    congrArg (fun z : StandardSimplexBoundary 7 ↦ z.1 a) h
+  rcases le_total (boundarySevenStrictFlagTail k F w j)
+      (boundarySevenStrictFlagTail m G v l) with htail | htail
+  · right
+    change (G.obj l).1 ⊆ (F.obj j).1
+    rw [hF, hG]
+    intro a ha
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at ha ⊢
+    rw [hcoord a]
+    exact htail.trans ha
+  · left
+    change (F.obj j).1 ⊆ (G.obj l).1
+    rw [hF, hG]
+    intro a ha
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at ha ⊢
+    rw [← hcoord a]
+    exact htail.trans ha
+
+/-- The positive levels in two equal strict-flag presentations are order-isomorphic, and the
+isomorphism matches literally equal faces. -/
+public theorem boundarySevenStrictFlag_overlap_positiveFaceOrderIso
+    (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1)))
+    (hF : StrictMono F.obj) (hG : StrictMono G.obj)
+    (h : boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v) :
+    ∃ e : {j : Fin (k + 1) // 0 < w j} ≃o
+        {l : Fin (m + 1) // 0 < v l},
+      ∀ j, F.obj j.1 = G.obj (e j).1 := by
+  let matchFG : {j : Fin (k + 1) // 0 < w j} →
+      {l : Fin (m + 1) // 0 < v l} := fun j ↦
+    ⟨Classical.choose
+      (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+        k m F G w v hF hG h j.1 j.2),
+      (Classical.choose_spec
+        (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+          k m F G w v hF hG h j.1 j.2)).1⟩
+  have hmatchFG (j : {j : Fin (k + 1) // 0 < w j}) :
+      F.obj j.1 = G.obj (matchFG j).1 :=
+    (Classical.choose_spec
+      (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+        k m F G w v hF hG h j.1 j.2)).2
+  let matchGF : {l : Fin (m + 1) // 0 < v l} →
+      {j : Fin (k + 1) // 0 < w j} := fun l ↦
+    ⟨Classical.choose
+      (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+        m k G F v w hG hF h.symm l.1 l.2),
+      (Classical.choose_spec
+        (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+          m k G F v w hG hF h.symm l.1 l.2)).1⟩
+  have hmatchGF (l : {l : Fin (m + 1) // 0 < v l}) :
+      G.obj l.1 = F.obj (matchGF l).1 :=
+    (Classical.choose_spec
+      (boundarySevenStrictFlag_overlap_exists_positive_face_eq
+        m k G F v w hG hF h.symm l.1 l.2)).2
+  have hFGGF (l : {l : Fin (m + 1) // 0 < v l}) :
+      matchFG (matchGF l) = l := by
+    apply Subtype.ext
+    apply hG.injective
+    exact (hmatchFG (matchGF l)).symm.trans (hmatchGF l).symm
+  have hGFFG (j : {j : Fin (k + 1) // 0 < w j}) :
+      matchGF (matchFG j) = j := by
+    apply Subtype.ext
+    apply hF.injective
+    exact (hmatchGF (matchFG j)).symm.trans (hmatchFG j).symm
+  have hmonoFG : Monotone matchFG := by
+    intro i j hij
+    apply (OrderEmbedding.ofStrictMono G.obj hG).le_iff_le.mp
+    change G.obj (matchFG i).1 ≤ G.obj (matchFG j).1
+    rw [← hmatchFG i, ← hmatchFG j]
+    exact hF.monotone hij
+  have hmonoGF : Monotone matchGF := by
+    intro i j hij
+    apply (OrderEmbedding.ofStrictMono F.obj hF).le_iff_le.mp
+    change F.obj (matchGF i).1 ≤ F.obj (matchGF j).1
+    rw [← hmatchGF i, ← hmatchGF j]
+    exact hG.monotone hij
+  let f : {j : Fin (k + 1) // 0 < w j} →o
+      {l : Fin (m + 1) // 0 < v l} := ⟨matchFG, hmonoFG⟩
+  let g : {l : Fin (m + 1) // 0 < v l} →o
+      {j : Fin (k + 1) // 0 < w j} := ⟨matchGF, hmonoGF⟩
+  let e := OrderIso.ofHomInv f g (by
+    ext l
+    exact congrArg (fun z ↦ z.1.1) (hFGGF l)) (by
+    ext j
+    exact congrArg (fun z ↦ z.1.1) (hGFFG j))
+  exact ⟨e, fun j ↦ hmatchFG j⟩
+
+/-- Exact remaining finite-order packaging: the positive levels of two equal strict-flag
+representations must be matched, in order, by equality of their recovered superlevel faces. -/
+public def BoundarySevenStrictFlagPositiveFaceOrderMatching : Prop :=
+  ∀ (k m : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace m)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (m + 1))),
+    StrictMono F.obj → StrictMono G.obj →
+    boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap m G v →
+    ∃ e : {j : Fin (k + 1) // 0 < w j} ≃o
+        {l : Fin (m + 1) // 0 < v l},
+      ∀ j, F.obj j.1 = G.obj (e j).1
+
+public theorem boundarySevenStrictFlagPositiveFaceOrderMatching :
+    BoundarySevenStrictFlagPositiveFaceOrderMatching := by
+  intro k m F G w v hF hG h
+  exact boundarySevenStrictFlag_overlap_positiveFaceOrderIso
+    k m F G w v hF hG h
+
+/-- Deleting the zero coordinates of a simplex preserves total mass. -/
+public theorem stdSimplex_sum_positive_subtype
+    {n : ℕ} (w : stdSimplex ℝ (Fin (n + 1))) :
+    ∑ j : {j : Fin (n + 1) // 0 < w j}, w j.1 = 1 := by
+  calc
+    _ = ∑ j ∈ Finset.univ.filter (fun j : Fin (n + 1) ↦ 0 < w j), w j := by
+      symm
+      apply Finset.sum_subtype
+      intro j
+      simp
+    _ = ∑ j : Fin (n + 1), w j := by
+      rw [Finset.sum_filter]
+      apply Finset.sum_congr rfl
+      intro j hj
+      by_cases hpos : 0 < w j
+      · simp [hpos]
+      · have hz : w j = 0 := le_antisymm (le_of_not_gt hpos) (w.2.1 j)
+        simp [hz]
+    _ = 1 := w.2.2
+
+/-- The exact common-restriction endpoint consumed by geometric-realization functoriality. -/
+public def BoundarySevenStrictFlagCommonRestriction : Prop :=
+  ∀ (k l : ℕ)
+    (F : ComposableArrows BoundarySevenProperFace k)
+    (G : ComposableArrows BoundarySevenProperFace l)
+    (w : stdSimplex ℝ (Fin (k + 1)))
+    (v : stdSimplex ℝ (Fin (l + 1))),
+    StrictMono F.obj → StrictMono G.obj →
+    boundarySevenProperFaceAffineFlagMap k F w =
+      boundarySevenProperFaceAffineFlagMap l G v →
+    ∃ (r : ℕ) (f : SimplexCategory.mk r ⟶ SimplexCategory.mk k)
+      (g : SimplexCategory.mk r ⟶ SimplexCategory.mk l)
+      (u : stdSimplex ℝ (Fin (r + 1))),
+      stdSimplex.map f u = w ∧
+      stdSimplex.map g u = v ∧
+      BoundarySevenProperFaceNerve.map f.op F =
+        BoundarySevenProperFaceNerve.map g.op G
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/FiniteSimplicialRealizationCompact.lean
+++ b/SphereSixComplex/Topology/FiniteSimplicialRealizationCompact.lean
@@ -1,0 +1,96 @@
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.Finite
+public import Mathlib.AlgebraicTopology.SimplicialSet.NonsingularColimit
+public import Mathlib.AlgebraicTopology.SimplicialSet.TopAdj
+
+/-!
+# Compactness of finite nonsingular simplicial realizations
+
+A finite nonsingular simplicial set is a finite colimit of its nondegenerate standard
+simplices.  Geometric realization preserves that colimit, so its underlying space is a finite
+union of continuous images of compact topological simplices.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The nerve of a finite partially ordered type has dimension strictly less than the
+cardinality of that type. -/
+public theorem finitePartialOrderNerve_hasDimensionLT
+    (T : Type) [PartialOrder T] [Fintype T] :
+    (CategoryTheory.nerve T).HasDimensionLT (Fintype.card T) := by
+  constructor
+  intro n hn
+  ext s
+  simp only [Set.top_eq_univ, Set.mem_univ, iff_true]
+  by_contra hs
+  have hs' : s ∈ (CategoryTheory.nerve T).nonDegenerate n := by
+    simpa [SSet.mem_degenerate_iff_notMem_nonDegenerate] using hs
+  have hinj : Function.Injective s.obj :=
+    (PartialOrder.mem_nerve_nonDegenerate_iff_injective s).mp hs'
+  have hcard : n + 1 ≤ Fintype.card T := by
+    simpa using Fintype.card_le_of_injective _ hinj
+  omega
+
+set_option linter.style.haveILetI false in
+/-- The nerve of a finite partially ordered type is a finite simplicial set. -/
+public theorem finitePartialOrderNerve_finite
+    (T : Type) [PartialOrder T] [Finite T] :
+    (CategoryTheory.nerve T).Finite := by
+  letI : Fintype T := Fintype.ofFinite T
+  letI : (CategoryTheory.nerve T).HasDimensionLT (Fintype.card T) :=
+    finitePartialOrderNerve_hasDimensionLT T
+  exact SSet.finite_of_hasDimensionLT (CategoryTheory.nerve T)
+    (Fintype.card T) (fun i _ ↦ by
+      letI : Finite (ComposableArrows T i) := by
+        apply Finite.of_injective
+          (fun F : ComposableArrows T i ↦ fun j ↦ F.obj j)
+        intro F G h
+        apply ComposableArrows.ext (fun j ↦ congrFun h j)
+        intro j hj
+        subsingleton
+      letI : Finite ((CategoryTheory.nerve T).obj
+          (Opposite.op (SimplexCategory.mk i))) := by
+        change Finite (ComposableArrows T i)
+        infer_instance
+      exact Finite.of_injective Subtype.val Subtype.val_injective)
+
+/-- The geometric realization of a finite nonsingular simplicial set is compact. -/
+public theorem finiteNonsingularSSet_realization_isCompact
+    (X : SSet.{0}) [X.Finite] [X.Nonsingular] :
+    IsCompact (Set.univ : Set (SSet.toTop.obj X : Type)) := by
+  let cTop := SSet.toTop.mapCocone X.coconeN'
+  have hcTop : IsColimit cTop :=
+    isColimitOfPreserves SSet.toTop X.isColimitCoconeN'
+  have hcType : IsColimit ((forget TopCat).mapCocone cTop) :=
+    isColimitOfPreserves (forget TopCat) hcTop
+  have hcover :
+      (Set.univ : Set (SSet.toTop.obj X : Type)) =
+        ⋃ s : X.N, Set.range (cTop.ι.app s) := by
+    apply (Set.eq_univ_of_forall _).symm
+    intro x
+    obtain ⟨s, y, hy⟩ := Types.jointly_surjective_of_isColimit hcType x
+    exact Set.mem_iUnion.mpr ⟨s, ⟨y, hy⟩⟩
+  rw [hcover]
+  apply isCompact_iUnion
+  intro s
+  have hdomain : IsCompact
+      (Set.univ : Set (SSet.toTop.obj (X.functorN'.obj s) : Type)) := by
+    change IsCompact (Set.univ : Set (SSet.toTop.obj (SSet.stdSimplex.obj
+      (SemiSimplexCategory.toSimplexCategory.obj
+        ((SSet.N.toSemiSimplexCategory X).obj s))) : Type))
+    let e := SimplexCategory.toTopHomeo
+      (SemiSimplexCategory.toSimplexCategory.obj
+        ((SSet.N.toSemiSimplexCategory X).obj s))
+    exact e.isCompact_preimage.mpr isCompact_univ
+  have himage := hdomain.image (cTop.ι.app s).hom.continuous
+  change IsCompact (Set.range (cTop.ι.app s))
+  simpa only [Set.image_univ] using himage
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StandardSimplexPositiveSupport.lean
+++ b/SphereSixComplex/Topology/StandardSimplexPositiveSupport.lean
@@ -1,0 +1,199 @@
+module
+
+public import Mathlib.AlgebraicTopology.TopologicalSimplex
+public import Mathlib.Data.Finset.Sort
+
+/-!
+# Positive-support compression for a standard simplex
+
+Every point of a finite real standard simplex is the image of a point with strictly positive
+coordinates on a uniquely ordered list of its positive coordinates.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Set
+
+namespace SphereSixComplex
+
+/-- The finite set of coordinates at which a standard-simplex point is strictly positive. -/
+public def standardSimplexPositiveSupport {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) : Finset (Fin (n + 1)) :=
+  Finset.univ.filter fun i ↦ 0 < w i
+
+@[simp]
+public theorem mem_standardSimplexPositiveSupport_iff {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) (i : Fin (n + 1)) :
+    i ∈ standardSimplexPositiveSupport w ↔ 0 < w i := by
+  simp [standardSimplexPositiveSupport]
+
+/-- A standard-simplex point has at least one strictly positive coordinate. -/
+public theorem standardSimplexPositiveSupport_nonempty {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    (standardSimplexPositiveSupport w).Nonempty := by
+  by_contra h
+  rw [Finset.not_nonempty_iff_eq_empty] at h
+  have hzero : ∀ i, w i = 0 := by
+    intro i
+    have hnpos : ¬ 0 < w i := by
+      intro hi
+      have : i ∈ standardSimplexPositiveSupport w :=
+        (mem_standardSimplexPositiveSupport_iff w i).2 hi
+      rw [h] at this
+      simp at this
+    exact le_antisymm (le_of_not_gt hnpos) (w.2.1 i)
+  have hsum : (∑ i, w i) = 0 := Finset.sum_eq_zero fun i _ ↦ hzero i
+  have hone : (1 : ℝ) = 0 := w.2.2.symm.trans hsum
+  norm_num at hone
+
+/-- The dimension of the simplex spanned by the positive support. -/
+public def standardSimplexPositiveSupportDimension {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) : ℕ :=
+  (standardSimplexPositiveSupport w).card - 1
+
+/-- The positive support has one more vertex than its dimension. -/
+public theorem standardSimplexPositiveSupport_card {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    (standardSimplexPositiveSupport w).card =
+      standardSimplexPositiveSupportDimension w + 1 := by
+  unfold standardSimplexPositiveSupportDimension
+  exact (Nat.sub_add_cancel (standardSimplexPositiveSupport_nonempty w).card_pos).symm
+
+/-- The increasing enumeration of the positive coordinates. -/
+public noncomputable def standardSimplexPositiveSupportIndex {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    Fin (standardSimplexPositiveSupportDimension w + 1) ↪o Fin (n + 1) :=
+  (standardSimplexPositiveSupport w).orderEmbOfFin
+    (standardSimplexPositiveSupport_card w)
+
+/-- The ordered positive-support enumeration is strictly increasing. -/
+public theorem standardSimplexPositiveSupportIndex_strictMono {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    StrictMono (standardSimplexPositiveSupportIndex w) :=
+  (standardSimplexPositiveSupportIndex w).strictMono
+
+/-- The ordered positive-support enumeration is injective. -/
+public theorem standardSimplexPositiveSupportIndex_injective {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    Function.Injective (standardSimplexPositiveSupportIndex w) :=
+  (standardSimplexPositiveSupportIndex w).injective
+
+@[simp]
+public theorem standardSimplexPositiveSupportIndex_mem {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1)))
+    (j : Fin (standardSimplexPositiveSupportDimension w + 1)) :
+    0 < w (standardSimplexPositiveSupportIndex w j) := by
+  rw [← mem_standardSimplexPositiveSupport_iff]
+  exact Finset.orderEmbOfFin_mem _ _ _
+
+/-- The increasing enumeration has exactly the positive coordinates as its range. -/
+public theorem range_standardSimplexPositiveSupportIndex {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    Set.range (standardSimplexPositiveSupportIndex w) = {i | 0 < w i} := by
+  rw [standardSimplexPositiveSupportIndex, Finset.range_orderEmbOfFin]
+  ext i
+  simp
+
+/-- A coordinate is positive exactly when it occurs in the ordered support enumeration. -/
+public theorem exists_standardSimplexPositiveSupportIndex_iff {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) (i : Fin (n + 1)) :
+    (∃ j, standardSimplexPositiveSupportIndex w j = i) ↔ 0 < w i := by
+  change i ∈ Set.range (standardSimplexPositiveSupportIndex w) ↔ 0 < w i
+  rw [range_standardSimplexPositiveSupportIndex]
+  rfl
+
+/-- The simplex point obtained by retaining precisely the positive coordinates. -/
+public noncomputable def standardSimplexPositiveSupportCompressed {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    stdSimplex ℝ (Fin (standardSimplexPositiveSupportDimension w + 1)) := by
+  let s := standardSimplexPositiveSupport w
+  let hcard := standardSimplexPositiveSupport_card w
+  let e : Fin (standardSimplexPositiveSupportDimension w + 1) ≃o s :=
+    s.orderIsoOfFin hcard
+  refine ⟨fun j ↦ w (e j), fun j ↦ w.2.1 _, ?_⟩
+  calc
+    (∑ j, w (e j)) = ∑ i : s, w i := by
+      change (∑ j, w (e.toEquiv j)) = ∑ i : s, w i
+      exact Equiv.sum_comp e.toEquiv (fun i : s ↦ w i)
+    _ = ∑ i ∈ s, w i := Finset.sum_coe_sort s (fun i ↦ w i)
+    _ = ∑ i, w i := by
+      apply Finset.sum_subset (Finset.subset_univ s)
+      intro i _ hi
+      have hnpos : ¬ 0 < w i := by
+        simpa [s, standardSimplexPositiveSupport] using hi
+      exact le_antisymm (le_of_not_gt hnpos) (w.2.1 i)
+    _ = 1 := w.2.2
+
+@[simp]
+public theorem standardSimplexPositiveSupportCompressed_apply {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1)))
+    (j : Fin (standardSimplexPositiveSupportDimension w + 1)) :
+    standardSimplexPositiveSupportCompressed w j =
+      w (standardSimplexPositiveSupportIndex w j) := by
+  rfl
+
+/-- Every coordinate of the compressed simplex point is strictly positive. -/
+public theorem standardSimplexPositiveSupportCompressed_pos {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1)))
+    (j : Fin (standardSimplexPositiveSupportDimension w + 1)) :
+    0 < standardSimplexPositiveSupportCompressed w j := by
+  rw [standardSimplexPositiveSupportCompressed_apply]
+  exact standardSimplexPositiveSupportIndex_mem w j
+
+/-- Expanding the compressed point along its ordered positive support recovers the original
+standard-simplex point. -/
+public theorem standardSimplex_map_positiveSupportCompressed {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    stdSimplex.map (standardSimplexPositiveSupportIndex w)
+        (standardSimplexPositiveSupportCompressed w) = w := by
+  apply stdSimplex.ext
+  funext i
+  classical
+  by_cases hi : 0 < w i
+  · have hirange : i ∈ Set.range (standardSimplexPositiveSupportIndex w) := by
+      rw [range_standardSimplexPositiveSupportIndex]
+      exact hi
+    obtain ⟨j, hj⟩ := hirange
+    subst i
+    simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply,
+      (standardSimplexPositiveSupportIndex w).injective.eq_iff]
+    rw [Finset.sum_eq_single j]
+    · exact standardSimplexPositiveSupportCompressed_apply w j
+    · simp
+    · simp
+  · have hwi : w i = 0 := le_antisymm (le_of_not_gt hi) (w.2.1 i)
+    simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
+    rw [Finset.sum_eq_zero]
+    · exact hwi.symm
+    · intro j hj
+      have hne : standardSimplexPositiveSupportIndex w j ≠ i := by
+        intro h
+        apply hi
+        simpa [h] using standardSimplexPositiveSupportIndex_mem w j
+      simp only [Finset.mem_filter] at hj
+      exact (hne hj.2).elim
+
+/-- Fully packaged positive-support compression data. -/
+public structure StandardSimplexPositiveSupportData {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) where
+  dimension : ℕ
+  index : Fin (dimension + 1) ↪o Fin (n + 1)
+  index_range : Set.range index = {i | 0 < w i}
+  compressed : stdSimplex ℝ (Fin (dimension + 1))
+  compressed_pos : ∀ j, 0 < compressed j
+  map_compressed : stdSimplex.map index compressed = w
+
+/-- Canonical packaged positive-support compression of a standard-simplex point. -/
+public noncomputable def standardSimplexPositiveSupportData {n : ℕ}
+    (w : stdSimplex ℝ (Fin (n + 1))) :
+    StandardSimplexPositiveSupportData w where
+  dimension := standardSimplexPositiveSupportDimension w
+  index := standardSimplexPositiveSupportIndex w
+  index_range := range_standardSimplexPositiveSupportIndex w
+  compressed := standardSimplexPositiveSupportCompressed w
+  compressed_pos := standardSimplexPositiveSupportCompressed_pos w
+  map_compressed := standardSimplex_map_positiveSupportCompressed w
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- prove compactness for finite nonsingular simplicial realizations
- delete zero coordinates and compare overlapping strict flag presentations
- construct common simplicial restrictions for equal affine points
- prove the proper-face affine realization is globally bijective
- upgrade it to a permutation-equivariant homeomorphism

This is PR 5 of 7 in the boundary-seven degree-transport stack, stacked on #69.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenProperFaceRealizationInjective
- Build completed successfully: 3081 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- audited endpoints use only propext, Classical.choice, and Quot.sound