### PR TITLE
Normalize and transport the boundary-seven generator

### DIFF
--- a/SphereSixComplex/Topology/BoundarySevenNormalizedGeneratorHomology.lean
+++ b/SphereSixComplex/Topology/BoundarySevenNormalizedGeneratorHomology.lean
@@ -1,0 +1,169 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorNormalization
+public import SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorTransportPrelude
+
+/-!
+# The normalized boundary-seven generator in simplicial homology
+
+This file packages the previously constructed normalization and top-cycle isomorphisms into an
+explicit orientation of unnormalized simplicial homology.  It also verifies that the intrinsic
+alternating facet chain represents the positive generator for that orientation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+public noncomputable abbrev BoundarySevenUnnormalizedIntegralChains :
+    ChainComplex AddCommGrpCat ℕ :=
+  (∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)
+
+/-- The canonical composite identifying unnormalized degree-six simplicial homology of
+`∂Δ[7]` with `ℤ`: normalize, identify normalized homology with its top cycle kernel,
+and use the orientation coming from the unique normalized seven-simplex of `Δ[7]`. -/
+public noncomputable def boundarySevenSimplicialHomologySixIsoInt :
+    BoundarySevenUnnormalizedIntegralChains.homology 6 ≅ AddCommGrpCat.of ℤ := by
+  let _ : QuasiIso ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+      (AddCommGrpCat.of ℤ)) := inferInstance
+  exact isoOfQuasiIsoAt
+      ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+        (AddCommGrpCat.of ℤ)) 6 ≪≫
+    boundarySeven_normalizedHomologySixIsoTopCycles ≪≫
+    boundarySevenTopCyclesIsoStandardSevenTopCycles ≪≫
+    standardSevenTopCyclesIsoInt
+
+/-- The explicit additive equivalence underlying
+`boundarySevenSimplicialHomologySixIsoInt`. -/
+public noncomputable def boundarySevenSimplicialHomologySixAddEquivInt :
+    BoundarySevenUnnormalizedIntegralChains.homology 6 ≃+ ℤ :=
+  boundarySevenSimplicialHomologySixIsoInt.addCommGroupIsoToAddEquiv
+
+/-- The intrinsic alternating facet chain, lifted to the cycle object of the unnormalized
+simplicial chain complex. -/
+public noncomputable def boundarySevenOriginalFundamentalCycle :
+    AddCommGrpCat.of ℤ ⟶ BoundarySevenUnnormalizedIntegralChains.cycles 6 :=
+  BoundarySevenUnnormalizedIntegralChains.liftCycles
+    boundarySevenOriginalFundamentalChain 5 (by simp)
+      boundarySevenOriginalFundamentalChain_isCycle
+
+@[reassoc (attr := simp)]
+public theorem boundarySevenOriginalFundamentalCycle_iCycles :
+    boundarySevenOriginalFundamentalCycle ≫
+        BoundarySevenUnnormalizedIntegralChains.iCycles 6 =
+      boundarySevenOriginalFundamentalChain := by
+  rw [boundarySevenOriginalFundamentalCycle]
+  apply HomologicalComplex.liftCycles_i
+
+/-- The homology class represented by the intrinsic alternating facet chain. -/
+public noncomputable def boundarySevenOriginalFundamentalHomologyClass :
+    AddCommGrpCat.of ℤ ⟶ BoundarySevenUnnormalizedIntegralChains.homology 6 :=
+  boundarySevenOriginalFundamentalCycle ≫
+    BoundarySevenUnnormalizedIntegralChains.homologyπ 6
+
+/-- A degree-six cycle followed by the standard homology--cycle-kernel composite is the
+corresponding kernel element when degree seven vanishes. -/
+private theorem cycle_homologySixIsoScTopCycles
+    {A : AddCommGrpCat}
+    (N : ChainComplex AddCommGrpCat ℕ)
+    (hf : (N.sc' 7 6 5).f = 0)
+    (c : A ⟶ N.cycles 6)
+    (z : A ⟶ kernel ((N.sc' 7 6 5).g))
+    (hz : c ≫ N.iCycles 6 = z ≫ kernel.ι ((N.sc' 7 6 5).g)) :
+    c ≫ N.homologyπ 6 ≫
+      (N.homologyIsoSc' 7 6 5 (by simp) (by simp) ≪≫
+        ((N.sc' 7 6 5).asIsoHomologyπ hf).symm ≪≫
+        (N.sc' 7 6 5).cyclesIsoKernel).hom = z := by
+  apply (cancel_mono (kernel.ι ((N.sc' 7 6 5).g))).1
+  simp only [Iso.trans_hom, Category.assoc]
+  rw [N.π_homologyIsoSc'_hom_assoc]
+  rw [Iso.symm_hom]
+  rw [ShortComplex.homologyπ_comp_asIsoHomologyπ_inv_assoc]
+  rw [ShortComplex.cyclesIsoKernel_hom]
+  rw [kernel.lift_ι]
+  rw [N.cyclesIsoSc'_hom_iCycles]
+  exact hz
+
+set_option backward.isDefEq.respectTransparency false in
+/-- A normalized cycle followed by the canonical normalized `H₆`--top-cycle isomorphism is
+the corresponding element of the differential kernel. -/
+private theorem normalizedCycle_homologySixIsoTopCycles
+    {A : AddCommGrpCat}
+    (c : A ⟶ BoundarySevenNormalizedIntegralChains.cycles 6)
+    (z : A ⟶ kernel (BoundarySevenNormalizedIntegralChains.d 6 5))
+    (hz : c ≫ BoundarySevenNormalizedIntegralChains.iCycles 6 =
+      z ≫ kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5)) :
+    c ≫ BoundarySevenNormalizedIntegralChains.homologyπ 6 ≫
+        boundarySeven_normalizedHomologySixIsoTopCycles.hom = z := by
+  let N := BoundarySevenNormalizedIntegralChains
+  let S := N.sc' 7 6 5
+  let hf : S.f = 0 :=
+    boundarySeven_normalizedChains_degreeSeven_isZero.eq_of_src _ _
+  change c ≫ N.homologyπ 6 ≫
+      (N.homologyIsoSc' 7 6 5 (by simp) (by simp) ≪≫
+        (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoKernel).hom = z
+  apply cycle_homologySixIsoScTopCycles N hf c z
+  exact hz
+
+/-- Normalization takes the lifted original boundary cycle to the distinguished normalized
+orientation cycle, after passing from normalized homology to its top-cycle kernel. -/
+public theorem boundarySevenOriginalFundamentalHomologyClass_normalized :
+    boundarySevenOriginalFundamentalHomologyClass ≫
+        HomologicalComplex.homologyMap
+          ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+            (AddCommGrpCat.of ℤ)) 6 ≫
+        boundarySeven_normalizedHomologySixIsoTopCycles.hom =
+      boundarySevenNormalizedOrientationGenerator := by
+  rw [boundarySevenOriginalFundamentalHomologyClass,
+    Category.assoc, HomologicalComplex.homologyπ_naturality_assoc]
+  apply normalizedCycle_homologySixIsoTopCycles
+    (c := boundarySevenOriginalFundamentalCycle ≫
+      HomologicalComplex.cyclesMap
+        ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+          (AddCommGrpCat.of ℤ)) 6)
+    (z := boundarySevenNormalizedOrientationGenerator)
+  simp only [Category.assoc, HomologicalComplex.cyclesMap_i]
+  rw [← Category.assoc, boundarySevenOriginalFundamentalCycle_iCycles]
+  exact boundarySevenOriginalFundamentalChain_toNormalized
+
+/-- The class of the intrinsic alternating facet chain is the positive generator for the
+explicit unnormalized simplicial-homology orientation. -/
+public theorem boundarySevenOriginalFundamentalHomologyClass_isoInt :
+    boundarySevenOriginalFundamentalHomologyClass ≫
+        boundarySevenSimplicialHomologySixIsoInt.hom =
+      𝟙 (AddCommGrpCat.of ℤ) := by
+  let F := (∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+    (AddCommGrpCat.of ℤ)
+  let E := boundarySevenTopCyclesIsoStandardSevenTopCycles ≪≫
+    standardSevenTopCyclesIsoInt
+  calc
+    boundarySevenOriginalFundamentalHomologyClass ≫
+          boundarySevenSimplicialHomologySixIsoInt.hom =
+        (boundarySevenOriginalFundamentalHomologyClass ≫
+          HomologicalComplex.homologyMap F 6 ≫
+          boundarySeven_normalizedHomologySixIsoTopCycles.hom) ≫ E.hom := by
+      dsimp only [F, E]
+      simp only [boundarySevenSimplicialHomologySixIsoInt,
+        Iso.trans_hom, isoOfQuasiIsoAt_hom, Category.assoc]
+    _ = boundarySevenNormalizedOrientationGenerator ≫ E.hom := by
+      rw [boundarySevenOriginalFundamentalHomologyClass_normalized]
+    _ = 𝟙 (AddCommGrpCat.of ℤ) := by
+      rw [boundarySevenNormalizedOrientationGenerator_eq_orientation_inv]
+      exact Iso.inv_hom_id E
+
+/-- Elementwise form: the homology class represented by
+`boundarySevenOriginalFundamentalChain` maps to `1 ∈ ℤ`. -/
+public theorem boundarySevenOriginalFundamentalHomologyClass_mapsToOne :
+    boundarySevenSimplicialHomologySixAddEquivInt
+        (boundarySevenOriginalFundamentalHomologyClass (1 : ℤ)) = 1 := by
+  have h := ConcreteCategory.congr_hom
+    boundarySevenOriginalFundamentalHomologyClass_isoInt (1 : ℤ)
+  change boundarySevenSimplicialHomologySixIsoInt.hom.hom
+    (boundarySevenOriginalFundamentalHomologyClass.hom (1 : ℤ)) = 1
+  exact h
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceGeneratorDegreeReduction.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceGeneratorDegreeReduction.lean
@@ -1,0 +1,49 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorTransportPrelude
+
+/-!
+# Reduction of boundary-seven degree transport to the proper-face generator
+
+The literal inclusion of the proper-face nerve is degreewise monic.  Consequently every scalar
+identity for the subdivided boundary generator pulls back to the intrinsic proper-face generator.
+This file packages that fact in the exact form consumed by the degree calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory Simplicial
+
+namespace SphereSixComplex
+
+/-- The remaining degree assertion expressed directly using the generator of the proper-face
+nerve whose affine realization is already an explicit homeomorphism. -/
+public def BoundarySevenProperFaceGeneratorDegreeTransport
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) : Prop :=
+  ∀ (sigma : Equiv.Perm (Fin 8)) (z : ℤ),
+    boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap (boundarySevenProperFaceNervePermIso sigma).hom
+          (AddCommGrpCat.of ℤ)).f 6 =
+      z • boundarySevenProperFaceFundamentalChain →
+    sixSphereHomologicalDegree
+        (sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison e)
+        (boundarySevenPermutationSphereMap e sigma) = z
+
+/-- Proper-face generator transport implies the earlier subdivision-generator transport without
+any additional geometric assumption. -/
+public theorem boundarySevenSubdivisionGeneratorDegreeTransport_of_properFace
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere)
+    (hproper : BoundarySevenProperFaceGeneratorDegreeTransport hcomparison e) :
+    BoundarySevenSubdivisionGeneratorDegreeTransport hcomparison e := by
+  intro sigma z hsubdivided
+  exact hproper sigma z
+    (boundarySevenProperFaceFundamentalChain_eq_zsmul_of_subdivided
+      sigma z hsubdivided)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceSubdivisionBridge.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceSubdivisionBridge.lean
@@ -1,0 +1,530 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorComparison
+public import Mathlib.AlgebraicTopology.SimplicialSet.NonsingularColimit
+
+/-!
+# The proper-face nerve and subdivision of the seven-simplex boundary
+
+This file constructs the comparison map from Mathlib's left-Kan-extension subdivision of
+`∂Δ[7]` to the explicit nerve of nonempty proper faces.  Its defining identity says that,
+after the literal inclusion of proper faces, it is exactly subdivision of the boundary
+inclusion (transported through the representable subdivision isomorphism).
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+public abbrev boundarySevenSimplicialBoundary : SSet.{0} :=
+  (SSet.boundary 7 : SSet.{0})
+
+/-- The ambient order map represented by a nondegenerate simplex of `∂Δ[7]`. -/
+public def boundarySevenNondegenerateAmbientOrderHom
+    (x : boundarySevenSimplicialBoundary.N) :
+    Fin (x.dim + 1) →o Fin 8 :=
+  SSet.stdSimplex.asOrderHom x.simplex.1
+
+/-- The ambient vertex map of a nondegenerate boundary simplex, with the universe lift used by
+`SimplexCategory.sd` removed. -/
+public def boundarySevenNondegenerateAmbientVertexHom
+    (x : boundarySevenSimplicialBoundary.N) :
+    PartOrd.of (ULift.{0} (Fin (x.dim + 1))) ⟶
+      PartOrd.of (Fin 8) :=
+  PartOrd.ofHom
+    { toFun := fun i ↦ boundarySevenNondegenerateAmbientOrderHom x i.down
+      monotone' := fun _ _ h ↦
+        (boundarySevenNondegenerateAmbientOrderHom x).monotone h }
+
+/-- Map a nonempty collection of vertices of a nondegenerate boundary simplex to the
+corresponding proper face of the ambient seven-simplex. -/
+public noncomputable def boundarySevenNondegenerateFaceMap
+    (x : boundarySevenSimplicialBoundary.N)
+    (s : NonemptyFiniteChains (ULift.{0} (Fin (x.dim + 1)))) :
+    BoundarySevenProperFace := by
+  let t : Finset (Fin 8) := s.finset.image
+    (boundarySevenNondegenerateAmbientVertexHom x).hom
+  refine ⟨t, Finset.image_nonempty.mpr s.nonempty, ?_⟩
+  intro ht
+  apply x.simplex.2
+  intro i
+  have hi : i ∈ t := by rw [ht]; simp
+  obtain ⟨j, -, hj⟩ := Finset.mem_image.mp hi
+  exact ⟨j.down, hj⟩
+
+@[simp]
+public theorem boundarySevenNondegenerateFaceMap_val
+    (x : boundarySevenSimplicialBoundary.N)
+    (s : NonemptyFiniteChains (ULift.{0} (Fin (x.dim + 1)))) :
+    (boundarySevenNondegenerateFaceMap x s).1 =
+      s.finset.image (boundarySevenNondegenerateAmbientVertexHom x).hom :=
+  rfl
+
+public theorem boundarySevenNondegenerateFaceMap_val_eq_chainMap
+    (x : boundarySevenSimplicialBoundary.N)
+    (s : NonemptyFiniteChains (ULift.{0} (Fin (x.dim + 1)))) :
+    (boundarySevenNondegenerateFaceMap x s).1 =
+      (NonemptyFiniteChains.map s
+        (boundarySevenNondegenerateAmbientVertexHom x).hom).finset := by
+  rw [boundarySevenNondegenerateFaceMap_val]
+  apply Finset.ext
+  intro a
+  constructor
+  · intro ha
+    obtain ⟨i, hi, hia⟩ := Finset.mem_image.mp ha
+    rw [NonemptyFiniteChains.mem_map_iff]
+    exact ⟨i, hi, hia⟩
+  · intro ha
+    rw [NonemptyFiniteChains.mem_map_iff] at ha
+    obtain ⟨i, hi, hia⟩ := ha
+    exact Finset.mem_image.mpr ⟨i, hi, hia⟩
+
+/-- The monotone map from the face poset of a nondegenerate boundary simplex to the ambient
+proper-face poset. -/
+public noncomputable def boundarySevenNondegenerateFaceHom
+    (x : boundarySevenSimplicialBoundary.N) :
+    PartOrd.nonemptyFiniteChainsFunctor.obj
+        (SimplexCategory.toPartOrd.obj (SimplexCategory.mk x.dim)) ⟶
+      PartOrd.of BoundarySevenProperFace :=
+  PartOrd.ofHom
+    { toFun := boundarySevenNondegenerateFaceMap x
+      monotone' := by
+        intro s t hst
+        change NonemptyFiniteChains (ULift.{0} (Fin (x.dim + 1))) at s t
+        change s.finset.image (boundarySevenNondegenerateAmbientVertexHom x).hom ⊆
+          t.finset.image (boundarySevenNondegenerateAmbientVertexHom x).hom
+        exact Finset.image_mono _ hst }
+
+/-- The explicit subdivision chart of a nondegenerate simplex of the boundary, with values in
+the global proper-face nerve. -/
+public noncomputable def boundarySevenNondegenerateSubdivisionChart
+    (x : boundarySevenSimplicialBoundary.N) :
+    SSet.sd.obj (SSet.stdSimplex.obj (SimplexCategory.mk x.dim)) ⟶
+      BoundarySevenProperFaceNerve :=
+  SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+    PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom x)
+
+public theorem boundarySevenNondegenerateAmbientOrderHom_monoOfLE
+    {x y : boundarySevenSimplicialBoundary.N} (h : x ≤ y)
+    (i : Fin (x.dim + 1)) :
+    boundarySevenNondegenerateAmbientOrderHom x i =
+      boundarySevenNondegenerateAmbientOrderHom y
+        ((SSet.N.monoOfLE h).toOrderHom i) := by
+  have hmap := SSet.N.map_monoOfLE h
+  change x.simplex.1 i =
+    y.simplex.1 ((SSet.N.monoOfLE h).toOrderHom i)
+  have hi := congrArg (fun z ↦ z.1 i) hmap
+  exact hi.symm
+
+public theorem boundarySevenNondegenerateAmbientVertexHom_comp_monoOfLE
+    {x y : boundarySevenSimplicialBoundary.N} (h : x ≤ y) :
+    SimplexCategory.toPartOrd.map (SSet.N.monoOfLE h) ≫
+        boundarySevenNondegenerateAmbientVertexHom y =
+      boundarySevenNondegenerateAmbientVertexHom x := by
+  apply PartOrd.ext
+  intro i
+  change boundarySevenNondegenerateAmbientOrderHom y
+      ((SSet.N.monoOfLE h).toOrderHom i.down) =
+    boundarySevenNondegenerateAmbientOrderHom x i.down
+  exact (boundarySevenNondegenerateAmbientOrderHom_monoOfLE h i.down).symm
+
+public theorem boundarySevenNondegenerateFaceHom_comp_monoOfLE
+    {x y : boundarySevenSimplicialBoundary.N} (h : x ≤ y) :
+    (PartOrd.nonemptyFiniteChainsFunctor.map
+          (SimplexCategory.toPartOrd.map
+          (SSet.N.monoOfLE h))) ≫
+      boundarySevenNondegenerateFaceHom y =
+      boundarySevenNondegenerateFaceHom x := by
+  apply PartOrd.ext
+  intro s
+  change NonemptyFiniteChains (ULift.{0} (Fin (x.dim + 1))) at s
+  apply Subtype.ext
+  have hvert :
+      PartOrd.nonemptyFiniteChainsFunctor.map
+          (SimplexCategory.toPartOrd.map (SSet.N.monoOfLE h)) ≫
+        PartOrd.nonemptyFiniteChainsFunctor.map
+          (boundarySevenNondegenerateAmbientVertexHom y) =
+      PartOrd.nonemptyFiniteChainsFunctor.map
+        (boundarySevenNondegenerateAmbientVertexHom x) := by
+    calc
+      _ = PartOrd.nonemptyFiniteChainsFunctor.map
+          (SimplexCategory.toPartOrd.map (SSet.N.monoOfLE h) ≫
+            boundarySevenNondegenerateAmbientVertexHom y) :=
+        (PartOrd.nonemptyFiniteChainsFunctor.map_comp _ _).symm
+      _ = _ := congrArg PartOrd.nonemptyFiniteChainsFunctor.map
+        (boundarySevenNondegenerateAmbientVertexHom_comp_monoOfLE h)
+  have happ := congrArg (fun q ↦ q.hom s) hvert
+  let t : NonemptyFiniteChains (ULift.{0} (Fin (y.dim + 1))) :=
+    (PartOrd.nonemptyFiniteChainsFunctor.map
+      (SimplexCategory.toPartOrd.map (SSet.N.monoOfLE h))).hom s
+  have happ' :
+      NonemptyFiniteChains.map t
+          (boundarySevenNondegenerateAmbientVertexHom y).hom =
+        NonemptyFiniteChains.map s
+          (boundarySevenNondegenerateAmbientVertexHom x).hom := by
+    exact happ
+  change (boundarySevenNondegenerateFaceMap y t).1 =
+    (boundarySevenNondegenerateFaceMap x s).1
+  calc
+    _ = (NonemptyFiniteChains.map t
+        (boundarySevenNondegenerateAmbientVertexHom y).hom).finset :=
+      boundarySevenNondegenerateFaceMap_val_eq_chainMap y t
+    _ = (NonemptyFiniteChains.map s
+        (boundarySevenNondegenerateAmbientVertexHom x).hom).finset :=
+      congrArg NonemptyFiniteChains.finset happ'
+    _ = _ := (boundarySevenNondegenerateFaceMap_val_eq_chainMap x s).symm
+
+public theorem boundarySevenNondegenerateSubdivisionChart_naturality
+    {x y : boundarySevenSimplicialBoundary.N} (f : x ⟶ y) :
+    (boundarySevenSimplicialBoundary.functorN' ⋙ SSet.sd).map f ≫
+        boundarySevenNondegenerateSubdivisionChart y =
+      boundarySevenNondegenerateSubdivisionChart x := by
+  let g := SSet.N.monoOfLE (leOfHom f)
+  have hsd := SSet.stdSimplex.sdIso.hom.naturality g
+  have hsd' :
+      SSet.sd.map (SSet.stdSimplex.map g) ≫
+          SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk y.dim) =
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+          SimplexCategory.sd.map g := by
+    exact hsd
+  change SSet.sd.map (SSet.stdSimplex.map g) ≫
+      (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk y.dim) ≫
+        PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y)) = _
+  calc
+    _ = (SSet.sd.map (SSet.stdSimplex.map g) ≫
+          SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk y.dim)) ≫
+        PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y) :=
+      (Category.assoc _ _ _).symm
+    _ = (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+          SimplexCategory.sd.map g) ≫
+        PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y) :=
+      congrArg (fun z ↦ z ≫
+        PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y)) hsd'
+    _ = SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+        (SimplexCategory.sd.map g ≫
+          PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y)) :=
+      Category.assoc _ _ _
+    _ = boundarySevenNondegenerateSubdivisionChart x := by
+      have hface :
+          PartOrd.nerveFunctor.map
+              (PartOrd.nonemptyFiniteChainsFunctor.map
+                (SimplexCategory.toPartOrd.map g)) ≫
+            PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y) =
+          PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom x) := by
+        rw [← Functor.map_comp,
+          boundarySevenNondegenerateFaceHom_comp_monoOfLE (leOfHom f)]
+      change SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+          (PartOrd.nerveFunctor.map
+              (PartOrd.nonemptyFiniteChainsFunctor.map
+                (SimplexCategory.toPartOrd.map g)) ≫
+            PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom y)) =
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+          PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom x)
+      exact congrArg
+        (fun z ↦ SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫ z)
+        hface
+
+/-- The chart cocone from the subdivided nondegenerate simplices of `∂Δ[7]` to the explicit
+proper-face nerve. -/
+public noncomputable def boundarySevenProperFaceSubdivisionCocone :
+    Cocone (boundarySevenSimplicialBoundary.functorN' ⋙ SSet.sd) where
+  pt := BoundarySevenProperFaceNerve
+  ι :=
+    { app := boundarySevenNondegenerateSubdivisionChart
+      naturality := fun _ _ f ↦ boundarySevenNondegenerateSubdivisionChart_naturality f }
+
+/-- Subdivision preserves the standard-simplex colimit presentation of the nonsingular
+boundary. -/
+public noncomputable def boundarySevenSubdivisionIsColimit :
+    IsColimit (SSet.sd.mapCocone boundarySevenSimplicialBoundary.coconeN') :=
+  isColimitOfPreserves SSet.sd boundarySevenSimplicialBoundary.isColimitCoconeN'
+
+/-- The canonical comparison from Mathlib's left-Kan-extension subdivision of `∂Δ[7]` to the
+explicit nerve of nonempty proper faces. -/
+public noncomputable def boundarySevenSubdivisionToProperFaceNerve :
+    SSet.sd.obj (∂Δ[7] : SSet.{0}) ⟶ BoundarySevenProperFaceNerve :=
+  boundarySevenSubdivisionIsColimit.desc boundarySevenProperFaceSubdivisionCocone
+
+/-- On every nondegenerate boundary simplex, the global comparison is the explicit map that
+sends a nonempty set of local vertices to its ambient proper face. -/
+public theorem boundarySevenSubdivisionToProperFaceNerve_chart
+    (x : boundarySevenSimplicialBoundary.N) :
+    SSet.sd.map (SSet.yonedaEquiv.symm x.simplex) ≫
+        boundarySevenSubdivisionToProperFaceNerve =
+      boundarySevenNondegenerateSubdivisionChart x := by
+  exact boundarySevenSubdivisionIsColimit.fac
+    boundarySevenProperFaceSubdivisionCocone x
+
+/-- The simplex-category morphism represented by a nondegenerate simplex of the boundary after
+forgetting that its image is proper. -/
+public def boundarySevenNondegenerateAmbientSimplexHom
+    (x : boundarySevenSimplicialBoundary.N) :
+    SimplexCategory.mk x.dim ⟶ SimplexCategory.mk 7 :=
+  SimplexCategory.Hom.mk (boundarySevenNondegenerateAmbientOrderHom x)
+
+/-- The underlying standard-simplex map of a boundary simplex is its ambient monotone vertex
+map. -/
+public theorem boundarySevenNondegenerateSimplex_comp_boundaryInclusion
+    (x : boundarySevenSimplicialBoundary.N) :
+    SSet.yonedaEquiv.symm x.simplex ≫ (SSet.boundary 7).ι =
+      SSet.stdSimplex.map (boundarySevenNondegenerateAmbientSimplexHom x) := by
+  apply SSet.yonedaEquiv.injective
+  rfl
+
+/-- Universe-lift the ambient vertices, matching the vertex convention in
+`SimplexCategory.sd`. -/
+public def boundarySevenAmbientVertexULiftHom :
+    PartOrd.of (Fin 8) ⟶ PartOrd.of (ULift.{0} (Fin 8)) :=
+  PartOrd.ofHom
+    { toFun := ULift.up
+      monotone' := fun _ _ h ↦ h }
+
+public theorem boundarySevenAmbientVertexHom_comp_uLift
+    (x : boundarySevenSimplicialBoundary.N) :
+    boundarySevenNondegenerateAmbientVertexHom x ≫
+        boundarySevenAmbientVertexULiftHom =
+      SimplexCategory.toPartOrd.map
+        (boundarySevenNondegenerateAmbientSimplexHom x) := by
+  apply PartOrd.ext
+  intro i
+  rfl
+
+public theorem boundarySevenFinsetImage_uLift_eq_chainMap
+    (s : NonemptyFiniteChains (Fin 8)) :
+    s.finset.image ULift.up =
+      (NonemptyFiniteChains.map s boundarySevenAmbientVertexULiftHom.hom).finset := by
+  apply Finset.ext
+  intro a
+  constructor
+  · intro ha
+    obtain ⟨i, hi, hia⟩ := Finset.mem_image.mp ha
+    rw [NonemptyFiniteChains.mem_map_iff]
+    exact ⟨i, hi, hia⟩
+  · intro ha
+    rw [NonemptyFiniteChains.mem_map_iff] at ha
+    obtain ⟨i, hi, hia⟩ := ha
+    exact Finset.mem_image.mpr ⟨i, hi, hia⟩
+
+/-- Including the proper faces produced by one boundary simplex is the usual map of full
+nonempty-face posets induced by its ambient vertex map. -/
+public theorem boundarySevenNondegenerateFaceHom_comp_inclusion
+    (x : boundarySevenSimplicialBoundary.N) :
+    boundarySevenNondegenerateFaceHom x ≫
+        boundarySevenProperFaceInclusionHom =
+      PartOrd.nonemptyFiniteChainsFunctor.map
+        (SimplexCategory.toPartOrd.map
+          (boundarySevenNondegenerateAmbientSimplexHom x)) := by
+  apply PartOrd.ext
+  intro s
+  change NonemptyFiniteChains (ULift.{0} (Fin (x.dim + 1))) at s
+  let t : NonemptyFiniteChains (Fin 8) :=
+    NonemptyFiniteChains.map s
+      (boundarySevenNondegenerateAmbientVertexHom x).hom
+  let u : NonemptyFiniteChains (ULift.{0} (Fin 8)) :=
+    NonemptyFiniteChains.map t boundarySevenAmbientVertexULiftHom.hom
+  let v : NonemptyFiniteChains (ULift.{0} (Fin 8)) :=
+    NonemptyFiniteChains.map s
+      (SimplexCategory.toPartOrd.map
+        (boundarySevenNondegenerateAmbientSimplexHom x)).hom
+  have hchain :
+      PartOrd.nonemptyFiniteChainsFunctor.map
+          (boundarySevenNondegenerateAmbientVertexHom x) ≫
+        PartOrd.nonemptyFiniteChainsFunctor.map
+          boundarySevenAmbientVertexULiftHom =
+      PartOrd.nonemptyFiniteChainsFunctor.map
+        (SimplexCategory.toPartOrd.map
+          (boundarySevenNondegenerateAmbientSimplexHom x)) := by
+    calc
+      _ = PartOrd.nonemptyFiniteChainsFunctor.map
+          (boundarySevenNondegenerateAmbientVertexHom x ≫
+            boundarySevenAmbientVertexULiftHom) :=
+        (PartOrd.nonemptyFiniteChainsFunctor.map_comp _ _).symm
+      _ = _ := congrArg PartOrd.nonemptyFiniteChainsFunctor.map
+        (boundarySevenAmbientVertexHom_comp_uLift x)
+  have huv : u = v := by
+    exact congrArg (fun q ↦ q.hom s) hchain
+  apply NonemptyFiniteChains.ext
+  change (boundarySevenNondegenerateFaceMap x s).1.image ULift.up = v.finset
+  calc
+    _ = t.finset.image ULift.up := by
+      rw [boundarySevenNondegenerateFaceMap_val_eq_chainMap]
+    _ = u.finset := boundarySevenFinsetImage_uLift_eq_chainMap t
+    _ = v.finset := congrArg NonemptyFiniteChains.finset huv
+
+/-- Each chart comparison followed by the literal proper-face inclusion is exactly the
+representable subdivision of its ambient simplex map. -/
+public theorem boundarySevenNondegenerateSubdivisionChart_comp_inclusion
+    (x : boundarySevenSimplicialBoundary.N) :
+    boundarySevenNondegenerateSubdivisionChart x ≫
+        boundarySevenProperFaceNerveInclusion =
+      SSet.sd.map
+          (SSet.stdSimplex.map
+            (boundarySevenNondegenerateAmbientSimplexHom x)) ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7) := by
+  have hface := congrArg PartOrd.nerveFunctor.map
+    (boundarySevenNondegenerateFaceHom_comp_inclusion x)
+  have hface' :
+      PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom x) ≫
+          PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom =
+        SimplexCategory.sd.map
+          (boundarySevenNondegenerateAmbientSimplexHom x) := by
+    calc
+      _ = PartOrd.nerveFunctor.map
+          (boundarySevenNondegenerateFaceHom x ≫
+            boundarySevenProperFaceInclusionHom) :=
+        (PartOrd.nerveFunctor.map_comp _ _).symm
+      _ = _ := hface
+  have hsd := SSet.stdSimplex.sdIso.hom.naturality
+    (boundarySevenNondegenerateAmbientSimplexHom x)
+  have hsd' :
+      SSet.sd.map
+          (SSet.stdSimplex.map
+            (boundarySevenNondegenerateAmbientSimplexHom x)) ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7) =
+      SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+        SimplexCategory.sd.map
+          (boundarySevenNondegenerateAmbientSimplexHom x) := by
+    exact hsd
+  change (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+      PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom x)) ≫
+        PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom = _
+  have hwhisker :
+      SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+          (PartOrd.nerveFunctor.map (boundarySevenNondegenerateFaceHom x) ≫
+            PartOrd.nerveFunctor.map boundarySevenProperFaceInclusionHom) =
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk x.dim) ≫
+          SimplexCategory.sd.map
+            (boundarySevenNondegenerateAmbientSimplexHom x) :=
+    congrArg
+      (fun z : SimplexCategory.sd.obj (SimplexCategory.mk x.dim) ⟶
+          SimplexCategory.sd.obj (SimplexCategory.mk 7) ↦
+        SSet.stdSimplex.sdIso.hom.app
+          (SimplexCategory.mk x.dim) ≫ z) hface'
+  exact (Category.assoc _ _ _).trans (hwhisker.trans hsd'.symm)
+
+/-- The canonical comparison is a literal factorization of subdivided boundary inclusion
+through the proper-face nerve.  This is the precise natural identity missing from the older
+proper-face API. -/
+public theorem boundarySevenSubdivisionToProperFaceNerve_comp_inclusion :
+    boundarySevenSubdivisionToProperFaceNerve ≫
+        boundarySevenProperFaceNerveInclusion =
+      SSet.sd.map (SSet.boundary.{0} 7).ι ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7) := by
+  apply boundarySevenSubdivisionIsColimit.hom_ext
+  intro x
+  calc
+    SSet.sd.map (SSet.yonedaEquiv.symm x.simplex) ≫
+          (boundarySevenSubdivisionToProperFaceNerve ≫
+            boundarySevenProperFaceNerveInclusion) =
+        (SSet.sd.map (SSet.yonedaEquiv.symm x.simplex) ≫
+          boundarySevenSubdivisionToProperFaceNerve) ≫
+            boundarySevenProperFaceNerveInclusion :=
+      (Category.assoc _ _ _).symm
+    _ = boundarySevenNondegenerateSubdivisionChart x ≫
+        boundarySevenProperFaceNerveInclusion := by
+      rw [boundarySevenSubdivisionToProperFaceNerve_chart]
+    _ = SSet.sd.map
+          (SSet.stdSimplex.map
+            (boundarySevenNondegenerateAmbientSimplexHom x)) ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7) :=
+      boundarySevenNondegenerateSubdivisionChart_comp_inclusion x
+    _ = SSet.sd.map
+          (SSet.yonedaEquiv.symm x.simplex ≫ (SSet.boundary 7).ι) ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7) := by
+      rw [boundarySevenNondegenerateSimplex_comp_boundaryInclusion]
+    _ = (SSet.sd.map (SSet.yonedaEquiv.symm x.simplex) ≫
+          SSet.sd.map (SSet.boundary 7).ι) ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7) := by
+      rw [Functor.map_comp]
+    _ = SSet.sd.map (SSet.yonedaEquiv.symm x.simplex) ≫
+        (SSet.sd.map (SSet.boundary 7).ι ≫
+          SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7)) :=
+      Category.assoc _ _ _
+
+/-- Chain-level form of the subdivision factorization, for arbitrary coefficients. -/
+public theorem boundarySevenSubdivisionToProperFaceNerve_chainMap_comp_inclusion
+    (R : AddCommGrpCat) :
+    SSet.chainComplexMap boundarySevenSubdivisionToProperFaceNerve R ≫
+        SSet.chainComplexMap boundarySevenProperFaceNerveInclusion R =
+      SSet.chainComplexMap (SSet.sd.map (SSet.boundary.{0} 7).ι) R ≫
+        SSet.chainComplexMap
+          (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7)) R := by
+  let F := (SSet.chainComplexFunctor AddCommGrpCat).obj R
+  calc
+    F.map boundarySevenSubdivisionToProperFaceNerve ≫
+          F.map boundarySevenProperFaceNerveInclusion =
+        F.map (boundarySevenSubdivisionToProperFaceNerve ≫
+          boundarySevenProperFaceNerveInclusion) :=
+      (F.map_comp _ _).symm
+    _ = F.map (SSet.sd.map (SSet.boundary 7).ι ≫
+        SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7)) :=
+      congrArg F.map boundarySevenSubdivisionToProperFaceNerve_comp_inclusion
+    _ = F.map (SSet.sd.map (SSet.boundary 7).ι) ≫
+        F.map (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7)) :=
+      F.map_comp _ _
+
+/-- The intrinsic fundamental chain of `∂Δ[7]`, after canonical barycentric subdivision and the
+new comparison, becomes the explicit subdivided boundary chain after the literal proper-face
+inclusion. -/
+public theorem boundarySevenOriginalFundamentalChain_subdivisionToProperFace_comp_inclusion :
+    ((boundarySevenOriginalFundamentalChain ≫
+          (barycentricSubdivisionChainMapCanonical (∂Δ[7] : SSet.{0})).f 6) ≫
+        (SSet.chainComplexMap boundarySevenSubdivisionToProperFaceNerve
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+      (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+        (AddCommGrpCat.of ℤ)).f 6 =
+      subdividedSevenBoundaryFundamentalChain := by
+  have hfactor := congrArg (fun k ↦ k.f 6)
+    (boundarySevenSubdivisionToProperFaceNerve_chainMap_comp_inclusion
+      (AddCommGrpCat.of ℤ))
+  let c := boundarySevenOriginalFundamentalChain ≫
+    (barycentricSubdivisionChainMapCanonical (∂Δ[7] : SSet.{0})).f 6
+  calc
+    (c ≫ (SSet.chainComplexMap boundarySevenSubdivisionToProperFaceNerve
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6 =
+      c ≫ ((SSet.chainComplexMap boundarySevenSubdivisionToProperFaceNerve
+          (AddCommGrpCat.of ℤ)).f 6 ≫
+        (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+          (AddCommGrpCat.of ℤ)).f 6) := Category.assoc _ _ _
+    _ = c ≫ ((SSet.chainComplexMap
+          (SSet.sd.map (SSet.boundary 7).ι) (AddCommGrpCat.of ℤ)).f 6 ≫
+        (SSet.chainComplexMap
+          (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7))
+          (AddCommGrpCat.of ℤ)).f 6) :=
+      congrArg (fun z ↦ c ≫ z) hfactor
+    _ = (c ≫ (SSet.chainComplexMap
+          (SSet.sd.map (SSet.boundary 7).ι) (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap
+          (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7))
+          (AddCommGrpCat.of ℤ)).f 6 := (Category.assoc _ _ _).symm
+    _ = (subdividedSevenBoundaryFundamentalChain ≫
+          (SSet.chainComplexMap
+            (SSet.stdSimplex.sdIso.inv.app (SimplexCategory.mk 7))
+            (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap
+          (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7))
+          (AddCommGrpCat.of ℤ)).f 6 := by
+      rw [boundarySevenOriginalFundamentalChain_barycentricSubdivision_comp_inclusion]
+    _ = subdividedSevenBoundaryFundamentalChain := by
+      rw [Category.assoc]
+      let F := (SSet.chainComplexFunctor AddCommGrpCat).obj (AddCommGrpCat.of ℤ)
+      have hcancel :
+          F.map (SSet.stdSimplex.sdIso.inv.app (SimplexCategory.mk 7)) ≫
+              F.map (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7)) =
+            𝟙 _ := by
+        rw [← F.map_comp]
+        simp
+      have hcancel' := congrArg (fun k ↦ k.f 6) hcancel
+      change
+        (F.map (SSet.stdSimplex.sdIso.inv.app (SimplexCategory.mk 7))).f 6 ≫
+            (F.map (SSet.stdSimplex.sdIso.hom.app (SimplexCategory.mk 7))).f 6 =
+          𝟙 _ at hcancel'
+      rw [hcancel', Category.comp_id]
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenSubdivisionGeneratorNormalization.lean
+++ b/SphereSixComplex/Topology/BoundarySevenSubdivisionGeneratorNormalization.lean
@@ -1,0 +1,210 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorComparison
+
+/-!
+# Normalization of the boundary-seven fundamental generator
+
+This file identifies the concrete unnormalized top simplex with the generator selected by
+the normalized-chain colimit used in the top-homology orientation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
+
+namespace SphereSixComplex
+
+/-- The unique unnormalized top simplex maps to the inverse of the canonical normalized
+degree-seven orientation isomorphism. -/
+public theorem standardSevenTopSimplexChain_toNormalized :
+    standardSevenTopSimplexChain ≫
+        ((Δ[7] : SSet.{0}).toNormalizedChainComplex
+          (AddCommGrpCat.of ℤ)).f 7 =
+      standardSevenNormalizedChainsXSevenIsoInt.inv := by
+  rw [standardSevenTopSimplexChain,
+    SSet.ιChainComplex_toNormalizedChainComplex_f]
+  let top : (Δ[7] : SSet.{0}).nonDegenerate 7 :=
+    ⟨SSet.stdSimplex.objEquiv.symm (𝟙 (SimplexCategory.mk 7)),
+      SSet.stdSimplex.objEquiv_symm_id_mem_nonDegenerate 7⟩
+  let _ : Unique ((Δ[7] : SSet.{0}).nonDegenerate 7) :=
+    { default := top
+      uniq := fun x ↦ by
+        apply Subtype.ext
+        have hx := x.2
+        have hx' : x.1 ∈
+            ({SSet.stdSimplex.objEquiv.symm (𝟙 (SimplexCategory.mk 7))} :
+              Set ((Δ[7] : SSet.{0}).obj
+                (Opposite.op (SimplexCategory.mk 7)))) := by
+          rw [← SSet.stdSimplex.nonDegenerate_top_dim]
+          exact hx
+        simpa [top] using hx' }
+  let P := (Δ[7] : SSet.{0}).isColimitCofanNormalizedChainComplex
+    (AddCommGrpCat.of ℤ) 7
+  let Q := Cofan.isColimitMkOfUnique (Iso.refl (AddCommGrpCat.of ℤ))
+    ((Δ[7] : SSet.{0}).nonDegenerate 7)
+  have h := IsColimit.comp_coconePointUniqueUpToIso_inv P Q
+    (Discrete.mk (default : (Δ[7] : SSet.{0}).nonDegenerate 7))
+  change (Δ[7] : SSet.{0}).ιNormalizedChainComplex
+      (standardSimplexTopSimplex 7) =
+    (P.coconePointUniqueUpToIso Q).inv
+  have hdefault :
+      (default : (Δ[7] : SSet.{0}).nonDegenerate 7).1 =
+        standardSimplexTopSimplex 7 := by
+    rfl
+  rw [← hdefault]
+  simpa [P, Q] using h.symm
+
+/-- The exactness isomorphism from the unique normalized seven-simplex to degree-six cycles
+includes as the normalized top differential. -/
+@[reassoc]
+public theorem standardSevenNormalizedChainsXSevenIsoTopCycles_hom_ι :
+    standardSevenNormalizedChainsXSevenIsoTopCycles.hom ≫
+        kernel.ι (StandardSevenNormalizedIntegralChains.d 6 5) =
+      StandardSevenNormalizedIntegralChains.d 7 6 := by
+  let _ : Mono (StandardSevenNormalizedIntegralChains.d 7 6) :=
+    standardSeven_normalized_d_seven_six_mono
+  have h₆ := standardSeven_normalizedChains_exactAt 6 (by omega)
+  have h₆' : (StandardSevenNormalizedIntegralChains.sc' 7 6 5).Exact :=
+    ShortComplex.exact_of_iso
+      (StandardSevenNormalizedIntegralChains.isoSc' 7 6 5 (by simp) (by simp)) h₆
+  let _ : Mono (StandardSevenNormalizedIntegralChains.sc' 7 6 5).f := by
+    change Mono (StandardSevenNormalizedIntegralChains.d 7 6)
+    exact standardSeven_normalized_d_seven_six_mono
+  change (IsLimit.conePointUniqueUpToIso h₆'.fIsKernel
+      (limit.isLimit (parallelPair
+        (StandardSevenNormalizedIntegralChains.d 6 5) 0))).hom ≫
+      limit.π (parallelPair (StandardSevenNormalizedIntegralChains.d 6 5) 0)
+        WalkingParallelPair.zero =
+    StandardSevenNormalizedIntegralChains.d 7 6
+  exact IsLimit.conePointUniqueUpToIso_hom_comp _ _ WalkingParallelPair.zero
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The canonical cycle-kernel comparison commutes with the inclusions into normalized
+degree six. -/
+@[reassoc]
+theorem boundarySevenTopCyclesIsoStandardSevenTopCycles_hom_ι :
+    boundarySevenTopCyclesIsoStandardSevenTopCycles.hom ≫
+        kernel.ι (StandardSevenNormalizedIntegralChains.d 6 5) =
+      kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5) ≫
+        (SSet.normalizedChainComplexMap
+          (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+          (AddCommGrpCat.of ℤ)).f 6 := by
+  let f := SSet.normalizedChainComplexMap
+    (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+      (AddCommGrpCat.of ℤ)
+  let φ := (HomologicalComplex.shortComplexFunctor' AddCommGrpCat
+    (ComplexShape.down ℕ) 7 6 5).map f
+  change (((BoundarySevenNormalizedIntegralChains.sc' 7 6 5).cyclesIsoKernel).inv ≫
+      ShortComplex.cyclesMap φ ≫
+      ((StandardSevenNormalizedIntegralChains.sc' 7 6 5).cyclesIsoKernel).hom) ≫
+        kernel.ι (StandardSevenNormalizedIntegralChains.d 6 5) =
+    kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5) ≫ f.f 6
+  have hB :
+      ((StandardSevenNormalizedIntegralChains.sc' 7 6 5).cyclesIsoKernel).hom ≫
+          kernel.ι (StandardSevenNormalizedIntegralChains.d 6 5) =
+        (StandardSevenNormalizedIntegralChains.sc' 7 6 5).iCycles := by
+    apply kernel.lift_ι
+  have hmap := ShortComplex.cyclesMap_i φ
+  have hmap' :
+      ShortComplex.cyclesMap φ ≫
+          (StandardSevenNormalizedIntegralChains.sc' 7 6 5).iCycles =
+        (BoundarySevenNormalizedIntegralChains.sc' 7 6 5).iCycles ≫ f.f 6 := by
+    exact hmap
+  have hA :
+      ((BoundarySevenNormalizedIntegralChains.sc' 7 6 5).cyclesIsoKernel).inv ≫
+          (BoundarySevenNormalizedIntegralChains.sc' 7 6 5).iCycles =
+        kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5) := by
+    apply ShortComplex.liftCycles_i
+  simp only [Category.assoc]
+  rw [hB, hmap']
+  rw [← Category.assoc, hA]
+
+/-- Transporting the standard cycle kernel back to the boundary and then including the
+boundary normalized chains is the standard kernel inclusion. -/
+@[reassoc]
+public theorem boundarySevenTopCyclesIsoStandardSevenTopCycles_inv_ι :
+    boundarySevenTopCyclesIsoStandardSevenTopCycles.inv ≫
+        kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5) ≫
+        (SSet.normalizedChainComplexMap
+          (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+          (AddCommGrpCat.of ℤ)).f 6 =
+      kernel.ι (StandardSevenNormalizedIntegralChains.d 6 5) := by
+  rw [← cancel_epi boundarySevenTopCyclesIsoStandardSevenTopCycles.hom]
+  simp only [Iso.hom_inv_id_assoc,
+    boundarySevenTopCyclesIsoStandardSevenTopCycles_hom_ι]
+
+/-- The ordinary boundary of the unique seven-simplex normalizes to the boundary of its
+canonical normalized generator. -/
+public theorem standardSevenOriginalBoundaryChain_toNormalized :
+    standardSevenOriginalBoundaryChain ≫
+        ((Δ[7] : SSet.{0}).toNormalizedChainComplex
+          (AddCommGrpCat.of ℤ)).f 6 =
+      standardSevenNormalizedChainsXSevenIsoInt.inv ≫
+        StandardSevenNormalizedIntegralChains.d 7 6 := by
+  let F := (Δ[7] : SSet.{0}).toNormalizedChainComplex
+    (AddCommGrpCat.of ℤ)
+  change (standardSevenTopSimplexChain ≫ _) ≫ F.f 6 = _
+  rw [Category.assoc, ← F.comm 7 6, ← Category.assoc,
+    standardSevenTopSimplexChain_toNormalized]
+
+/-- The intrinsic alternating boundary chain normalizes to the canonical generator used by
+the degree-six orientation of `∂Δ[7]`. -/
+public theorem boundarySevenOriginalFundamentalChain_toNormalized :
+    boundarySevenOriginalFundamentalChain ≫
+        ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+          (AddCommGrpCat.of ℤ)).f 6 =
+      boundarySevenNormalizedOrientationGenerator ≫
+        kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5) := by
+  let j := (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+  let g := SSet.normalizedChainComplexMap j (AddCommGrpCat.of ℤ)
+  let e₆ := boundarySevenNormalizedChainsXIsoStandard 6 (by omega)
+  let _ : IsIso (g.f 6) := by
+    change IsIso e₆.hom
+    infer_instance
+  rw [← cancel_mono (g.f 6)]
+  have hnat := congrArg (fun k ↦ k.f 6)
+    (SSet.toNormalizedChainComplex_normalizedChainComplexMap
+      (f := j) (R := AddCommGrpCat.of ℤ))
+  calc
+    (boundarySevenOriginalFundamentalChain ≫
+          ((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+            (AddCommGrpCat.of ℤ)).f 6) ≫ g.f 6 =
+        boundarySevenOriginalFundamentalChain ≫
+          (((∂Δ[7] : SSet.{0}).toNormalizedChainComplex
+              (AddCommGrpCat.of ℤ)).f 6 ≫ g.f 6) :=
+      Category.assoc _ _ _
+    _ = boundarySevenOriginalFundamentalChain ≫
+          ((SSet.chainComplexMap j (AddCommGrpCat.of ℤ)).f 6 ≫
+            ((Δ[7] : SSet.{0}).toNormalizedChainComplex
+              (AddCommGrpCat.of ℤ)).f 6) := by
+      exact congrArg (fun k ↦ boundarySevenOriginalFundamentalChain ≫ k) hnat
+    _ = (boundarySevenOriginalFundamentalChain ≫
+          (SSet.chainComplexMap j (AddCommGrpCat.of ℤ)).f 6) ≫
+            ((Δ[7] : SSet.{0}).toNormalizedChainComplex
+              (AddCommGrpCat.of ℤ)).f 6 :=
+      (Category.assoc _ _ _).symm
+    _ = standardSevenOriginalBoundaryChain ≫
+          ((Δ[7] : SSet.{0}).toNormalizedChainComplex
+            (AddCommGrpCat.of ℤ)).f 6 := by
+      rw [boundarySevenOriginalFundamentalChain_comp_boundaryInclusion]
+    _ = standardSevenNormalizedChainsXSevenIsoInt.inv ≫
+          StandardSevenNormalizedIntegralChains.d 7 6 :=
+      standardSevenOriginalBoundaryChain_toNormalized
+    _ = standardSevenNormalizedChainsXSevenIsoInt.inv ≫
+          standardSevenNormalizedChainsXSevenIsoTopCycles.hom ≫
+            kernel.ι (StandardSevenNormalizedIntegralChains.d 6 5) := by
+      rw [standardSevenNormalizedChainsXSevenIsoTopCycles_hom_ι]
+    _ = (boundarySevenNormalizedOrientationGenerator ≫
+          kernel.ι (BoundarySevenNormalizedIntegralChains.d 6 5)) ≫
+            g.f 6 := by
+      rw [boundarySevenNormalizedOrientationGenerator]
+      have h := congrArg
+        (fun k ↦ standardSevenNormalizedChainsXSevenIsoInt.inv ≫
+          standardSevenNormalizedChainsXSevenIsoTopCycles.hom ≫ k)
+        boundarySevenTopCyclesIsoStandardSevenTopCycles_inv_ι.symm
+      simpa only [Category.assoc] using h
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenSubdivisionGeneratorTransportPrelude.lean
+++ b/SphereSixComplex/Topology/BoundarySevenSubdivisionGeneratorTransportPrelude.lean
@@ -1,0 +1,194 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceSubdivisionBridge
+public import Mathlib.CategoryTheory.Limits.MonoCoprod
+
+/-!
+# Chain-level preliminaries for the boundary-seven generator transport
+
+This file proves the degreewise monomorphism and cycle facts needed to transport the explicit
+subdivided boundary generator through the proper-face nerve.  It deliberately contains no
+normalization or affine-realization comparison.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- A simplicial map which is injective in degree `n` induces a monomorphism on degree-`n`
+integral simplicial chains. -/
+public theorem chainComplexMap_f_mono_of_app_injective
+    {X Y : SSet.{0}} (f : X ⟶ Y) (n : ℕ)
+    (hf : Function.Injective
+      (f.app (Opposite.op (SimplexCategory.mk n)))) :
+    Mono ((SSet.chainComplexMap f (AddCommGrpCat.of ℤ)).f n) := by
+  change Mono (Sigma.map'
+    (f := fun _ : X.obj (Opposite.op (SimplexCategory.mk n)) ↦ AddCommGrpCat.of ℤ)
+    (g := fun _ : Y.obj (Opposite.op (SimplexCategory.mk n)) ↦ AddCommGrpCat.of ℤ)
+    (f.app (Opposite.op (SimplexCategory.mk n)))
+    (fun _ ↦ 𝟙 (AddCommGrpCat.of ℤ)))
+  exact MonoCoprod.mono_map'_of_injective
+    (fun _ : Y.obj (Opposite.op (SimplexCategory.mk n)) ↦ AddCommGrpCat.of ℤ)
+    (f.app (Opposite.op (SimplexCategory.mk n))) hf
+
+/-- The literal inclusion of proper faces into all nonempty faces is injective on simplices in
+every degree. -/
+public theorem boundarySevenProperFaceNerveInclusion_app_injective (n : ℕ) :
+    Function.Injective
+      ((boundarySevenProperFaceNerveInclusion).app
+        (Opposite.op (SimplexCategory.mk n))) := by
+  intro F G hFG
+  refine ComposableArrows.ext (fun i ↦ ?_) (fun _ _ ↦ by subsingleton)
+  have hi := congrArg (fun H ↦ H.obj i) hFG
+  apply Subtype.ext
+  have hi' := congrArg NonemptyFiniteChains.finset hi
+  change (F.obj i).1.image ULift.up = (G.obj i).1.image ULift.up at hi'
+  exact Finset.image_injective ULift.up_injective hi'
+
+/-- The proper-face nerve inclusion is degreewise monic on integral simplicial chains. -/
+public theorem boundarySevenProperFaceNerveInclusion_chainComplexMap_f_mono (n : ℕ) :
+    Mono ((SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+      (AddCommGrpCat.of ℤ)).f n) :=
+  chainComplexMap_f_mono_of_app_injective
+    boundarySevenProperFaceNerveInclusion n
+      (boundarySevenProperFaceNerveInclusion_app_injective n)
+
+/-- Any scalar action on the explicit subdivided boundary chain pulls back to the intrinsic
+proper-face fundamental chain. -/
+public theorem boundarySevenProperFaceFundamentalChain_eq_zsmul_of_subdivided
+    (sigma : Equiv.Perm (Fin 8)) (z : ℤ)
+    (h : subdividedSevenBoundaryFundamentalChain ≫
+          (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+            (AddCommGrpCat.of ℤ)).f 6 =
+        z • subdividedSevenBoundaryFundamentalChain) :
+    boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap (boundarySevenProperFaceNervePermIso sigma).hom
+          (AddCommGrpCat.of ℤ)).f 6 =
+      z • boundarySevenProperFaceFundamentalChain := by
+  let I := (SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+    (AddCommGrpCat.of ℤ)).f 6
+  let P := (SSet.chainComplexMap (boundarySevenProperFaceNervePermIso sigma).hom
+    (AddCommGrpCat.of ℤ)).f 6
+  let Q := (SSet.chainComplexMap (simplexSubdivisionVertexPermMap sigma)
+    (AddCommGrpCat.of ℤ)).f 6
+  have hmap := ((SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)).congr_map
+      (boundarySevenProperFaceNerveInclusion_equivariant sigma)
+  rw [Functor.map_comp, Functor.map_comp] at hmap
+  have hn := congrArg (fun k ↦ k.f 6) hmap
+  change P ≫ I = I ≫ Q at hn
+  let _ : Mono I :=
+    boundarySevenProperFaceNerveInclusion_chainComplexMap_f_mono 6
+  apply (cancel_mono I).1
+  calc
+    (boundarySevenProperFaceFundamentalChain ≫ P) ≫ I =
+        boundarySevenProperFaceFundamentalChain ≫ (P ≫ I) :=
+      Category.assoc _ _ _
+    _ = boundarySevenProperFaceFundamentalChain ≫ (I ≫ Q) := by rw [hn]
+    _ = (boundarySevenProperFaceFundamentalChain ≫ I) ≫ Q :=
+      (Category.assoc _ _ _).symm
+    _ = subdividedSevenBoundaryFundamentalChain ≫ Q := by
+      rw [boundarySevenProperFaceFundamentalChain_comp_inclusion]
+    _ = z • subdividedSevenBoundaryFundamentalChain := h
+    _ = (z • boundarySevenProperFaceFundamentalChain) ≫ I := by
+      rw [Preadditive.zsmul_comp,
+        boundarySevenProperFaceFundamentalChain_comp_inclusion]
+
+/-- The intrinsic proper-face fundamental chain is a cycle. -/
+public theorem boundarySevenProperFaceFundamentalChain_isCycle :
+    boundarySevenProperFaceFundamentalChain ≫
+        (BoundarySevenProperFaceNerve.chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 = 0 := by
+  let I := SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+    (AddCommGrpCat.of ℤ)
+  let _ : Mono (I.f 5) :=
+    boundarySevenProperFaceNerveInclusion_chainComplexMap_f_mono 5
+  apply (cancel_mono (I.f 5)).1
+  calc
+    (boundarySevenProperFaceFundamentalChain ≫
+          (BoundarySevenProperFaceNerve.chainComplex
+            (AddCommGrpCat.of ℤ)).d 6 5) ≫ I.f 5 =
+        boundarySevenProperFaceFundamentalChain ≫
+          ((BoundarySevenProperFaceNerve.chainComplex
+            (AddCommGrpCat.of ℤ)).d 6 5 ≫ I.f 5) :=
+      Category.assoc _ _ _
+    _ = boundarySevenProperFaceFundamentalChain ≫
+        (I.f 6 ≫
+          ((SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7)).chainComplex
+            (AddCommGrpCat.of ℤ)).d 6 5) := by
+      rw [I.comm 6 5]
+    _ = (boundarySevenProperFaceFundamentalChain ≫ I.f 6) ≫
+        ((SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7)).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 :=
+      (Category.assoc _ _ _).symm
+    _ = subdividedSevenBoundaryFundamentalChain ≫
+        ((SimplexCategory.sd.{0}.obj (SimplexCategory.mk 7)).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 := by
+      rw [boundarySevenProperFaceFundamentalChain_comp_inclusion]
+    _ = 0 := subdividedSevenBoundaryFundamentalChain_isCycle
+    _ = 0 ≫ I.f 5 := by simp
+
+/-- The simplicial boundary inclusion is injective on simplices in every degree. -/
+public theorem boundarySevenInclusion_app_injective (n : ℕ) :
+    Function.Injective
+      (((SSet.boundary 7 : SSet.Subcomplex (SSet.stdSimplex.obj
+        (SimplexCategory.mk 7))).ι).app
+          (Opposite.op (SimplexCategory.mk n))) :=
+  Subtype.val_injective
+
+/-- The simplicial boundary inclusion is degreewise monic on integral chains. -/
+public theorem boundarySevenInclusion_chainComplexMap_f_mono (n : ℕ) :
+    Mono ((SSet.chainComplexMap
+      ((SSet.boundary 7 : SSet.Subcomplex (SSet.stdSimplex.obj
+        (SimplexCategory.mk 7))).ι)
+      (AddCommGrpCat.of ℤ)).f n) :=
+  chainComplexMap_f_mono_of_app_injective
+    (SSet.boundary 7 : SSet.Subcomplex
+      (SSet.stdSimplex.obj (SimplexCategory.mk 7))).ι n
+      (boundarySevenInclusion_app_injective n)
+
+/-- The intrinsic alternating facet chain in `∂Δ[7]` is a cycle. -/
+public theorem boundarySevenOriginalFundamentalChain_isCycle :
+    boundarySevenOriginalFundamentalChain ≫
+        ((∂Δ[7] : SSet.{0}).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 = 0 := by
+  let j := (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+  let I := SSet.chainComplexMap j (AddCommGrpCat.of ℤ)
+  let _ : Mono (I.f 5) := boundarySevenInclusion_chainComplexMap_f_mono 5
+  apply (cancel_mono (I.f 5)).1
+  calc
+    (boundarySevenOriginalFundamentalChain ≫
+          ((∂Δ[7] : SSet.{0}).chainComplex
+            (AddCommGrpCat.of ℤ)).d 6 5) ≫ I.f 5 =
+        boundarySevenOriginalFundamentalChain ≫
+          (((∂Δ[7] : SSet.{0}).chainComplex
+            (AddCommGrpCat.of ℤ)).d 6 5 ≫ I.f 5) :=
+      Category.assoc _ _ _
+    _ = boundarySevenOriginalFundamentalChain ≫
+        (I.f 6 ≫
+          ((Δ[7] : SSet.{0}).chainComplex
+            (AddCommGrpCat.of ℤ)).d 6 5) := by
+      rw [I.comm 6 5]
+    _ = (boundarySevenOriginalFundamentalChain ≫ I.f 6) ≫
+        ((Δ[7] : SSet.{0}).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 :=
+      (Category.assoc _ _ _).symm
+    _ = standardSevenOriginalBoundaryChain ≫
+        ((Δ[7] : SSet.{0}).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 := by
+      rw [boundarySevenOriginalFundamentalChain_comp_boundaryInclusion]
+    _ = (standardSevenTopSimplexChain ≫
+          ((Δ[7] : SSet.{0}).chainComplex
+            (AddCommGrpCat.of ℤ)).d 7 6) ≫
+        ((Δ[7] : SSet.{0}).chainComplex
+          (AddCommGrpCat.of ℤ)).d 6 5 := rfl
+    _ = 0 := by
+      rw [Category.assoc,
+        HomologicalComplex.d_comp_d, comp_zero]
+    _ = 0 ≫ I.f 5 := by simp
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- bridge canonical barycentric subdivision to the proper-face nerve
- normalize the alternating boundary cycle to the canonical orientation generator
- prove the original and proper-face chains are cycles with monic inclusions
- package the canonical H6 equivalence with Z and send the original fundamental class to one
- reduce the final subdivision degree statement to the proper-face affine generator

This is PR 6 of 7 in the boundary-seven degree-transport stack, stacked on #70.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenNormalizedGeneratorHomology SphereSixComplex.Topology.BoundarySevenProperFaceGeneratorDegreeReduction
- Build completed successfully: 3075 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- audited endpoints use only propext, Classical.choice, and Quot.sound