### PR TITLE
Complete boundary-seven degree transport

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -240,6 +240,7 @@ public import SphereSixComplex.Topology.RelativeSingularHomology
 public import SphereSixComplex.Topology.SingularExcision
 public import SphereSixComplex.Topology.SingularExcisionOpenCover
 public import SphereSixComplex.Topology.BoundarySevenCechTotalQuasiIsoProof
+public import SphereSixComplex.Topology.BoundarySevenDegreeTheoryProof
 public import SphereSixComplex.Topology.SingularBarycentricAllDegrees
 public import SphereSixComplex.Topology.SingularBarycentricOuterFaces
 public import SphereSixComplex.Topology.SingularBarycentricHomotopy

--- a/SphereSixComplex/Topology/BoundarySevenDegreeTheoryProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenDegreeTheoryProof.lean
@@ -1,0 +1,28 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenCechTotalQuasiIsoProof
+public import SphereSixComplex.Topology.BoundarySevenDegreeTransportProof
+
+/-!
+# The boundary-seven degree theory
+
+The Cech argument supplies the canonical integral simplicial-to-singular comparison, while the
+independent generator-transport argument proves that coordinate reflection acts by negation on
+top homology.  This downstream adapter combines the two results without making the pure Cech or
+mod-two homology development depend on degree theory.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace SphereSixComplex
+
+/-- The standard six-sphere has the complete degree theory used by the oriented homotopy-sphere
+development. -/
+public theorem sixSphereDegreeTheory_proof :
+    Nonempty OrientedMarkedSmoothHomotopySixSphere.SixSphereDegreeTheory :=
+  sixSphereDegreeTheory_of_boundarySevenComparison
+    boundarySeven_integralComparison_proof
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenDegreeTransportProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenDegreeTransportProof.lean
@@ -1,0 +1,54 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceDegreeTransportProof
+public import SphereSixComplex.Topology.SixSphereAntipodalReflectionDegree
+
+/-!
+# Unconditional boundary-seven generator transport
+
+The normalized generator and affine proper-face realization now discharge the former
+subdivision-generator transport assumption.  Consequently, once the canonical integral
+simplicial-to-singular comparison is available, coordinate reflection acts by negation and the
+standard six-sphere has the required degree theory.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory Simplicial
+
+namespace SphereSixComplex
+
+/-- The former subdivision-generator transport predicate follows with no additional geometric
+input. -/
+public theorem boundarySevenSubdivisionGeneratorDegreeTransport_proof
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    BoundarySevenSubdivisionGeneratorDegreeTransport hcomparison e :=
+  boundarySevenSubdivisionGeneratorDegreeTransport_of_properFace hcomparison e
+    (boundarySevenProperFaceGeneratorDegreeTransport_proof hcomparison e)
+
+/-- Coordinate reflection acts by literal negation on top integral homology as soon as the
+canonical boundary comparison is known to be a quasi-isomorphism. -/
+public theorem sixSphereCoordinateReflection_homology_negation_of_boundaryComparison
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) :
+    sixSphereTopIntegralHomologyMap sixSphereCoordinateReflectionMap =
+      -AddMonoidHom.id (IntegralSingularHomology 6 SixSphere) :=
+  sixSphereCoordinateReflection_homology_negation_of_subdivisionGeneratorTransport
+    hcomparison
+    (boundarySevenSubdivisionGeneratorDegreeTransport_proof hcomparison
+      boundarySevenReflectionEquivariantHomeomorph)
+
+/-- The canonical integral boundary comparison is now the only remaining input to the complete
+degree theory of the standard six-sphere. -/
+public theorem sixSphereDegreeTheory_of_boundarySevenComparison
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) :
+    Nonempty OrientedMarkedSmoothHomotopySixSphere.SixSphereDegreeTheory :=
+  sixSphereDegreeTheory_of_comparison_coordinateReflection hcomparison
+    (sixSphereCoordinateReflection_homology_negation_of_boundaryComparison hcomparison)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceAffineGenerator.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceAffineGenerator.lean
@@ -1,0 +1,418 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenProperFaceRealizationInjective
+public import SphereSixComplex.Topology.BoundarySevenSubdivisionGeneratorTransportPrelude
+public import SphereSixComplex.Topology.SingularAffineSubdivisionPrism
+
+/-!
+# The proper-face fundamental chain under affine realization
+
+This file evaluates the intrinsic proper-face generator under the explicit affine singular map.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory ContinuousMap Opposite PartialOrder Simplicial
+
+namespace SphereSixComplex
+
+/-- The standard homeomorphism from the realization of a representable simplex to its ordinary
+topological simplex, regarded as a morphism of topological spaces. -/
+public noncomputable def standardSimplexRealizationToStdSimplexTopMap (n : ℕ) :
+    SSet.toTop.obj (Δ[n] : SSet.{0}) ⟶
+      TopCat.of (stdSimplex ℝ (Fin (n + 1))) :=
+  TopCat.ofHom ⟨SimplexCategory.toTopHomeo (SimplexCategory.mk n),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk n)).continuous⟩
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The top simplex sent through the realization/singular adjunction unit and the standard
+realization homeomorphism is the universal identity singular simplex. -/
+theorem standardSimplexTopSimplex_comparison_realization
+    (n : ℕ) :
+    (TopCat.toSSet.map (standardSimplexRealizationToStdSimplexTopMap n)).app
+        (Opposite.op (SimplexCategory.mk n))
+        ((sSetTopAdj.unit.app (Δ[n] : SSet.{0})).app
+          (Opposite.op (SimplexCategory.mk n))
+          (standardSimplexTopSimplex n)) =
+      standardTopologicalSimplexIdentitySimplex n := by
+  apply (TopCat.toSSetObjEquiv _ _).injective
+  apply ContinuousMap.ext
+  intro w
+  have hunit := sSetTopAdj_unit_app_app_down (Δ[n] : SSet.{0})
+    (Opposite.op (SimplexCategory.mk n)) (standardSimplexTopSimplex n)
+  have hid : SSet.yonedaEquiv.symm (standardSimplexTopSimplex n) =
+      𝟙 (Δ[n] : SSet.{0}) := by
+    apply SSet.yonedaEquiv.injective
+    rfl
+  have hmapid : SSet.toTop.map (𝟙 (Δ[n] : SSet.{0})) =
+      𝟙 (SSet.toTop.obj (Δ[n] : SSet.{0})) :=
+    SSet.toTop.map_id _
+  have hunit' :
+      ((sSetTopAdj.unit.app (Δ[n] : SSet.{0})).app
+        (Opposite.op (SimplexCategory.mk n))
+        (standardSimplexTopSimplex n)).down =
+          SSet.toTopSimplex.inv.app (SimplexCategory.mk n) := by
+    calc
+      _ = SSet.toTopSimplex.inv.app (SimplexCategory.mk n) ≫
+          SSet.toTop.map
+            (SSet.yonedaEquiv.symm (standardSimplexTopSimplex n)) := hunit
+      _ = SSet.toTopSimplex.inv.app (SimplexCategory.mk n) ≫
+          𝟙 (SSet.toTop.obj (Δ[n] : SSet.{0})) := by rw [hid, hmapid]
+      _ = SSet.toTopSimplex.inv.app (SimplexCategory.mk n) :=
+        Category.comp_id _
+  have hpoint := ConcreteCategory.congr_hom hunit' (ULift.up w)
+  have hinv :
+      ConcreteCategory.hom
+          (SSet.toTopSimplex.inv.app (SimplexCategory.mk n)) (ULift.up w) =
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk n)).symm w := by
+    rfl
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk n)
+      (((sSetTopAdj.unit.app (Δ[n] : SSet.{0})).app
+        (Opposite.op (SimplexCategory.mk n))
+        (standardSimplexTopSimplex n)).down.hom (ULift.up w)) = w
+  rw [hpoint]
+  calc
+    _ = SimplexCategory.toTopHomeo (SimplexCategory.mk n)
+        ((SimplexCategory.toTopHomeo (SimplexCategory.mk n)).symm w) :=
+      congrArg (SimplexCategory.toTopHomeo (SimplexCategory.mk n)) hinv
+    _ = w := Homeomorph.apply_symm_apply _ _
+
+/-- Chain-level form of `standardSimplexTopSimplex_comparison_realization`. -/
+public theorem standardSimplexTopSimplexChain_comparison_realization
+    (n : ℕ) :
+    (((Δ[n] : SSet.{0}).ιChainComplex (standardSimplexTopSimplex n) ≫
+        (simplicialToRealizationSingularChainMap
+          (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)).f n) ≫
+      (SSet.chainComplexMap
+        (TopCat.toSSet.map (standardSimplexRealizationToStdSimplexTopMap n))
+        (AddCommGrpCat.of ℤ)).f n) =
+    (TopCat.toSSet.obj
+      (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+        (standardTopologicalSimplexIdentitySimplex n) := by
+  unfold simplicialToRealizationSingularChainMap
+  rw [SSet.ι_chainComplexMap_f, SSet.ι_chainComplexMap_f]
+  exact congrArg
+    (TopCat.toSSet.obj
+      (TopCat.of (stdSimplex ℝ (Fin (n + 1))))).ιChainComplex
+      (standardSimplexTopSimplex_comparison_realization n)
+
+/-- The canonical realization map from the simplicial boundary to the ambient ordinary
+seven-simplex, as a morphism of topological spaces. -/
+public noncomputable def boundarySevenRealizationToStdSimplexTopMap :
+    SSet.toTop.obj (∂Δ[7] : SSet.{0}) ⟶
+      TopCat.of (stdSimplex ℝ (Fin 8)) :=
+  TopCat.ofHom boundarySevenRealizationToStdSimplex
+
+/-- Realizing the simplicial boundary inclusion and then using the standard representable
+homeomorphism is the canonical affine map from the realized boundary. -/
+public theorem boundarySevenRealizationToStdSimplexTopMap_factorization :
+    SSet.toTop.map
+        ((SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι) ≫
+      standardSimplexRealizationToStdSimplexTopMap 7 =
+    boundarySevenRealizationToStdSimplexTopMap := by
+  rfl
+
+/-- Naturality of the canonical comparison, followed by the affine realization map, identifies
+the boundary route with inclusion into the full representable simplex. -/
+public theorem boundarySevenComparisonRealizationToStdSimplex_factorization :
+    SSet.chainComplexMap
+          ((SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι)
+          (AddCommGrpCat.of ℤ) ≫
+        simplicialToRealizationSingularChainMap
+          (Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ≫
+      SSet.chainComplexMap
+        (TopCat.toSSet.map (standardSimplexRealizationToStdSimplexTopMap 7))
+        (AddCommGrpCat.of ℤ) =
+    simplicialToRealizationSingularChainMap
+          (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ) ≫
+      SSet.chainComplexMap
+        (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+        (AddCommGrpCat.of ℤ) := by
+  let j := (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+  rw [← Category.assoc, simplicialToRealizationSingularChainMap_naturality j,
+    Category.assoc]
+  congr 1
+  rw [← Functor.map_comp, ← Functor.map_comp,
+    boundarySevenRealizationToStdSimplexTopMap_factorization]
+
+/-- The intrinsic alternating boundary, sent through the canonical comparison and the affine
+boundary realization, is the ordinary singular boundary of the universal seven-simplex. -/
+public theorem boundarySevenOriginalFundamentalChain_comparison_realization_stdSimplex :
+    (boundarySevenOriginalFundamentalChain ≫
+        (simplicialToRealizationSingularChainMap
+          (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)).f 6) ≫
+      (SSet.chainComplexMap
+        (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+        (AddCommGrpCat.of ℤ)).f 6 =
+    (TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin 8)))).ιChainComplex
+          (standardTopologicalSimplexIdentitySimplex 7) ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin 8)))).chainComplex
+          (AddCommGrpCat.of ℤ)).d 7 6 := by
+  let j := (SSet.boundary 7 : SSet.Subcomplex (Δ[7] : SSet.{0})).ι
+  let Cbdry := simplicialToRealizationSingularChainMap
+    (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)
+  let Tbdry := SSet.chainComplexMap
+    (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+      (AddCommGrpCat.of ℤ)
+  let Cstd := simplicialToRealizationSingularChainMap
+    (Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)
+  let Tstd := SSet.chainComplexMap
+    (TopCat.toSSet.map (standardSimplexRealizationToStdSimplexTopMap 7))
+      (AddCommGrpCat.of ℤ)
+  let J := SSet.chainComplexMap j (AddCommGrpCat.of ℤ)
+  have hfactor := congrArg (fun K ↦ K.f 6)
+    boundarySevenComparisonRealizationToStdSimplex_factorization
+  change (J ≫ Cstd ≫ Tstd).f 6 = (Cbdry ≫ Tbdry).f 6 at hfactor
+  have hfactor' : J.f 6 ≫ Cstd.f 6 ≫ Tstd.f 6 =
+      Cbdry.f 6 ≫ Tbdry.f 6 := by
+    exact hfactor
+  calc
+    (boundarySevenOriginalFundamentalChain ≫ Cbdry.f 6) ≫ Tbdry.f 6 =
+        boundarySevenOriginalFundamentalChain ≫ (Cbdry.f 6 ≫ Tbdry.f 6) :=
+      Category.assoc _ _ _
+    _ = boundarySevenOriginalFundamentalChain ≫
+          (J.f 6 ≫ Cstd.f 6 ≫ Tstd.f 6) := by rw [hfactor']
+    _ = ((boundarySevenOriginalFundamentalChain ≫ J.f 6) ≫
+          Cstd.f 6) ≫ Tstd.f 6 := by simp only [Category.assoc]
+    _ = (standardSevenOriginalBoundaryChain ≫ Cstd.f 6) ≫ Tstd.f 6 := by
+      rw [boundarySevenOriginalFundamentalChain_comp_boundaryInclusion]
+    _ = (((standardSevenTopSimplexChain ≫ Cstd.f 7) ≫ Tstd.f 7) ≫
+          ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin 8)))).chainComplex
+              (AddCommGrpCat.of ℤ)).d 7 6) := by
+      rw [standardSevenOriginalBoundaryChain]
+      calc
+        ((standardSevenTopSimplexChain ≫
+            ((Δ[7] : SSet.{0}).chainComplex
+              (AddCommGrpCat.of ℤ)).d 7 6) ≫ Cstd.f 6) ≫ Tstd.f 6 =
+            (standardSevenTopSimplexChain ≫
+              (((Δ[7] : SSet.{0}).chainComplex
+                (AddCommGrpCat.of ℤ)).d 7 6 ≫ Cstd.f 6)) ≫ Tstd.f 6 :=
+          congrArg (fun q ↦ q ≫ Tstd.f 6)
+            (Category.assoc _ _ _)
+        _ = (standardSevenTopSimplexChain ≫
+              (Cstd.f 7 ≫
+                ((TopCat.toSSet.obj
+                  (SSet.toTop.obj (Δ[7] : SSet.{0}))).chainComplex
+                    (AddCommGrpCat.of ℤ)).d 7 6)) ≫ Tstd.f 6 := by
+          rw [Cstd.comm 7 6]
+        _ = ((standardSevenTopSimplexChain ≫ Cstd.f 7) ≫
+              ((TopCat.toSSet.obj
+                (SSet.toTop.obj (Δ[7] : SSet.{0}))).chainComplex
+                  (AddCommGrpCat.of ℤ)).d 7 6) ≫ Tstd.f 6 := by
+          rw [← Category.assoc]
+        _ = (standardSevenTopSimplexChain ≫ Cstd.f 7) ≫
+              (((TopCat.toSSet.obj
+                (SSet.toTop.obj (Δ[7] : SSet.{0}))).chainComplex
+                  (AddCommGrpCat.of ℤ)).d 7 6 ≫ Tstd.f 6) :=
+          Category.assoc _ _ _
+        _ = (standardSevenTopSimplexChain ≫ Cstd.f 7) ≫
+              (Tstd.f 7 ≫
+                ((TopCat.toSSet.obj
+                  (TopCat.of (stdSimplex ℝ (Fin 8)))).chainComplex
+                    (AddCommGrpCat.of ℤ)).d 7 6) := by
+          rw [Tstd.comm 7 6]
+        _ = ((standardSevenTopSimplexChain ≫ Cstd.f 7) ≫ Tstd.f 7) ≫
+              ((TopCat.toSSet.obj
+                (TopCat.of (stdSimplex ℝ (Fin 8)))).chainComplex
+                  (AddCommGrpCat.of ℤ)).d 7 6 :=
+          (Category.assoc _ _ _).symm
+    _ = (TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin 8)))).ιChainComplex
+            (standardTopologicalSimplexIdentitySimplex 7) ≫
+          ((TopCat.toSSet.obj
+            (TopCat.of (stdSimplex ℝ (Fin 8)))).chainComplex
+              (AddCommGrpCat.of ℤ)).d 7 6 := by
+      rw [standardSevenTopSimplexChain]
+      rw [standardSimplexTopSimplexChain_comparison_realization]
+
+/-- For the universal identity singular simplex, the alternating affine subdivisions of its
+faces are the explicit alternating affine boundary chain. -/
+public theorem standardTopologicalSimplexIdentity_affineSubdivisionAlternatingFaceChain
+    (n : ℕ) :
+    affineSubdivisionSingularSimplexAlternatingFaceChain
+        (TopCat.of (stdSimplex ℝ (Fin (n + 2)))) n
+        (standardTopologicalSimplexIdentitySimplex (n + 1)) =
+      affineSubdividedSimplexAlternatingFaceChain n := by
+  rw [affineSubdividedSimplexAlternatingFaceChain_eq_expected]
+  rw [affineSubdivisionSingularSimplexAlternatingFaceChain,
+    affineSubdividedSimplexExpectedBoundaryChain]
+  apply Finset.sum_congr rfl
+  intro p _
+  apply congrArg (fun q ↦ ((-1 : ℤ) ^ p.val) • q)
+  rw [affineSubdivisionSingularSimplexChain,
+    singularSimplexTopCatMap_identity_delta]
+
+/-- Affine singular subdivision sends the ordinary singular boundary of the universal
+seven-simplex to the explicit alternating affine subdivided boundary. -/
+public theorem standardSevenTopologicalBoundary_affineSubdivision :
+    ((TopCat.toSSet.obj
+          (TopCat.of (stdSimplex ℝ (Fin 8)))).ιChainComplex
+        (standardTopologicalSimplexIdentitySimplex 7) ≫
+      ((TopCat.toSSet.obj
+        (TopCat.of (stdSimplex ℝ (Fin 8)))).chainComplex
+          (AddCommGrpCat.of ℤ)).d 7 6) ≫
+      (affineSingularSubdivisionChainMap
+        (TopCat.of (stdSimplex ℝ (Fin 8)))).f 6 =
+    affineSubdividedSimplexAlternatingFaceChain 6 := by
+  let S := affineSingularSubdivisionChainMap
+    (TopCat.of (stdSimplex ℝ (Fin 8)))
+  change (_ ≫ _) ≫ S.f 6 = _
+  rw [Category.assoc, ← S.comm 7 6, ← Category.assoc]
+  rw [affineSingularSubdivisionChainMap_f,
+    iota_affineSingularSubdivisionComponent,
+    affineSubdivisionSingularSimplexChain_boundary,
+    standardTopologicalSimplexIdentity_affineSubdivisionAlternatingFaceChain]
+
+/-- After one affine singular subdivision, the original boundary generator transported through
+the canonical comparison is the explicit alternating affine subdivided boundary. -/
+public theorem boundarySevenOriginalFundamentalChain_comparison_affineSubdivision :
+    (((boundarySevenOriginalFundamentalChain ≫
+          (simplicialToRealizationSingularChainMap
+            (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+      (affineSingularSubdivisionChainMap
+        (TopCat.of (stdSimplex ℝ (Fin 8)))).f 6) =
+    affineSubdividedSimplexAlternatingFaceChain 6 := by
+  rw [boundarySevenOriginalFundamentalChain_comparison_realization_stdSimplex]
+  exact standardSevenTopologicalBoundary_affineSubdivision
+
+/-- Forget the proof that a point lies in the ordinary simplex boundary. -/
+public noncomputable def standardSimplexBoundaryToStdSimplexTopMap :
+    TopCat.of (StandardSimplexBoundary 7) ⟶
+      TopCat.of (stdSimplex ℝ (Fin 8)) :=
+  TopCat.ofHom ⟨Subtype.val, continuous_subtype_val⟩
+
+/-- Forgetting the boundary witness, the proper-face affine simplex is the ordinary affine flag
+simplex associated to its image in the full nonempty-face nerve. -/
+public theorem boundarySevenProperFaceAffineFlagMap_val_eq_affineFlagContinuousMap
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k)
+    (w : stdSimplex ℝ (Fin (k + 1))) :
+    (boundarySevenProperFaceAffineFlagMap k F w : stdSimplex ℝ (Fin 8)) =
+      affineFlagContinuousMap 7 k
+        (boundarySevenProperFaceNerveInclusion.app
+          (Opposite.op (SimplexCategory.mk k)) F) w := by
+  rfl
+
+/-- After forgetting the boundary witness, the proper-face singular simplex is literally the
+ambient affine flag singular simplex. -/
+public theorem boundarySevenProperFaceAffineSingularSimplex_map_val
+    (k : ℕ) (F : ComposableArrows BoundarySevenProperFace k) :
+    (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap).app
+        (Opposite.op (SimplexCategory.mk k))
+        (boundarySevenProperFaceAffineSingularSimplex k F) =
+      affineFlagSingularSimplex 7 k
+        (boundarySevenProperFaceNerveInclusion.app
+          (Opposite.op (SimplexCategory.mk k)) F) := by
+  apply (TopCat.toSSetObjEquiv _ _).injective
+  apply ContinuousMap.ext
+  intro w
+  exact boundarySevenProperFaceAffineFlagMap_val_eq_affineFlagContinuousMap k F w
+
+/-- The proper-face affine chain map, followed by the boundary inclusion, is the restriction of
+the ambient affine flag chain map along the proper-face nerve inclusion. -/
+public theorem boundarySevenProperFaceAffineChainMap_comp_val :
+    SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+        (AddCommGrpCat.of ℤ) ≫
+      SSet.chainComplexMap
+          (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+          (AddCommGrpCat.of ℤ) =
+    SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+        (AddCommGrpCat.of ℤ) ≫
+      affineFlagChainMap 7 := by
+  let A := SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+    (AddCommGrpCat.of ℤ)
+  let V := SSet.chainComplexMap
+    (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+      (AddCommGrpCat.of ℤ)
+  let I := SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+    (AddCommGrpCat.of ℤ)
+  let G := affineFlagChainMap 7
+  apply HomologicalComplex.Hom.ext
+  funext k
+  apply BoundarySevenProperFaceNerve.chainComplex_hom_ext
+  intro F
+  change ((BoundarySevenProperFaceNerve.ιChainComplex F ≫ A.f k) ≫ V.f k) =
+    ((BoundarySevenProperFaceNerve.ιChainComplex F ≫ I.f k) ≫ G.f k)
+  rw [SSet.ι_chainComplexMap_f, SSet.ι_chainComplexMap_f,
+    SSet.ι_chainComplexMap_f]
+  dsimp only [G]
+  rw [affineFlagChainMap_f]
+  rw [iota_affineFlagChainComponent]
+  exact congrArg
+    (TopCat.toSSet.obj (TopCat.of (stdSimplex ℝ (Fin 8)))).ιChainComplex
+      (boundarySevenProperFaceAffineSingularSimplex_map_val k F)
+
+/-- The ambient affine realization of the explicit subdivided boundary is the alternating affine
+boundary of the subdivided seven-simplex. -/
+public theorem subdividedSevenBoundaryFundamentalChain_affineFlag :
+    subdividedSevenBoundaryFundamentalChain ≫
+        (affineFlagChainMap 7).f 6 =
+      affineSubdividedSimplexAlternatingFaceChain 6 := by
+  let G := affineFlagChainMap 7
+  change (subdividedSimplexFundamentalChain 7 ≫ _) ≫ G.f 6 = _
+  rw [Category.assoc, ← G.comm 7 6, ← Category.assoc]
+  exact affineSubdividedSimplexFundamentalChain_boundary 6
+
+/-- Under the canonical proper-face comparison and affine homeomorphism, the intrinsic
+proper-face generator is exactly the alternating affine boundary chain, after forgetting the
+boundary witness. -/
+public theorem boundarySevenProperFaceFundamentalChain_affine_realization_val :
+    (boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+      (SSet.chainComplexMap
+        (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+        (AddCommGrpCat.of ℤ)).f 6 =
+    affineSubdividedSimplexAlternatingFaceChain 6 := by
+  let A := SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+    (AddCommGrpCat.of ℤ)
+  let V := SSet.chainComplexMap
+    (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+      (AddCommGrpCat.of ℤ)
+  let I := SSet.chainComplexMap boundarySevenProperFaceNerveInclusion
+    (AddCommGrpCat.of ℤ)
+  let G := affineFlagChainMap 7
+  have hmap := congrArg (fun K ↦ K.f 6)
+    boundarySevenProperFaceAffineChainMap_comp_val
+  change A.f 6 ≫ V.f 6 = I.f 6 ≫ G.f 6 at hmap
+  calc
+    (boundarySevenProperFaceFundamentalChain ≫ A.f 6) ≫ V.f 6 =
+        boundarySevenProperFaceFundamentalChain ≫ (A.f 6 ≫ V.f 6) :=
+      Category.assoc _ _ _
+    _ = boundarySevenProperFaceFundamentalChain ≫ (I.f 6 ≫ G.f 6) := by
+      rw [hmap]
+    _ = (boundarySevenProperFaceFundamentalChain ≫ I.f 6) ≫ G.f 6 :=
+      (Category.assoc _ _ _).symm
+    _ = subdividedSevenBoundaryFundamentalChain ≫ G.f 6 := by
+      rw [boundarySevenProperFaceFundamentalChain_comp_inclusion]
+    _ = affineSubdividedSimplexAlternatingFaceChain 6 :=
+      subdividedSevenBoundaryFundamentalChain_affineFlag
+
+/-- The proper-face affine generator and the original boundary generator agree exactly after
+transporting both to ambient singular chains and applying one affine subdivision to the latter. -/
+public theorem boundarySevenProperFaceGenerator_eq_original_after_affineSubdivision :
+    (boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+      (SSet.chainComplexMap
+        (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+        (AddCommGrpCat.of ℤ)).f 6 =
+    ((boundarySevenOriginalFundamentalChain ≫
+          (simplicialToRealizationSingularChainMap
+            (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+      (affineSingularSubdivisionChainMap
+        (TopCat.of (stdSimplex ℝ (Fin 8)))).f 6 := by
+  rw [boundarySevenProperFaceFundamentalChain_affine_realization_val,
+    boundarySevenOriginalFundamentalChain_comparison_affineSubdivision]
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/BoundarySevenProperFaceDegreeTransportProof.lean
+++ b/SphereSixComplex/Topology/BoundarySevenProperFaceDegreeTransportProof.lean
@@ -1,0 +1,666 @@
+module
+
+public import SphereSixComplex.Topology.BoundarySevenNormalizedGeneratorHomology
+public import SphereSixComplex.Topology.BoundarySevenProperFaceAffineGenerator
+public import SphereSixComplex.Topology.BoundarySevenProperFaceGeneratorDegreeReduction
+public import SphereSixComplex.Topology.SixSphereHomologicalDegreeScalar
+
+/-!
+# Degree transport from the proper-face generator
+
+This file closes the generator-transport reduction.  First it strengthens the ambient affine
+chain identity to singular chains in the ordinary simplex boundary.  It then transports the
+explicit normalized orientation through that identity and proves the proper-face degree formula.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology CategoryTheory CategoryTheory.Limits ContinuousMap Opposite PartialOrder
+  Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical map from the realization of the simplicial boundary to the ordinary affine
+boundary, bundled as a morphism of topological spaces. -/
+public noncomputable def boundarySevenRealizationToBoundaryTopMap :
+    SSet.toTop.obj (∂Δ[7] : SSet.{0}) ⟶
+      TopCat.of (StandardSimplexBoundary 7) :=
+  TopCat.ofHom boundarySevenRealizationToBoundary
+
+/-- The ambient realization map factors through the ordinary affine boundary. -/
+public theorem boundarySevenRealizationToStdSimplexTopMap_factorization_boundary :
+    boundarySevenRealizationToBoundaryTopMap ≫
+        standardSimplexBoundaryToStdSimplexTopMap =
+      boundarySevenRealizationToStdSimplexTopMap := by
+  rfl
+
+/-- Forgetting that a singular simplex lands in the affine boundary is injective in every
+simplicial degree. -/
+public theorem standardSimplexBoundaryToStdSimplex_singularMap_app_injective
+    (n : ℕ) :
+    Function.Injective
+      ((TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap).app
+        (Opposite.op (SimplexCategory.mk n))) := by
+  intro f g hfg
+  apply (TopCat.toSSetObjEquiv _ _).injective
+  apply ContinuousMap.ext
+  intro w
+  apply Subtype.ext
+  have h := congrArg
+    (fun q ↦ (TopCat.toSSetObjEquiv
+      (TopCat.of (stdSimplex ℝ (Fin 8)))
+        (Opposite.op (SimplexCategory.mk n)) q) w) hfg
+  exact h
+
+/-- The induced map from boundary-valued to ambient singular chains is degreewise monic. -/
+public theorem standardSimplexBoundaryToStdSimplex_singularChainMap_f_mono
+    (n : ℕ) :
+    Mono ((SSet.chainComplexMap
+      (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+      (AddCommGrpCat.of ℤ)).f n) :=
+  chainComplexMap_f_mono_of_app_injective
+    (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap) n
+      (standardSimplexBoundaryToStdSimplex_singularMap_app_injective n)
+
+/-- The proper-face affine generator agrees with the original comparison generator already in
+singular chains of the ordinary boundary, after one affine subdivision. -/
+public theorem boundarySevenProperFaceGenerator_eq_original_after_affineSubdivision_boundary :
+    boundarySevenProperFaceFundamentalChain ≫
+        (SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+          (AddCommGrpCat.of ℤ)).f 6 =
+      ((boundarySevenOriginalFundamentalChain ≫
+          (simplicialToRealizationSingularChainMap
+            (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)).f 6) ≫
+        (SSet.chainComplexMap
+          (TopCat.toSSet.map boundarySevenRealizationToBoundaryTopMap)
+          (AddCommGrpCat.of ℤ)).f 6) ≫
+      (affineSingularSubdivisionChainMap
+        (TopCat.of (StandardSimplexBoundary 7))).f 6 := by
+  let A := SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+    (AddCommGrpCat.of ℤ)
+  let B := simplicialToRealizationSingularChainMap
+    (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)
+  let R := SSet.chainComplexMap
+    (TopCat.toSSet.map boundarySevenRealizationToBoundaryTopMap)
+      (AddCommGrpCat.of ℤ)
+  let V := SSet.chainComplexMap
+    (TopCat.toSSet.map standardSimplexBoundaryToStdSimplexTopMap)
+      (AddCommGrpCat.of ℤ)
+  let Sd := affineSingularSubdivisionChainMap
+    (TopCat.of (StandardSimplexBoundary 7))
+  let Sa := affineSingularSubdivisionChainMap
+    (TopCat.of (stdSimplex ℝ (Fin 8)))
+  let _ : Mono (V.f 6) :=
+    standardSimplexBoundaryToStdSimplex_singularChainMap_f_mono 6
+  apply (cancel_mono (V.f 6)).1
+  have htop := congrArg (fun f ↦ TopCat.toSSet.map f)
+    boundarySevenRealizationToStdSimplexTopMap_factorization_boundary
+  rw [Functor.map_comp] at htop
+  have hsset := ((SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)).congr_map htop
+  have hfactor := congrArg (fun K ↦ K.f 6) hsset
+  rw [Functor.map_comp] at hfactor
+  change R.f 6 ≫ V.f 6 =
+    (SSet.chainComplexMap
+      (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+      (AddCommGrpCat.of ℤ)).f 6 at hfactor
+  have hnat := congrArg (fun K ↦ K.f 6)
+    (affineSingularSubdivisionChainMap_naturality
+      standardSimplexBoundaryToStdSimplexTopMap)
+  change V.f 6 ≫ Sa.f 6 = Sd.f 6 ≫ V.f 6 at hnat
+  calc
+    (boundarySevenProperFaceFundamentalChain ≫ A.f 6) ≫ V.f 6 =
+        ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫
+          (SSet.chainComplexMap
+            (TopCat.toSSet.map boundarySevenRealizationToStdSimplexTopMap)
+            (AddCommGrpCat.of ℤ)).f 6) ≫ Sa.f 6 :=
+      boundarySevenProperFaceGenerator_eq_original_after_affineSubdivision
+    _ = ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫
+          (R.f 6 ≫ V.f 6)) ≫ Sa.f 6 := by rw [hfactor]
+    _ = ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6) ≫
+          (V.f 6 ≫ Sa.f 6) := by simp only [Category.assoc]
+    _ = ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6) ≫
+          (Sd.f 6 ≫ V.f 6) := by rw [hnat]
+    _ = (((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6) ≫
+          Sd.f 6) ≫ V.f 6 := by simp only [Category.assoc]
+
+/-! ## Homology classes represented by explicit cycles -/
+
+/-- Postcomposition of a degree-six cycle by a chain map is again a cycle. -/
+public theorem degreeSixCycle_comp_chainMap_isCycle
+    {K L : ChainComplex AddCommGrpCat ℕ}
+    (F : K ⟶ L) (c : AddCommGrpCat.of ℤ ⟶ K.X 6)
+    (hc : c ≫ K.d 6 5 = 0) :
+    (c ≫ F.f 6) ≫ L.d 6 5 = 0 := by
+  rw [Category.assoc, F.comm 6 5, ← Category.assoc, hc, zero_comp]
+
+/-- The degree-six homology class represented by a chain-level cycle. -/
+public noncomputable def degreeSixCycleHomologyClass
+    (K : ChainComplex AddCommGrpCat ℕ)
+    (c : AddCommGrpCat.of ℤ ⟶ K.X 6)
+    (hc : c ≫ K.d 6 5 = 0) :
+    AddCommGrpCat.of ℤ ⟶ K.homology 6 :=
+  K.liftCycles c 5 (by simp) hc ≫ K.homologyπ 6
+
+/-- Cycle representatives commute with the homology map induced by a chain map. -/
+public theorem degreeSixCycleHomologyClass_naturality
+    {K L : ChainComplex AddCommGrpCat ℕ}
+    (F : K ⟶ L) (c : AddCommGrpCat.of ℤ ⟶ K.X 6)
+    (hc : c ≫ K.d 6 5 = 0) :
+    degreeSixCycleHomologyClass K c hc ≫
+        HomologicalComplex.homologyMap F 6 =
+      degreeSixCycleHomologyClass L (c ≫ F.f 6)
+        (degreeSixCycle_comp_chainMap_isCycle F c hc) := by
+  unfold degreeSixCycleHomologyClass
+  rw [Category.assoc, HomologicalComplex.homologyπ_naturality]
+  rw [← Category.assoc]
+  rw [HomologicalComplex.liftCycles_comp_cyclesMap]
+
+/-- Taking the homology class of a scalar multiple of a cycle scales its class. -/
+public theorem degreeSixCycleHomologyClass_zsmul
+    (K : ChainComplex AddCommGrpCat ℕ)
+    (c : AddCommGrpCat.of ℤ ⟶ K.X 6)
+    (hc : c ≫ K.d 6 5 = 0) (z : ℤ) :
+    degreeSixCycleHomologyClass K (z • c)
+        (by rw [Preadditive.zsmul_comp, hc, smul_zero]) =
+      z • degreeSixCycleHomologyClass K c hc := by
+  unfold degreeSixCycleHomologyClass
+  have hlift :
+      K.liftCycles (z • c) 5 (by simp)
+          (by rw [Preadditive.zsmul_comp, hc, smul_zero]) =
+        z • K.liftCycles c 5 (by simp) hc := by
+    apply (cancel_mono (K.iCycles 6)).1
+    rw [HomologicalComplex.liftCycles_i]
+    rw [Preadditive.zsmul_comp, HomologicalComplex.liftCycles_i]
+  rw [hlift, Preadditive.zsmul_comp]
+
+/-- The homology class depends only on its chain representative, not on the selected proof that
+the representative is a cycle. -/
+public theorem degreeSixCycleHomologyClass_eq_of_eq
+    (K : ChainComplex AddCommGrpCat ℕ)
+    (c d : AddCommGrpCat.of ℤ ⟶ K.X 6)
+    (hc : c ≫ K.d 6 5 = 0) (hd : d ≫ K.d 6 5 = 0)
+    (h : c = d) :
+    degreeSixCycleHomologyClass K c hc =
+      degreeSixCycleHomologyClass K d hd := by
+  subst d
+  rfl
+
+/-- The homology class of the proper-face fundamental cycle. -/
+public noncomputable def boundarySevenProperFaceFundamentalHomologyClass :
+    AddCommGrpCat.of ℤ ⟶
+      (BoundarySevenProperFaceNerve.chainComplex
+        (AddCommGrpCat.of ℤ)).homology 6 :=
+  degreeSixCycleHomologyClass
+    (BoundarySevenProperFaceNerve.chainComplex (AddCommGrpCat.of ℤ))
+    boundarySevenProperFaceFundamentalChain
+    boundarySevenProperFaceFundamentalChain_isCycle
+
+/-- The proper-face class transported by its affine realization to singular homology of the
+ordinary simplex boundary. -/
+public noncomputable def boundarySevenProperFaceSingularBoundaryHomologyClass :
+    AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (StandardSimplexBoundary 7))).chainComplex
+          (AddCommGrpCat.of ℤ)).homology 6 :=
+  boundarySevenProperFaceFundamentalHomologyClass ≫
+    HomologicalComplex.homologyMap
+      (SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+        (AddCommGrpCat.of ℤ)) 6
+
+/-- The original boundary class transported by the canonical realization homeomorphism to
+singular homology of the ordinary simplex boundary. -/
+public noncomputable def boundarySevenOriginalSingularBoundaryHomologyClass :
+    AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj
+        (TopCat.of (StandardSimplexBoundary 7))).chainComplex
+          (AddCommGrpCat.of ℤ)).homology 6 :=
+  boundarySevenOriginalFundamentalHomologyClass ≫
+    HomologicalComplex.homologyMap
+      (simplicialToRealizationSingularChainMap
+        (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 6 ≫
+    HomologicalComplex.homologyMap
+      (SSet.chainComplexMap
+        (TopCat.toSSet.map boundarySevenRealizationToBoundaryTopMap)
+        (AddCommGrpCat.of ℤ)) 6
+
+/-- The proper-face affine singular class is the original singular boundary class. -/
+public theorem boundarySevenProperFaceSingularBoundaryHomologyClass_eq_original :
+    boundarySevenProperFaceSingularBoundaryHomologyClass =
+      boundarySevenOriginalSingularBoundaryHomologyClass := by
+  let K := (BoundarySevenProperFaceNerve.chainComplex (AddCommGrpCat.of ℤ))
+  let L := (TopCat.toSSet.obj
+    (TopCat.of (StandardSimplexBoundary 7))).chainComplex (AddCommGrpCat.of ℤ)
+  let A := SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+    (AddCommGrpCat.of ℤ)
+  let B := simplicialToRealizationSingularChainMap
+    (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)
+  let R := SSet.chainComplexMap
+    (TopCat.toSSet.map boundarySevenRealizationToBoundaryTopMap)
+      (AddCommGrpCat.of ℤ)
+  let Sd := affineSingularSubdivisionChainMap
+    (TopCat.of (StandardSimplexBoundary 7))
+  have hsubdivision : HomologicalComplex.homologyMap Sd 6 = 𝟙 (L.homology 6) := by
+    dsimp only [Sd, L]
+    rw [(affineSingularSubdivisionHomotopy
+      (TopCat.of (StandardSimplexBoundary 7))).homologyMap_eq 6]
+    exact HomologicalComplex.homologyMap_id _ _
+  have hproper := degreeSixCycleHomologyClass_naturality A
+    boundarySevenProperFaceFundamentalChain
+      boundarySevenProperFaceFundamentalChain_isCycle
+  have horiginalB := degreeSixCycleHomologyClass_naturality B
+    boundarySevenOriginalFundamentalChain
+      boundarySevenOriginalFundamentalChain_isCycle
+  have horiginalR := degreeSixCycleHomologyClass_naturality R
+    (boundarySevenOriginalFundamentalChain ≫ B.f 6)
+      (degreeSixCycle_comp_chainMap_isCycle B
+        boundarySevenOriginalFundamentalChain
+          boundarySevenOriginalFundamentalChain_isCycle)
+  have horiginalSd := degreeSixCycleHomologyClass_naturality Sd
+    ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6)
+      (degreeSixCycle_comp_chainMap_isCycle R
+        (boundarySevenOriginalFundamentalChain ≫ B.f 6)
+        (degreeSixCycle_comp_chainMap_isCycle B
+          boundarySevenOriginalFundamentalChain
+            boundarySevenOriginalFundamentalChain_isCycle))
+  have hchain :=
+    boundarySevenProperFaceGenerator_eq_original_after_affineSubdivision_boundary
+  change boundarySevenProperFaceFundamentalChain ≫ A.f 6 =
+    ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6) ≫
+      Sd.f 6 at hchain
+  have hclasses :
+      degreeSixCycleHomologyClass L
+          (boundarySevenProperFaceFundamentalChain ≫ A.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle A
+            boundarySevenProperFaceFundamentalChain
+              boundarySevenProperFaceFundamentalChain_isCycle) =
+        degreeSixCycleHomologyClass L
+          (((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6) ≫
+            Sd.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle Sd
+            ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6)
+            (degreeSixCycle_comp_chainMap_isCycle R
+              (boundarySevenOriginalFundamentalChain ≫ B.f 6)
+              (degreeSixCycle_comp_chainMap_isCycle B
+                boundarySevenOriginalFundamentalChain
+                  boundarySevenOriginalFundamentalChain_isCycle))) := by
+    exact degreeSixCycleHomologyClass_eq_of_eq L _ _ _ _ hchain
+  have horiginalBase :
+      boundarySevenOriginalFundamentalHomologyClass =
+        degreeSixCycleHomologyClass
+          ((∂Δ[7] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ))
+          boundarySevenOriginalFundamentalChain
+          boundarySevenOriginalFundamentalChain_isCycle := by
+    rfl
+  calc
+    boundarySevenProperFaceSingularBoundaryHomologyClass =
+        degreeSixCycleHomologyClass L
+          (boundarySevenProperFaceFundamentalChain ≫ A.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle A
+            boundarySevenProperFaceFundamentalChain
+              boundarySevenProperFaceFundamentalChain_isCycle) := by
+      rw [boundarySevenProperFaceSingularBoundaryHomologyClass,
+        boundarySevenProperFaceFundamentalHomologyClass]
+      exact hproper
+    _ = degreeSixCycleHomologyClass L
+          (((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6) ≫
+            Sd.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle Sd
+            ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6)
+            (degreeSixCycle_comp_chainMap_isCycle R
+              (boundarySevenOriginalFundamentalChain ≫ B.f 6)
+              (degreeSixCycle_comp_chainMap_isCycle B
+                boundarySevenOriginalFundamentalChain
+                  boundarySevenOriginalFundamentalChain_isCycle))) := hclasses
+    _ = degreeSixCycleHomologyClass L
+          ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle R
+            (boundarySevenOriginalFundamentalChain ≫ B.f 6)
+            (degreeSixCycle_comp_chainMap_isCycle B
+              boundarySevenOriginalFundamentalChain
+                boundarySevenOriginalFundamentalChain_isCycle)) ≫
+          HomologicalComplex.homologyMap Sd 6 := horiginalSd.symm
+    _ = degreeSixCycleHomologyClass L
+          ((boundarySevenOriginalFundamentalChain ≫ B.f 6) ≫ R.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle R
+            (boundarySevenOriginalFundamentalChain ≫ B.f 6)
+            (degreeSixCycle_comp_chainMap_isCycle B
+              boundarySevenOriginalFundamentalChain
+                boundarySevenOriginalFundamentalChain_isCycle)) := by
+      rw [hsubdivision, Category.comp_id]
+    _ = boundarySevenOriginalSingularBoundaryHomologyClass := by
+      rw [← horiginalR, ← horiginalB, ← horiginalBase]
+      rfl
+
+/-- A scalar action on the proper-face chain induces the same scalar action on its affine
+singular homology class. -/
+public theorem boundarySevenProperFaceSingularBoundaryHomologyClass_permutation
+    (sigma : Equiv.Perm (Fin 8)) (z : ℤ)
+    (h : boundarySevenProperFaceFundamentalChain ≫
+          (SSet.chainComplexMap
+            (boundarySevenProperFaceNervePermIso sigma).hom
+            (AddCommGrpCat.of ℤ)).f 6 =
+        z • boundarySevenProperFaceFundamentalChain) :
+    boundarySevenProperFaceSingularBoundaryHomologyClass ≫
+        HomologicalComplex.homologyMap
+          (SSet.chainComplexMap
+            (TopCat.toSSet.map (standardSimplexBoundaryPermTopMap sigma))
+            (AddCommGrpCat.of ℤ)) 6 =
+      z • boundarySevenProperFaceSingularBoundaryHomologyClass := by
+  let K := BoundarySevenProperFaceNerve.chainComplex (AddCommGrpCat.of ℤ)
+  let L := (TopCat.toSSet.obj
+    (TopCat.of (StandardSimplexBoundary 7))).chainComplex (AddCommGrpCat.of ℤ)
+  let P := SSet.chainComplexMap
+    (boundarySevenProperFaceNervePermIso sigma).hom (AddCommGrpCat.of ℤ)
+  let A := SSet.chainComplexMap boundarySevenProperFaceAffineSingularMap
+    (AddCommGrpCat.of ℤ)
+  let T := SSet.chainComplexMap
+    (TopCat.toSSet.map (standardSimplexBoundaryPermTopMap sigma))
+      (AddCommGrpCat.of ℤ)
+  have hmap := ((SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)).congr_map
+      (boundarySevenProperFaceAffineSingularMap_equivariant sigma)
+  rw [Functor.map_comp, Functor.map_comp] at hmap
+  have hmap6 := congrArg (fun F ↦ F.f 6) hmap
+  change P.f 6 ≫ A.f 6 = A.f 6 ≫ T.f 6 at hmap6
+  have hchain :
+      (boundarySevenProperFaceFundamentalChain ≫ A.f 6) ≫ T.f 6 =
+        z • (boundarySevenProperFaceFundamentalChain ≫ A.f 6) := by
+    calc
+      _ = boundarySevenProperFaceFundamentalChain ≫
+          (A.f 6 ≫ T.f 6) := Category.assoc _ _ _
+      _ = boundarySevenProperFaceFundamentalChain ≫
+          (P.f 6 ≫ A.f 6) := by rw [hmap6]
+      _ = (boundarySevenProperFaceFundamentalChain ≫ P.f 6) ≫
+          A.f 6 := (Category.assoc _ _ _).symm
+      _ = (z • boundarySevenProperFaceFundamentalChain) ≫ A.f 6 := by
+        rw [h]
+      _ = z • (boundarySevenProperFaceFundamentalChain ≫ A.f 6) := by
+        rw [Preadditive.zsmul_comp]
+  have hA := degreeSixCycleHomologyClass_naturality A
+    boundarySevenProperFaceFundamentalChain
+      boundarySevenProperFaceFundamentalChain_isCycle
+  have hT := degreeSixCycleHomologyClass_naturality T
+    (boundarySevenProperFaceFundamentalChain ≫ A.f 6)
+      (degreeSixCycle_comp_chainMap_isCycle A
+        boundarySevenProperFaceFundamentalChain
+          boundarySevenProperFaceFundamentalChain_isCycle)
+  calc
+    boundarySevenProperFaceSingularBoundaryHomologyClass ≫
+          HomologicalComplex.homologyMap T 6 =
+        degreeSixCycleHomologyClass L
+          (boundarySevenProperFaceFundamentalChain ≫ A.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle A
+            boundarySevenProperFaceFundamentalChain
+              boundarySevenProperFaceFundamentalChain_isCycle) ≫
+            HomologicalComplex.homologyMap T 6 := by
+      rw [boundarySevenProperFaceSingularBoundaryHomologyClass,
+        boundarySevenProperFaceFundamentalHomologyClass, hA]
+    _ = degreeSixCycleHomologyClass L
+          ((boundarySevenProperFaceFundamentalChain ≫ A.f 6) ≫ T.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle T
+            (boundarySevenProperFaceFundamentalChain ≫ A.f 6)
+            (degreeSixCycle_comp_chainMap_isCycle A
+              boundarySevenProperFaceFundamentalChain
+                boundarySevenProperFaceFundamentalChain_isCycle)) := hT
+    _ = degreeSixCycleHomologyClass L
+          (z • (boundarySevenProperFaceFundamentalChain ≫ A.f 6))
+          (by
+            rw [Preadditive.zsmul_comp]
+            rw [degreeSixCycle_comp_chainMap_isCycle A
+              boundarySevenProperFaceFundamentalChain
+                boundarySevenProperFaceFundamentalChain_isCycle, smul_zero]) := by
+      apply degreeSixCycleHomologyClass_eq_of_eq
+      exact hchain
+    _ = z • degreeSixCycleHomologyClass L
+          (boundarySevenProperFaceFundamentalChain ≫ A.f 6)
+          (degreeSixCycle_comp_chainMap_isCycle A
+            boundarySevenProperFaceFundamentalChain
+              boundarySevenProperFaceFundamentalChain_isCycle) :=
+      degreeSixCycleHomologyClass_zsmul L _ _ z
+    _ = z • boundarySevenProperFaceSingularBoundaryHomologyClass := by
+      rw [boundarySevenProperFaceSingularBoundaryHomologyClass,
+        boundarySevenProperFaceFundamentalHomologyClass, hA]
+
+/-- The same scalar action holds on the singular class coming from the original simplicial
+boundary generator. -/
+public theorem boundarySevenOriginalSingularBoundaryHomologyClass_permutation
+    (sigma : Equiv.Perm (Fin 8)) (z : ℤ)
+    (h : boundarySevenProperFaceFundamentalChain ≫
+          (SSet.chainComplexMap
+            (boundarySevenProperFaceNervePermIso sigma).hom
+            (AddCommGrpCat.of ℤ)).f 6 =
+        z • boundarySevenProperFaceFundamentalChain) :
+    boundarySevenOriginalSingularBoundaryHomologyClass ≫
+        HomologicalComplex.homologyMap
+          (SSet.chainComplexMap
+            (TopCat.toSSet.map (standardSimplexBoundaryPermTopMap sigma))
+            (AddCommGrpCat.of ℤ)) 6 =
+      z • boundarySevenOriginalSingularBoundaryHomologyClass := by
+  rw [← boundarySevenProperFaceSingularBoundaryHomologyClass_eq_original]
+  exact boundarySevenProperFaceSingularBoundaryHomologyClass_permutation sigma z h
+
+/-! ## The explicit sphere orientation and degree -/
+
+/-- The canonical realization homeomorphism followed by a chosen affine-boundary model of the
+standard six-sphere. -/
+public noncomputable def boundarySevenRealizationHomeomorphSphere
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    (SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type) ≃ₜ SixSphere :=
+  (boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+    boundarySevenRealizationToBoundary_injective).trans e
+
+/-- The chain-complex isomorphism induced by the canonical realization homeomorphism to the
+ordinary affine boundary. -/
+public noncomputable def boundarySevenRealizationSingularChainIso :
+    (TopCat.toSSet.obj (SSet.toTop.obj (∂Δ[7] : SSet.{0}))).chainComplex
+        (AddCommGrpCat.of ℤ) ≅
+      (TopCat.toSSet.obj
+        (TopCat.of (StandardSimplexBoundary 7))).chainComplex
+          (AddCommGrpCat.of ℤ) :=
+  ((SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)).mapIso
+      (TopCat.toSSet.mapIso
+        (TopCat.isoOfHomeo
+          (boundarySevenRealizationHomeomorphStandardBoundary_of_injective
+            boundarySevenRealizationToBoundary_injective)))
+
+/-- The singular chain-complex isomorphism induced by a boundary--sphere homeomorphism. -/
+public noncomputable def boundarySevenBoundarySphereSingularChainIso
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    (TopCat.toSSet.obj
+        (TopCat.of (StandardSimplexBoundary 7))).chainComplex
+          (AddCommGrpCat.of ℤ) ≅
+      (TopCat.toSSet.obj (TopCat.of SixSphere)).chainComplex
+        (AddCommGrpCat.of ℤ) :=
+  ((SSet.chainComplexFunctor AddCommGrpCat).obj
+    (AddCommGrpCat.of ℤ)).mapIso
+      (TopCat.toSSet.mapIso (TopCat.isoOfHomeo e))
+
+/-- The fully explicit top-homology orientation of the standard sphere obtained from the
+normalized simplicial generator, the comparison map, and the selected boundary model. -/
+public noncomputable def boundarySevenExplicitSphereHomologyIsoInt
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    ((TopCat.toSSet.obj (TopCat.of SixSphere)).chainComplex
+      (AddCommGrpCat.of ℤ)).homology 6 ≅ AddCommGrpCat.of ℤ := by
+  let _ : QuasiIso (simplicialToRealizationSingularChainMap
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) := hcomparison
+  let comparisonIso := isoOfQuasiIsoAt
+    (simplicialToRealizationSingularChainMap
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 6
+  let realizationIso := HomologicalComplex.homologyMapIso
+    boundarySevenRealizationSingularChainIso 6
+  let sphereIso := HomologicalComplex.homologyMapIso
+    (boundarySevenBoundarySphereSingularChainIso e) 6
+  exact (comparisonIso.trans realizationIso |>.trans sphereIso).symm ≪≫
+    boundarySevenSimplicialHomologySixIsoInt
+
+/-- The additive equivalence underlying the explicit sphere orientation. -/
+public noncomputable def boundarySevenExplicitSphereHomologyAddEquivInt
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    IntegralSingularHomology 6 SixSphere ≃+ ℤ :=
+  (boundarySevenExplicitSphereHomologyIsoInt hcomparison e).addCommGroupIsoToAddEquiv
+
+/-- The original simplicial generator transported to singular homology of the standard sphere. -/
+public noncomputable def boundarySevenOriginalSingularSphereHomologyClass
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    AddCommGrpCat.of ℤ ⟶
+      ((TopCat.toSSet.obj (TopCat.of SixSphere)).chainComplex
+        (AddCommGrpCat.of ℤ)).homology 6 :=
+  boundarySevenOriginalSingularBoundaryHomologyClass ≫
+    (HomologicalComplex.homologyMapIso
+      (boundarySevenBoundarySphereSingularChainIso e) 6).hom
+
+/-- The transported original class is the positive generator for the explicit sphere
+orientation. -/
+public theorem boundarySevenOriginalSingularSphereHomologyClass_isoInt
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    boundarySevenOriginalSingularSphereHomologyClass e ≫
+        (boundarySevenExplicitSphereHomologyIsoInt hcomparison e).hom =
+      𝟙 (AddCommGrpCat.of ℤ) := by
+  let _ : QuasiIso (simplicialToRealizationSingularChainMap
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) := hcomparison
+  let comparisonIso := isoOfQuasiIsoAt
+    (simplicialToRealizationSingularChainMap
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ)) 6
+  let realizationIso := HomologicalComplex.homologyMapIso
+    boundarySevenRealizationSingularChainIso 6
+  let sphereIso := HomologicalComplex.homologyMapIso
+    (boundarySevenBoundarySphereSingularChainIso e) 6
+  let E := comparisonIso.trans realizationIso |>.trans sphereIso
+  change (boundarySevenOriginalFundamentalHomologyClass ≫ E.hom) ≫
+      (E.symm ≪≫ boundarySevenSimplicialHomologySixIsoInt).hom = 𝟙 _
+  simp only [Iso.trans_hom, Iso.symm_hom, Category.assoc,
+    Iso.hom_inv_id_assoc]
+  exact boundarySevenOriginalFundamentalHomologyClass_isoInt
+
+/-- Elementwise, the explicit sphere orientation sends the transported original generator to
+one. -/
+public theorem boundarySevenOriginalSingularSphereHomologyClass_mapsToOne
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    boundarySevenExplicitSphereHomologyAddEquivInt hcomparison e
+        (boundarySevenOriginalSingularSphereHomologyClass e (1 : ℤ)) = 1 := by
+  have h := ConcreteCategory.congr_hom
+    (boundarySevenOriginalSingularSphereHomologyClass_isoInt hcomparison e)
+      (1 : ℤ)
+  change (boundarySevenExplicitSphereHomologyIsoInt hcomparison e).hom.hom
+    (boundarySevenOriginalSingularSphereHomologyClass e |>.hom (1 : ℤ)) = 1
+  exact h
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Transporting first to the ordinary boundary and then along `e` gives the same sphere class
+as the composite realization homeomorphism. -/
+public theorem boundarySevenOriginalSingularSphereHomologyClass_eq_boundary
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    boundarySevenOriginalSingularSphereHomologyClass e =
+      boundarySevenOriginalSingularBoundaryHomologyClass ≫
+        ((singularHomologyFunctor AddCommGrpCat 6).obj
+          (AddCommGrpCat.of ℤ)).map (TopCat.ofHom e) := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The scalar action on the original boundary generator transports to the conjugate sphere
+self-map. -/
+public theorem boundarySevenOriginalSingularSphereHomologyClass_permutation
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere)
+    (sigma : Equiv.Perm (Fin 8)) (z : ℤ)
+    (h : boundarySevenProperFaceFundamentalChain ≫
+          (SSet.chainComplexMap
+            (boundarySevenProperFaceNervePermIso sigma).hom
+            (AddCommGrpCat.of ℤ)).f 6 =
+        z • boundarySevenProperFaceFundamentalChain) :
+    boundarySevenOriginalSingularSphereHomologyClass e ≫
+        ((singularHomologyFunctor AddCommGrpCat 6).obj
+          (AddCommGrpCat.of ℤ)).map
+            (TopCat.ofHom (boundarySevenPermutationSphereMap e sigma)) =
+      z • boundarySevenOriginalSingularSphereHomologyClass e := by
+  let H := (singularHomologyFunctor AddCommGrpCat 6).obj
+    (AddCommGrpCat.of ℤ)
+  let eTopIso : TopCat.of (StandardSimplexBoundary 7) ≅ TopCat.of SixSphere :=
+    TopCat.isoOfHomeo e
+  let eIso := H.mapIso eTopIso
+  let P := H.map (standardSimplexBoundaryPermTopMap sigma)
+  have hboundary :=
+    boundarySevenOriginalSingularBoundaryHomologyClass_permutation sigma z h
+  change boundarySevenOriginalSingularBoundaryHomologyClass ≫ P =
+    z • boundarySevenOriginalSingularBoundaryHomologyClass at hboundary
+  have htop :
+      TopCat.ofHom (boundarySevenPermutationSphereMap e sigma) =
+        eTopIso.inv ≫
+          standardSimplexBoundaryPermTopMap sigma ≫
+            eTopIso.hom := by
+    rfl
+  have hmap := congrArg (fun f ↦ H.map f) htop
+  simp only [Functor.map_comp] at hmap
+  change H.map (TopCat.ofHom (boundarySevenPermutationSphereMap e sigma)) =
+    eIso.inv ≫ P ≫ eIso.hom at hmap
+  rw [boundarySevenOriginalSingularSphereHomologyClass_eq_boundary]
+  calc
+    (boundarySevenOriginalSingularBoundaryHomologyClass ≫ eIso.hom) ≫
+          H.map (TopCat.ofHom (boundarySevenPermutationSphereMap e sigma)) =
+        (boundarySevenOriginalSingularBoundaryHomologyClass ≫ eIso.hom) ≫
+          (eIso.inv ≫ P ≫ eIso.hom) := by rw [hmap]
+    _ = (boundarySevenOriginalSingularBoundaryHomologyClass ≫ P) ≫
+          eIso.hom := by simp only [Category.assoc, Iso.hom_inv_id_assoc]
+    _ = (z • boundarySevenOriginalSingularBoundaryHomologyClass) ≫
+          eIso.hom := congrArg (fun q ↦ q ≫ eIso.hom) hboundary
+    _ = z •
+          (boundarySevenOriginalSingularBoundaryHomologyClass ≫ eIso.hom) :=
+      Preadditive.zsmul_comp _ _ z
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The proper-face fundamental cycle computes the homological degree for every vertex
+permutation.  No generator-transport assumption remains: the explicit normalized orientation
+computes the degree first, and orientation-independence transfers the result to the orientation
+used by the public comparison API. -/
+public theorem boundarySevenProperFaceGeneratorDegreeTransport_proof
+    (hcomparison : SimplicialToSingularComparisonQuasiIsomorphism
+      (∂Δ[7] : SSet.{0}) (AddCommGrpCat.of ℤ))
+    (e : StandardSimplexBoundary 7 ≃ₜ SixSphere) :
+    BoundarySevenProperFaceGeneratorDegreeTransport hcomparison e := by
+  intro sigma z h
+  let orientation₀ :=
+    boundarySevenExplicitSphereHomologyAddEquivInt hcomparison e
+  let c := boundarySevenOriginalSingularSphereHomologyClass e
+  have hdegree₀ :
+      sixSphereHomologicalDegree orientation₀
+        (boundarySevenPermutationSphereMap e sigma) = z := by
+    rw [sixSphereHomologicalDegree]
+    have hc_one : orientation₀ (c (1 : ℤ)) = 1 :=
+      boundarySevenOriginalSingularSphereHomologyClass_mapsToOne hcomparison e
+    have horientation_symm : orientation₀.symm 1 = c (1 : ℤ) := by
+      apply orientation₀.injective
+      rw [orientation₀.apply_symm_apply, hc_one]
+    rw [horientation_symm]
+    let H := (singularHomologyFunctor AddCommGrpCat 6).obj
+      (AddCommGrpCat.of ℤ)
+    change orientation₀
+      ((H.map (TopCat.ofHom
+        (boundarySevenPermutationSphereMap e sigma))).hom (c.hom (1 : ℤ))) = z
+    have hperm := ConcreteCategory.congr_hom
+      (boundarySevenOriginalSingularSphereHomologyClass_permutation e sigma z h)
+        (1 : ℤ)
+    change (H.map (TopCat.ofHom
+        (boundarySevenPermutationSphereMap e sigma))).hom (c.hom (1 : ℤ)) =
+      z • c.hom (1 : ℤ) at hperm
+    rw [hperm]
+    calc
+      orientation₀ (z • c (1 : ℤ)) =
+          z • orientation₀ (c (1 : ℤ)) :=
+        orientation₀.toAddMonoidHom.map_zsmul _ _
+      _ = z := by rw [hc_one]; simp
+  exact sixSphereHomologicalDegree_allOrientations_of_one orientation₀
+    (boundarySevenPermutationSphereMap e sigma) z hdegree₀
+      (sixSphereTopHomologyAddEquivOfStandardBoundaryComparison hcomparison e)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/SixSphereHomologicalDegreeScalar.lean
+++ b/SphereSixComplex/Topology/SixSphereHomologicalDegreeScalar.lean
@@ -1,0 +1,56 @@
+module
+
+public import SphereSixComplex.Topology.SixSphereDegreeHomology
+
+/-!
+# Scalar actions and homological degree on the six-sphere
+
+This file records that a degree calculation made with one additive orientation determines the
+entire endomorphism of top homology, and hence gives the same degree for every orientation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open AlgebraicTopology ContinuousMap
+
+namespace SphereSixComplex
+
+/-- On an infinite-cyclic top homology group, degree `z` with respect to one orientation forces
+the induced endomorphism to be scalar multiplication by `z`. -/
+public theorem sixSphereTopIntegralHomologyMap_eq_zsmul_id_of_degree
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (f : C(SixSphere, SixSphere)) (z : ℤ)
+    (hdegree : sixSphereHomologicalDegree orientation f = z) :
+    sixSphereTopIntegralHomologyMap f =
+      z • AddMonoidHom.id (IntegralSingularHomology 6 SixSphere) := by
+  let H := IntegralSingularHomology 6 SixSphere
+  let fH : H →+ H := sixSphereTopIntegralHomologyMap f
+  let fZ : ℤ →+ ℤ := orientation.toAddMonoidHom.comp
+    (fH.comp orientation.symm.toAddMonoidHom)
+  have hf (a : ℤ) : orientation (fH (orientation.symm a)) = a * z := by
+    change fZ a = a * z
+    rw [intAddHom_apply_eq_mul_apply_one]
+    change a * sixSphereHomologicalDegree orientation f = a * z
+    rw [hdegree]
+  apply AddMonoidHom.ext
+  intro x
+  apply orientation.injective
+  have hx := hf (orientation x)
+  rw [orientation.symm_apply_apply] at hx
+  simpa [mul_comm] using hx
+
+/-- A degree computed using one additive orientation has the same value for every other additive
+orientation of top homology. -/
+public theorem sixSphereHomologicalDegree_allOrientations_of_one
+    (orientation₀ : IntegralSingularHomology 6 SixSphere ≃+ ℤ)
+    (f : C(SixSphere, SixSphere)) (z : ℤ)
+    (h₀ : sixSphereHomologicalDegree orientation₀ f = z)
+    (orientation : IntegralSingularHomology 6 SixSphere ≃+ ℤ) :
+    sixSphereHomologicalDegree orientation f = z := by
+  rw [sixSphereHomologicalDegree,
+    sixSphereTopIntegralHomologyMap_eq_zsmul_id_of_degree orientation₀ f z h₀]
+  simp
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- identify the proper-face affine singular generator with the ambient subdivided boundary chain
- transport the positive normalized generator through affine subdivision homotopy
- prove coordinate reflection acts by literal negation on top integral homology
- construct the complete six-sphere degree theory from the canonical boundary comparison
- add a downstream adapter that preserves the pure H3/Cech dependency boundary
- expose the unconditional degree-theory theorem through Main

This is PR 7 of 7 in the boundary-seven degree-transport stack, stacked on #71.

## Verification

- lake build SphereSixComplex.Topology.BoundarySevenDegreeTheoryProof
- Terminal build completed successfully: 3267 jobs
- lake build SphereSixComplex
- Full project build completed successfully: 9436 jobs
- git diff --check
- no sorry, admit, axiom, opaque, sorryAx, or implemented_by placeholders
- final degree-theory axiom audit: only propext, Classical.choice, and Quot.sound