### PR TITLE
Build the rank-seven stable-framing foundation

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -225,6 +225,10 @@ public import SphereSixComplex.Topology.SingularHomologyDegreeZero
 public import SphereSixComplex.Topology.SmoothSixSphereClassification
 public import SphereSixComplex.Topology.SmoothRecognition
 public import SphereSixComplex.Topology.SmoothRecognitionFoundations
+public import SphereSixComplex.Topology.StableFraming
+public import SphereSixComplex.Topology.StableFramingHomotopySixSphere
+public import SphereSixComplex.Topology.StableFramingHomotopySixSphereClutching
+public import SphereSixComplex.Topology.StableFramingStandardSixSphereCover
 public import SphereSixComplex.Topology.SphereFiniteCWModel
 public import SphereSixComplex.Topology.SphereLoopContraction
 public import SphereSixComplex.Topology.SixSphereHCobordismAdapter

--- a/SphereSixComplex/Topology/StableFraming.lean
+++ b/SphereSixComplex/Topology/StableFraming.lean
@@ -1,0 +1,95 @@
+module
+
+public import SphereSixComplex.Topology.OrientedSmoothHomotopySphere
+public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame
+public import Mathlib.LinearAlgebra.Basis.Basic
+public import Mathlib.Topology.VectorBundle.Constructions
+
+/-!
+# Stable framings of smooth manifolds
+
+This module introduces the concrete differential-topological datum used by the
+Pontryagin--Thom construction.  A stable framing is not represented by a proposition saying that
+one exists: it is a global smooth frame of the Whitney sum of the tangent bundle with a trivial
+bundle.
+
+For a six-manifold the classical stabilization is by one real line, so the resulting bundle has a
+frame indexed by `Fin 7`.  Constructing such a frame on every homotopy six-sphere is the stable
+parallelizability theorem; it is deliberately exposed as a separate obligation below.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle Module
+open scoped Bundle ContDiff Manifold
+
+namespace SphereSixComplex
+
+universe u
+
+/-- A smooth stable framing of a manifold.
+
+The sections take values in `TM ⊕ (M × F)`.  `IsLocalFrameOn ... Set.univ` asserts both that
+they form a basis in every fiber and that every section is smooth.  Thus this structure retains
+the geometric data needed by Pontryagin--Thom, rather than only the fact that a stable
+trivialization exists. -/
+public structure SmoothStableFraming
+    {E H M : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace H] (I : ModelWithCorners ℝ E H)
+    [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    (F ι : Type*) [NormedAddCommGroup F] [NormedSpace ℝ F] where
+  /-- The global sections of the stabilized tangent bundle. -/
+  sections : ι → (x : M) →
+    (TangentSpace I x × Bundle.Trivial M F x)
+  /-- At every point the sections are a basis, and they vary smoothly. -/
+  isFrame : IsLocalFrameOn I (E × F) ∞ sections Set.univ
+
+namespace SmoothStableFraming
+
+/-- The basis of a stabilized tangent fiber supplied by a stable framing. -/
+public def basisAt
+    {E H M : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    {F ι : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+    (f : SmoothStableFraming (M := M) I F ι) (x : M) :
+    Basis ι ℝ (TangentSpace I x × Bundle.Trivial M F x) :=
+  f.isFrame.toBasisAt (Set.mem_univ x)
+
+@[simp]
+public theorem basisAt_apply
+    {E H M : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    {F ι : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+    (f : SmoothStableFraming (M := M) I F ι) (x : M) (i : ι) :
+    f.basisAt x i = f.sections i x := by
+  exact f.isFrame.toBasisAt_coe (Set.mem_univ x) i
+
+end SmoothStableFraming
+
+/-- The concrete stable-framing datum relevant to a smooth six-manifold: a seven-element smooth
+frame of `TM ⊕ ε¹`. -/
+public abbrev SmoothStableFramingSix
+    {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] :=
+  SmoothStableFraming (M := M) 𝓘(ℝ, RealModel) ℝ (Fin 7)
+
+/-- Stable parallelizability of a smooth six-manifold, stated using an actual global smooth
+frame. -/
+public def StablyParallelizableSixManifold
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] : Prop :=
+  Nonempty (SmoothStableFramingSix (M := M))
+
+/-- The classical theorem that every smooth homotopy six-sphere is stably parallelizable.
+
+This is a named proof obligation, not an axiom.  Its conclusion contains a concrete frame that can
+feed a future Pontryagin--Thom construction. -/
+public def HomotopySixSpheresStablyParallelizable : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    StablyParallelizableSixManifold S.carrier
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StableFramingHomotopySixSphere.lean
+++ b/SphereSixComplex/Topology/StableFramingHomotopySixSphere.lean
@@ -1,0 +1,173 @@
+module
+
+public import SphereSixComplex.Topology.StableFraming
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.LinearAlgebra.Basis.Prod
+
+/-!
+# Reducing stable framings of homotopy six-spheres to bundle triviality
+
+This file records the strongest construction currently supported by Mathlib's smooth vector-bundle
+API.  A global compatible trivialization of `TM ⊕ ε¹` produces the concrete seven-element smooth
+frame required by `SmoothStableFramingSix`.
+
+The remaining classical input is therefore isolated precisely: for every marked smooth homotopy
+six-sphere, the stabilized tangent bundle must admit a smooth fiberwise-linear trivialization.
+The marking is only a topological homotopy equivalence, so it cannot be differentiated to
+construct this trivialization.  A second, stronger adapter records what follows from a global
+trivialization that is literally present in Mathlib's designated bundle atlas.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle Module
+open scoped Bundle ContDiff Manifold
+
+namespace SphereSixComplex
+
+universe u
+
+/-- The fiber family of the tangent bundle of a six-manifold stabilized by one trivial real
+line. -/
+public abbrev StabilizedTangentFiberSix
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    (x : M) : Type :=
+  TangentSpace 𝓘(ℝ, RealModel) x × Bundle.Trivial M ℝ x
+
+/-- A fixed seven-element basis of the model fiber `ℝ⁶ × ℝ`.
+
+Using a fixed basis makes the passage from a global bundle trivialization to a stable frame
+completely canonical up to this harmless coordinate choice. -/
+public noncomputable def stabilizedRealModelBasisSix :
+    Basis (Fin 7) ℝ (RealModel × ℝ) :=
+  (((EuclideanSpace.basisFun (Fin 6) ℝ).toBasis.prod
+      (Basis.singleton (Fin 1) ℝ)).reindex finSumFinEquiv)
+
+/-- A smooth fiberwise-linear trivialization of `TM ⊕ ε¹`, expressed without requiring an
+arbitrary global trivialization to be literally present in Mathlib's designated local atlas.
+
+The fiberwise equivalence gives the bundle trivialization.  Smoothness is recorded on the inverse
+images of a fixed basis; by linearity these are exactly the seven smooth sections needed for a
+stable frame. -/
+public structure SmoothStableTangentTrivializationSix
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] where
+  /-- A linear identification of the fixed seven-dimensional model with every stabilized tangent
+  fiber. -/
+  fiberEquiv : (x : M) →
+    (RealModel × ℝ) ≃ₗ[ℝ]
+      (TangentSpace 𝓘(ℝ, RealModel) x × Bundle.Trivial M ℝ x)
+  /-- The inverse images of the fixed coordinate basis vary smoothly. -/
+  contMDiffOn_basis (i : Fin 7) :
+    ContMDiffOn 𝓘(ℝ, RealModel)
+      (𝓘(ℝ, RealModel).prod 𝓘(ℝ, RealModel × ℝ)) ∞
+      (fun x ↦ TotalSpace.mk' (RealModel × ℝ) x
+        (fiberEquiv x (stabilizedRealModelBasisSix i))) Set.univ
+
+/-- A smooth fiberwise-linear trivialization of `TM ⊕ ε¹` supplies a stable frame. -/
+public def SmoothStableTangentTrivializationSix.toSmoothStableFraming
+    {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+    (t : SmoothStableTangentTrivializationSix M) :
+    SmoothStableFramingSix (M := M) where
+  sections i x := t.fiberEquiv x (stabilizedRealModelBasisSix i)
+  isFrame :=
+    { linearIndependent := by
+        intro x _
+        exact (stabilizedRealModelBasisSix.map (t.fiberEquiv x)).linearIndependent
+      generating := by
+        intro x _
+        exact (stabilizedRealModelBasisSix.map (t.fiberEquiv x)).span_eq.ge
+      contMDiffOn := t.contMDiffOn_basis }
+
+/-- Conversely, a stable frame determines a smooth fiberwise-linear trivialization by mapping the
+fixed model basis to the given frame at each point. -/
+public def SmoothStableFraming.toSmoothStableTangentTrivializationSix
+    {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+    (f : SmoothStableFramingSix (M := M)) :
+    SmoothStableTangentTrivializationSix M where
+  fiberEquiv x := stabilizedRealModelBasisSix.equiv (f.basisAt x) (Equiv.refl (Fin 7))
+  contMDiffOn_basis i := by
+    simpa only [Basis.equiv_apply, Equiv.refl_apply, SmoothStableFraming.basisAt_apply] using
+      f.isFrame.contMDiffOn i
+
+/-- The bundle-triviality formulation and the concrete stable-frame formulation are equivalent.
+This pins down the missing geometric result without introducing an axiom. -/
+public theorem nonempty_smoothStableTangentTrivializationSix_iff_stablyParallelizable
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] :
+    Nonempty (SmoothStableTangentTrivializationSix M) ↔
+      StablyParallelizableSixManifold M := by
+  constructor
+  · rintro ⟨t⟩
+    exact ⟨t.toSmoothStableFraming⟩
+  · rintro ⟨f⟩
+    exact ⟨f.toSmoothStableTangentTrivializationSix⟩
+
+/-- An atlas-level bundle-theoretic input sufficient to construct a smooth stable framing.
+
+The trivialization is required to be a member of the designated smooth vector-bundle atlas and
+to have all of `M` as its base set.  These two conditions respectively encode smooth
+compatibility and globality.  This is deliberately stronger than intrinsic smooth triviality:
+for bundles built from a `FiberBundleCore`, Mathlib's designated atlas contains the original local
+trivializations rather than every smoothly compatible trivialization. -/
+public def StabilizedTangentBundleTrivialSix
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] : Prop :=
+  ∃ e : Trivialization (RealModel × ℝ)
+      (TotalSpace.proj :
+        TotalSpace (RealModel × ℝ) (StabilizedTangentFiberSix M) → M),
+    e ∈ FiberBundle.trivializationAtlas (RealModel × ℝ) (StabilizedTangentFiberSix M) ∧
+      e.baseSet = Set.univ
+
+/-- A global smooth-compatible trivialization of `TM ⊕ ε¹` gives the concrete stable
+framing used by the Pontryagin--Thom layer. -/
+public theorem smoothStableFramingSix_of_stabilizedTangentBundleTrivial
+    {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+    (h : StabilizedTangentBundleTrivialSix M) :
+    Nonempty (SmoothStableFramingSix (M := M)) := by
+  obtain ⟨e, he, hbase⟩ := h
+  let _ : MemTrivializationAtlas e := ⟨he⟩
+  refine ⟨
+    { sections := e.localFrame stabilizedRealModelBasisSix
+      isFrame := ?_ }⟩
+  simpa only [hbase] using
+    e.isLocalFrameOn_localFrame_baseSet 𝓘(ℝ, RealModel) ∞ stabilizedRealModelBasisSix
+
+/-- The stronger atlas-level bundle-triviality statement for marked smooth homotopy six-spheres. -/
+public def HomotopySixSphereAtlasStableTangentTriviality : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    StabilizedTangentBundleTrivialSix S.carrier
+
+/-- Once the stronger atlas-level stable tangent bundle triviality is supplied, the existing
+stable-framing obligation is discharged without any further geometric input. -/
+public theorem homotopySixSpheresStablyParallelizable_of_stableTangentTriviality
+    (h : HomotopySixSphereAtlasStableTangentTriviality) :
+    HomotopySixSpheresStablyParallelizable := by
+  intro S
+  exact smoothStableFramingSix_of_stabilizedTangentBundleTrivial (h S)
+
+/-- The mathematically intrinsic stable tangent triviality obligation for marked homotopy
+six-spheres. -/
+public def HomotopySixSphereStableTangentTriviality : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    Nonempty (SmoothStableTangentTrivializationSix S.carrier)
+
+/-- The intrinsic stable tangent triviality statement is exactly equivalent to the stable-framing
+obligation already used by the project. -/
+public theorem homotopySixSphereStableTangentTriviality_iff_stablyParallelizable :
+    HomotopySixSphereStableTangentTriviality ↔
+      HomotopySixSpheresStablyParallelizable := by
+  constructor
+  · intro h S
+    exact (nonempty_smoothStableTangentTrivializationSix_iff_stablyParallelizable
+      S.carrier).mp (h S)
+  · intro h S
+    exact (nonempty_smoothStableTangentTrivializationSix_iff_stablyParallelizable
+      S.carrier).mpr (h S)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StableFramingHomotopySixSphereClutching.lean
+++ b/SphereSixComplex/Topology/StableFramingHomotopySixSphereClutching.lean
@@ -171,18 +171,18 @@ public def toSmoothStableFraming (c : SmoothRankSevenClutchingExtensionSix p) :
         contMDiffOn := ?_ }
     · intro x _
       by_cases hxN : x ∈ p.north
-      · simpa only [gluedSections, dif_pos hxN] using p.northFrame.linearIndependent hxN
+      · simpa only [gluedSections, dite_eq_left hxN] using p.northFrame.linearIndependent hxN
       · have hxS : x ∈ p.south := by
           have hx : x ∈ p.north ∪ p.south := by rw [p.cover]; exact Set.mem_univ x
           exact hx.resolve_left hxN
-        simpa only [gluedSections, dif_neg hxN] using c.adjustedSouthFrame.linearIndependent hxS
+        simpa only [gluedSections, dite_eq_right hxN] using c.adjustedSouthFrame.linearIndependent hxS
     · intro x _
       by_cases hxN : x ∈ p.north
-      · simpa only [gluedSections, dif_pos hxN] using p.northFrame.generating hxN
+      · simpa only [gluedSections, dite_eq_left hxN] using p.northFrame.generating hxN
       · have hxS : x ∈ p.south := by
           have hx : x ∈ p.north ∪ p.south := by rw [p.cover]; exact Set.mem_univ x
           exact hx.resolve_left hxN
-        simpa only [gluedSections, dif_neg hxN] using c.adjustedSouthFrame.generating hxS
+        simpa only [gluedSections, dite_eq_right hxN] using c.adjustedSouthFrame.generating hxS
     · intro i
       have hN : ContMDiffOn 𝓘(ℝ, RealModel)
           (𝓘(ℝ, RealModel).prod 𝓘(ℝ, RealModel × ℝ)) ∞
@@ -193,7 +193,7 @@ public def toSmoothStableFraming (c : SmoothRankSevenClutchingExtensionSix p) :
           (fun x ↦ TotalSpace.mk' (RealModel × ℝ) x (c.gluedSections i x)) p.south :=
         (c.adjustedSouthFrame.contMDiffOn i).congr fun x hxS ↦ by
           by_cases hxN : x ∈ p.north
-          · simp only [gluedSections, dif_pos hxN]
+          · simp only [gluedSections, dite_eq_left hxN]
             exact congrArg (TotalSpace.mk' (RealModel × ℝ) x)
               (c.adjustedSouthSections_eq_northSections i x hxN hxS).symm
           · simp [gluedSections, hxN]

--- a/SphereSixComplex/Topology/StableFramingHomotopySixSphereClutching.lean
+++ b/SphereSixComplex/Topology/StableFramingHomotopySixSphereClutching.lean
@@ -1,0 +1,304 @@
+module
+
+public import SphereSixComplex.Topology.StableFramingHomotopySixSphere
+public import Mathlib.LinearAlgebra.StdBasis
+
+/-!
+# A clutching reduction for stable framings of homotopy six-spheres
+
+This file isolates the classical rank-seven clutching calculation in a geometric form that can be
+used by the smooth vector-bundle API currently present in Mathlib.
+
+A `SmoothRankSevenClutchingPresentationSix` consists of two open sets covering a six-manifold and
+a smooth local frame of `TM ⊕ ε¹` on each set.  On the overlap, the two bases determine a
+canonical transition automorphism of `ℝ⁷`.  A `SmoothRankSevenClutchingExtensionSix` is a smooth
+extension of this transition automorphism across the second patch.  Applying that extension as a
+gauge transformation to the second frame makes the two frames agree on the overlap, and hence they
+glue to a global stable frame.
+
+For a hemispherical presentation, existence of the extension is exactly the concrete geometric
+form of vanishing of the clutching class in `π₅(GL₇(ℝ))` (equivalently, after orthogonalization
+and orientation, in `π₅(SO(7))`).  Mathlib does not currently supply the required Bott-periodicity
+calculation or the smooth clutching classification, so that final existence statement remains a
+named proposition rather than an axiom.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle ContinuousMap Module
+open scoped Bundle Classical ContDiff Manifold
+
+namespace SphereSixComplex
+
+universe u
+
+/-- The coordinate space in which the rank-seven transition functions are written. -/
+public abbrev StableFrameCoordinatesSix := Fin 7 → ℝ
+
+/-- The standard five-sphere which models the equator of a hemispherical six-sphere cover. -/
+public abbrev StableClutchingEquatorFiveSphere : Type :=
+  ↑(Metric.sphere (0 : EuclideanSpace ℝ (Fin 6)) 1)
+
+/-- Two smooth local stable frames on an open two-set cover.
+
+The transition between `northSections` and `southSections` is the rank-seven clutching function.
+No assertion about a preferred hemispherical cover is hidden in this definition. -/
+public structure SmoothRankSevenClutchingPresentationSix
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] where
+  north : Set M
+  south : Set M
+  north_isOpen : IsOpen north
+  south_isOpen : IsOpen south
+  cover : north ∪ south = Set.univ
+  northSections : Fin 7 → (x : M) → StabilizedTangentFiberSix M x
+  southSections : Fin 7 → (x : M) → StabilizedTangentFiberSix M x
+  northFrame :
+    IsLocalFrameOn 𝓘(ℝ, RealModel) (RealModel × ℝ) ∞ northSections north
+  southFrame :
+    IsLocalFrameOn 𝓘(ℝ, RealModel) (RealModel × ℝ) ∞ southSections south
+
+namespace SmoothRankSevenClutchingPresentationSix
+
+variable {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+  [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+
+/-- The coordinate transition from the north frame to the south frame at a point of the overlap.
+
+Thus applying this map to north-frame coordinates and then interpreting the result in the south
+frame gives the same vector in the stabilized tangent fiber. -/
+public def coordinateTransition
+    (p : SmoothRankSevenClutchingPresentationSix M) (x : M)
+    (hxN : x ∈ p.north) (hxS : x ∈ p.south) :
+    StableFrameCoordinatesSix ≃ₗ[ℝ] StableFrameCoordinatesSix :=
+  (p.northFrame.toBasisAt hxN).equivFun.symm.trans
+    (p.southFrame.toBasisAt hxS).equivFun
+
+end SmoothRankSevenClutchingPresentationSix
+
+/-- A smooth extension, across the south patch, of the rank-seven clutching transition.
+
+The scalar coordinate functions are required to be smooth; this is precisely what is needed to
+apply the gauge to a smooth local frame.  Values of `gauge` outside the south patch are junk.
+For a genuine hemispherical presentation this is an explicit disk extension of the equatorial
+transition map, and hence an explicit null-clutching witness. -/
+public structure SmoothRankSevenClutchingExtensionSix
+    {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+    (p : SmoothRankSevenClutchingPresentationSix M) where
+  gauge : (x : M) → StableFrameCoordinatesSix ≃ₗ[ℝ] StableFrameCoordinatesSix
+  contMDiffOn_coeff (i j : Fin 7) :
+    ContMDiffOn 𝓘(ℝ, RealModel) 𝓘(ℝ, ℝ) ∞
+      (fun x ↦ gauge x ((Pi.basisFun ℝ (Fin 7)) i) j) p.south
+  agrees_transition (x : M) (hxN : x ∈ p.north) (hxS : x ∈ p.south) :
+    gauge x = p.coordinateTransition x hxN hxS
+
+namespace SmoothRankSevenClutchingExtensionSix
+
+variable {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+  [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+  {p : SmoothRankSevenClutchingPresentationSix M}
+
+/-- Gauge-transform the south local frame using the extended transition. -/
+public def adjustedSouthSections (c : SmoothRankSevenClutchingExtensionSix p) :
+    Fin 7 → (x : M) → StabilizedTangentFiberSix M x :=
+  fun i x ↦ ∑ j, (c.gauge x ((Pi.basisFun ℝ (Fin 7)) i)) j • p.southSections j x
+
+/-- The gauge-transformed south sections are again a smooth local frame. -/
+public theorem adjustedSouthFrame (c : SmoothRankSevenClutchingExtensionSix p) :
+    IsLocalFrameOn 𝓘(ℝ, RealModel) (RealModel × ℝ) ∞
+      c.adjustedSouthSections p.south := by
+  refine
+    { linearIndependent := ?_
+      generating := ?_
+      contMDiffOn := ?_ }
+  · intro x hx
+    let b : Basis (Fin 7) ℝ (StabilizedTangentFiberSix M x) :=
+      (Pi.basisFun ℝ (Fin 7)).map
+        ((c.gauge x).trans (p.southFrame.toBasisAt hx).equivFun.symm)
+    have hb (i : Fin 7) : b i = c.adjustedSouthSections i x := by
+      simp only [b, Basis.map_apply, LinearEquiv.trans_apply, Basis.equivFun_symm_apply,
+        adjustedSouthSections, p.southFrame.toBasisAt_coe hx]
+    have hfun : (b : Fin 7 → StabilizedTangentFiberSix M x) =
+        fun i ↦ c.adjustedSouthSections i x := funext hb
+    rw [← hfun]
+    exact b.linearIndependent
+  · intro x hx
+    let b : Basis (Fin 7) ℝ (StabilizedTangentFiberSix M x) :=
+      (Pi.basisFun ℝ (Fin 7)).map
+        ((c.gauge x).trans (p.southFrame.toBasisAt hx).equivFun.symm)
+    have hb (i : Fin 7) : b i = c.adjustedSouthSections i x := by
+      simp only [b, Basis.map_apply, LinearEquiv.trans_apply, Basis.equivFun_symm_apply,
+        adjustedSouthSections, p.southFrame.toBasisAt_coe hx]
+    have hfun : (b : Fin 7 → StabilizedTangentFiberSix M x) =
+        fun i ↦ c.adjustedSouthSections i x := funext hb
+    rw [← hfun]
+    exact b.span_eq.ge
+  · intro i
+    exact ContMDiffOn.sum_section fun j _ ↦
+      (c.contMDiffOn_coeff i j).smul_section (p.southFrame.contMDiffOn j)
+
+/-- On the overlap, the adjusted south frame agrees pointwise with the north frame. -/
+public theorem adjustedSouthSections_eq_northSections
+    (c : SmoothRankSevenClutchingExtensionSix p) (i : Fin 7) (x : M)
+    (hxN : x ∈ p.north) (hxS : x ∈ p.south) :
+    c.adjustedSouthSections i x = p.northSections i x := by
+  rw [adjustedSouthSections, c.agrees_transition x hxN hxS]
+  simp only [SmoothRankSevenClutchingPresentationSix.coordinateTransition,
+    LinearEquiv.trans_apply, Basis.equivFun_apply]
+  rw [← p.northFrame.toBasisAt_coe hxN]
+  simp_rw [← p.southFrame.toBasisAt_coe hxS]
+  rw [(p.southFrame.toBasisAt hxS).sum_repr]
+  simp
+
+/-- The global sections obtained by using the north frame on the north patch and the adjusted
+south frame elsewhere. -/
+public def gluedSections (c : SmoothRankSevenClutchingExtensionSix p) :
+    Fin 7 → (x : M) → StabilizedTangentFiberSix M x :=
+  fun i x ↦ if _hx : x ∈ p.north then p.northSections i x else c.adjustedSouthSections i x
+
+/-- A smooth extension of the clutching transition glues the two local frames to a concrete
+global stable framing. -/
+public def toSmoothStableFraming (c : SmoothRankSevenClutchingExtensionSix p) :
+    SmoothStableFramingSix (M := M) where
+  sections := c.gluedSections
+  isFrame := by
+    refine
+      { linearIndependent := ?_
+        generating := ?_
+        contMDiffOn := ?_ }
+    · intro x _
+      by_cases hxN : x ∈ p.north
+      · simpa only [gluedSections, dif_pos hxN] using p.northFrame.linearIndependent hxN
+      · have hxS : x ∈ p.south := by
+          have hx : x ∈ p.north ∪ p.south := by rw [p.cover]; exact Set.mem_univ x
+          exact hx.resolve_left hxN
+        simpa only [gluedSections, dif_neg hxN] using c.adjustedSouthFrame.linearIndependent hxS
+    · intro x _
+      by_cases hxN : x ∈ p.north
+      · simpa only [gluedSections, dif_pos hxN] using p.northFrame.generating hxN
+      · have hxS : x ∈ p.south := by
+          have hx : x ∈ p.north ∪ p.south := by rw [p.cover]; exact Set.mem_univ x
+          exact hx.resolve_left hxN
+        simpa only [gluedSections, dif_neg hxN] using c.adjustedSouthFrame.generating hxS
+    · intro i
+      have hN : ContMDiffOn 𝓘(ℝ, RealModel)
+          (𝓘(ℝ, RealModel).prod 𝓘(ℝ, RealModel × ℝ)) ∞
+          (fun x ↦ TotalSpace.mk' (RealModel × ℝ) x (c.gluedSections i x)) p.north :=
+        (p.northFrame.contMDiffOn i).congr fun x hx ↦ by simp [gluedSections, hx]
+      have hS : ContMDiffOn 𝓘(ℝ, RealModel)
+          (𝓘(ℝ, RealModel).prod 𝓘(ℝ, RealModel × ℝ)) ∞
+          (fun x ↦ TotalSpace.mk' (RealModel × ℝ) x (c.gluedSections i x)) p.south :=
+        (c.adjustedSouthFrame.contMDiffOn i).congr fun x hxS ↦ by
+          by_cases hxN : x ∈ p.north
+          · simp only [gluedSections, dif_pos hxN]
+            exact congrArg (TotalSpace.mk' (RealModel × ℝ) x)
+              (c.adjustedSouthSections_eq_northSections i x hxN hxS).symm
+          · simp [gluedSections, hxN]
+      rw [← p.cover]
+      exact hN.union_of_isOpen hS p.north_isOpen p.south_isOpen
+
+end SmoothRankSevenClutchingExtensionSix
+
+/-- The topological part of a hemispherical two-patch presentation.
+
+Keeping this data separate from the local stable frames lets the standard stereographic cover be
+constructed and tested independently of the bundle-theoretic clutching calculation.  For an
+arbitrary homotopy sphere, existence of such a cover is the twisted-sphere/two-disk input. -/
+public structure SmoothHemisphericalOpenCoverSix
+    (M : Type u) [TopologicalSpace M] where
+  north : Set M
+  south : Set M
+  north_isOpen : IsOpen north
+  south_isOpen : IsOpen south
+  cover : north ∪ south = Set.univ
+  north_contractible : ContractibleSpace north
+  south_contractible : ContractibleSpace south
+  equatorMarking :
+    {x : M // x ∈ north ∩ south} ≃ₕ StableClutchingEquatorFiveSphere
+
+/-- A genuinely hemispherical form of the two-patch clutching presentation.
+
+The two patches are contractible and their overlap is marked by the standard five-sphere.  This
+extra topology prevents the clutching obligation below from degenerating to the tautological cover
+by two copies of `Set.univ`.  Producing such a presentation for an arbitrary smooth homotopy
+six-sphere is the geometric (Morse-theoretic/twisted-sphere) part of a clutching proof. -/
+public structure SmoothHemisphericalRankSevenClutchingPresentationSix
+    (M : Type u) [TopologicalSpace M] [ChartedSpace RealModel M]
+    [IsManifold 𝓘(ℝ, RealModel) ∞ M] where
+  toClutchingPresentation : SmoothRankSevenClutchingPresentationSix M
+  north_contractible : ContractibleSpace toClutchingPresentation.north
+  south_contractible : ContractibleSpace toClutchingPresentation.south
+  equatorMarking :
+    {x : M // x ∈ toClutchingPresentation.north ∩ toClutchingPresentation.south} ≃ₕ
+      StableClutchingEquatorFiveSphere
+
+namespace SmoothHemisphericalRankSevenClutchingPresentationSix
+
+variable {M : Type u} [TopologicalSpace M] [ChartedSpace RealModel M]
+  [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+
+/-- Forget the local stable frames while retaining the hemispherical open-cover geometry. -/
+public def toOpenCover
+    (p : SmoothHemisphericalRankSevenClutchingPresentationSix M) :
+    SmoothHemisphericalOpenCoverSix M where
+  north := p.toClutchingPresentation.north
+  south := p.toClutchingPresentation.south
+  north_isOpen := p.toClutchingPresentation.north_isOpen
+  south_isOpen := p.toClutchingPresentation.south_isOpen
+  cover := p.toClutchingPresentation.cover
+  north_contractible := p.north_contractible
+  south_contractible := p.south_contractible
+  equatorMarking := p.equatorMarking
+
+end SmoothHemisphericalRankSevenClutchingPresentationSix
+
+/-- The precise hemispherical rank-seven clutching obligation.
+
+It separates the remaining classical proof into (1) a two-disk presentation of a smooth homotopy
+sphere and its stabilized tangent bundle and (2) extension of the resulting `GL₇(ℝ)` transition
+over one disk.  The latter is the geometric content of the vanishing of its class in
+`π₅(GL₇(ℝ))`, or in `π₅(SO(7))` after choosing a metric and orientation. -/
+public def HomotopySixSphereHemisphericalRankSevenClutchingVanishing : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    ∃ p : SmoothHemisphericalRankSevenClutchingPresentationSix S.carrier,
+      Nonempty (SmoothRankSevenClutchingExtensionSix p.toClutchingPresentation)
+
+/-- The precise remaining rank-seven clutching obligation for marked homotopy six-spheres.
+
+It asks for a two-patch stable tangent presentation together with an actual smooth extension of
+its transition automorphism.  For hemispherical patches this is the geometric representative of
+the statement `π₅(SO(7)) = 0`; no homotopy-group computation is postulated here. -/
+public def HomotopySixSphereRankSevenClutchingExtension : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    ∃ p : SmoothRankSevenClutchingPresentationSix S.carrier,
+      Nonempty (SmoothRankSevenClutchingExtensionSix p)
+
+/-- Forgetting the hemispherical topology gives the bare extension obligation. -/
+public theorem homotopySixSphereRankSevenClutchingExtension_of_hemispherical
+    (h : HomotopySixSphereHemisphericalRankSevenClutchingVanishing) :
+    HomotopySixSphereRankSevenClutchingExtension := by
+  intro S
+  obtain ⟨p, hc⟩ := h S
+  exact ⟨p.toClutchingPresentation, hc⟩
+
+/-- The rank-seven clutching extension obligation supplies the project's concrete stable framing
+obligation. -/
+public theorem homotopySixSpheresStablyParallelizable_of_rankSevenClutchingExtension
+    (h : HomotopySixSphereRankSevenClutchingExtension) :
+    HomotopySixSpheresStablyParallelizable := by
+  intro S
+  obtain ⟨p, ⟨c⟩⟩ := h S
+  exact ⟨c.toSmoothStableFraming⟩
+
+/-- The clutching extension also supplies the intrinsic smooth stabilized-tangent
+trivialization used by the bundle-theoretic reduction. -/
+public theorem homotopySixSphereStableTangentTriviality_of_rankSevenClutchingExtension
+    (h : HomotopySixSphereRankSevenClutchingExtension) :
+    HomotopySixSphereStableTangentTriviality :=
+  homotopySixSphereStableTangentTriviality_iff_stablyParallelizable.mpr
+    (homotopySixSpheresStablyParallelizable_of_rankSevenClutchingExtension h)
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StableFramingStandardSixSphereCover.lean
+++ b/SphereSixComplex/Topology/StableFramingStandardSixSphereCover.lean
@@ -1,0 +1,268 @@
+module
+
+public import SphereSixComplex.Topology.SphereSimplyConnected
+public import SphereSixComplex.Topology.StableFramingHomotopySixSphereClutching
+public import Mathlib.Analysis.Convex.Contractible
+public import Mathlib.Analysis.Normed.Module.Ball.RadialEquiv
+
+/-!
+# The standard stereographic two-patch cover of the six-sphere
+
+This file constructs the topological part of the hemispherical clutching presentation for the
+standard `S⁶`.  The two patches are complements of antipodal poles, hence stereographically
+homeomorphic to `ℝ⁶`; their overlap is stereographically homeomorphic to punctured `ℝ⁶`, and polar
+coordinates identify that overlap up to homotopy with `S⁵`.
+
+The construction deliberately stops before choosing local frames of `TS⁶ ⊕ ε¹`.  It is the first
+independent geometric component of the rank-seven clutching proof and fixes the exact overlap model
+that the later smooth collar and transition calculations must use.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle ContinuousMap Metric Set
+open scoped Bundle ContDiff Manifold
+
+namespace SphereSixComplex
+
+/-- A chosen pole of the standard six-sphere. -/
+public noncomputable def sixSphereNorthPole : SixSphere := by
+  refine ⟨PiLp.single 2 (0 : Fin 7) 1, ?_⟩
+  simp
+
+/-- The antipodal pole. -/
+public noncomputable def sixSphereSouthPole : SixSphere :=
+  -sixSphereNorthPole
+
+@[simp]
+public theorem sixSphereSouthPole_eq_neg :
+    sixSphereSouthPole = -sixSphereNorthPole :=
+  rfl
+
+public theorem sixSphereNorthPole_ne_southPole :
+    sixSphereNorthPole ≠ sixSphereSouthPole := by
+  intro h
+  have hval := congrArg (fun x : SixSphere ↦ x.1 (0 : Fin 7)) h
+  norm_num [sixSphereNorthPole, sixSphereSouthPole] at hval
+
+/-- Stereographic projection from one pole sends the antipodal pole to the origin. -/
+@[simp]
+public theorem sixSphereStereographic_apply_antipode (v : SixSphere) :
+    sixSphereStereographic v (-v) = 0 := by
+  unfold sixSphereStereographic
+  simp only [stereographic']
+  simp
+
+/-- The stereographic patch omitting the north pole. -/
+public def standardSixSphereNorthPatch : Set SixSphere :=
+  {sixSphereNorthPole}ᶜ
+
+/-- The stereographic patch omitting the south pole. -/
+public def standardSixSphereSouthPatch : Set SixSphere :=
+  {sixSphereSouthPole}ᶜ
+
+public theorem standardSixSphereNorthPatch_isOpen :
+    IsOpen standardSixSphereNorthPatch := by
+  exact isOpen_compl_singleton
+
+public theorem standardSixSphereSouthPatch_isOpen :
+    IsOpen standardSixSphereSouthPatch := by
+  exact isOpen_compl_singleton
+
+public theorem standardSixSpherePatch_cover :
+    standardSixSphereNorthPatch ∪ standardSixSphereSouthPatch = Set.univ := by
+  ext x
+  simp only [standardSixSphereNorthPatch, standardSixSphereSouthPatch, mem_union,
+    mem_compl_iff, mem_singleton_iff, mem_univ, iff_true]
+  by_cases hx : x = sixSphereNorthPole
+  · exact Or.inr fun hxSouth ↦
+      sixSphereNorthPole_ne_southPole (hx.symm.trans hxSouth)
+  · exact Or.inl hx
+
+/-- Every one-pole complement in `S⁶` is contractible by stereographic projection. -/
+public theorem sixSphere_compl_singleton_contractible (v : SixSphere) :
+    ContractibleSpace ({v}ᶜ : Set SixSphere) := by
+  let e := (sixSphereStereographic v).toHomeomorphSourceTarget
+  rw [← sixSphereStereographic_source v]
+  rw [e.toHomotopyEquiv.contractibleSpace_iff]
+  rw [sixSphereStereographic_target]
+  exact (Homeomorph.Set.univ RealModel).contractibleSpace
+
+/-- The chosen north patch is contractible. -/
+public theorem standardSixSphereNorthPatch_contractible :
+    ContractibleSpace standardSixSphereNorthPatch := by
+  exact sixSphere_compl_singleton_contractible sixSphereNorthPole
+
+/-- The chosen south patch is contractible. -/
+public theorem standardSixSphereSouthPatch_contractible :
+    ContractibleSpace standardSixSphereSouthPatch := by
+  exact sixSphere_compl_singleton_contractible sixSphereSouthPole
+
+/-- Stereographic projection identifies the two-pole complement with punctured `ℝ⁶`. -/
+public noncomputable def standardSixSphereOverlapHomeomorph :
+    {x : SixSphere //
+      x ∈ standardSixSphereNorthPatch ∩ standardSixSphereSouthPatch} ≃ₜ
+      ({0}ᶜ : Set RealModel) := by
+  let e := sixSphereStereographic sixSphereNorthPole
+  apply e.homeomorphOfImageSubsetSource
+  · intro x hx
+    simpa [e, standardSixSphereNorthPatch] using hx.1
+  · apply Set.Subset.antisymm
+    · rintro y ⟨x, hx, rfl⟩ hy0
+      have hxSource : x ∈ e.source := by
+        simpa [e, standardSixSphereNorthPatch] using hx.1
+      have hsouthSource : sixSphereSouthPole ∈ e.source := by
+        simpa [e, standardSixSphereNorthPatch, sixSphereSouthPole] using
+          sixSphereNorthPole_ne_southPole.symm
+      have heq : x = sixSphereSouthPole :=
+        e.injOn hxSource hsouthSource (by
+          rw [Set.mem_singleton_iff.mp hy0]
+          simp [e, sixSphereSouthPole])
+      exact hx.2 (by simp [heq])
+    · intro y hy
+      have hyTarget : y ∈ e.target := by simp [e]
+      let x : SixSphere := e.symm y
+      have hxSource : x ∈ e.source := e.map_target hyTarget
+      have hxy : e x = y := e.right_inv hyTarget
+      refine ⟨x, ?_, hxy⟩
+      constructor
+      · simpa [e, standardSixSphereNorthPatch] using hxSource
+      · simp only [standardSixSphereSouthPatch, mem_compl_iff, mem_singleton_iff]
+        intro hxSouth
+        have : y = 0 := by
+          rw [← hxy, hxSouth]
+          simp [e, sixSphereSouthPole]
+        exact hy this
+
+/-- Punctured real six-space deformation-retracts, up to homotopy equivalence, onto its unit
+five-sphere. -/
+public noncomputable def puncturedRealModelHomotopyEquivFiveSphere :
+    ({0}ᶜ : Set RealModel) ≃ₕ StableClutchingEquatorFiveSphere := by
+  letI : ContractibleSpace (Set.Ioi (0 : ℝ)) :=
+    (convex_Ioi (0 : ℝ)).contractibleSpace nonempty_Ioi
+  let radial : ({0}ᶜ : Set RealModel) ≃ₕ
+      StableClutchingEquatorFiveSphere × Set.Ioi (0 : ℝ) :=
+    (homeomorphUnitSphereProd RealModel).toHomotopyEquiv
+  let radialFactor : Set.Ioi (0 : ℝ) ≃ₕ Unit :=
+    Classical.choice (ContractibleSpace.hequiv (Set.Ioi (0 : ℝ)) Unit)
+  exact radial.trans
+    ((ContinuousMap.HomotopyEquiv.refl StableClutchingEquatorFiveSphere).prodCongr radialFactor) |>.trans
+      (Homeomorph.prodUnique StableClutchingEquatorFiveSphere Unit).toHomotopyEquiv
+
+/-- The overlap of the two standard stereographic patches has the homotopy type of `S⁵`. -/
+public noncomputable def standardSixSphereOverlapEquatorMarking :
+    {x : SixSphere //
+      x ∈ standardSixSphereNorthPatch ∩ standardSixSphereSouthPatch} ≃ₕ
+      StableClutchingEquatorFiveSphere :=
+  standardSixSphereOverlapHomeomorph.toHomotopyEquiv.trans
+    puncturedRealModelHomotopyEquivFiveSphere
+
+/-- The standard six-sphere has the topological open-cover geometry required by a hemispherical
+rank-seven clutching presentation. -/
+public noncomputable def standardSixSphereHemisphericalOpenCover :
+    SmoothHemisphericalOpenCoverSix SixSphere where
+  north := standardSixSphereNorthPatch
+  south := standardSixSphereSouthPatch
+  north_isOpen := standardSixSphereNorthPatch_isOpen
+  south_isOpen := standardSixSphereSouthPatch_isOpen
+  cover := standardSixSpherePatch_cover
+  north_contractible := standardSixSphereNorthPatch_contractible
+  south_contractible := standardSixSphereSouthPatch_contractible
+  equatorMarking := standardSixSphereOverlapEquatorMarking
+
+/-- The tangent-bundle chart over the north patch, stabilized by the trivial real line. -/
+public noncomputable def standardSixSphereNorthStableTrivialization :
+    Trivialization (RealModel × ℝ)
+      (TotalSpace.proj : TotalSpace (RealModel × ℝ)
+        (StabilizedTangentFiberSix SixSphere) → SixSphere) :=
+  (trivializationAt RealModel
+      (TangentSpace 𝓘(ℝ, RealModel)) sixSphereSouthPole).prod
+    (Bundle.Trivial.trivialization SixSphere ℝ)
+
+/-- The tangent-bundle chart over the south patch, stabilized by the trivial real line. -/
+public noncomputable def standardSixSphereSouthStableTrivialization :
+    Trivialization (RealModel × ℝ)
+      (TotalSpace.proj : TotalSpace (RealModel × ℝ)
+        (StabilizedTangentFiberSix SixSphere) → SixSphere) :=
+  (trivializationAt RealModel
+      (TangentSpace 𝓘(ℝ, RealModel)) sixSphereNorthPole).prod
+    (Bundle.Trivial.trivialization SixSphere ℝ)
+
+public noncomputable instance standardSixSphereTrivialLineTrivialization_memAtlas :
+    MemTrivializationAtlas (Bundle.Trivial.trivialization SixSphere ℝ) where
+  out := by simp
+
+public noncomputable instance standardSixSphereNorthStableTrivialization_memAtlas :
+    MemTrivializationAtlas standardSixSphereNorthStableTrivialization := by
+  unfold standardSixSphereNorthStableTrivialization
+  infer_instance
+
+public noncomputable instance standardSixSphereSouthStableTrivialization_memAtlas :
+    MemTrivializationAtlas standardSixSphereSouthStableTrivialization := by
+  unfold standardSixSphereSouthStableTrivialization
+  infer_instance
+
+@[simp]
+public theorem standardSixSphereNorthStableTrivialization_baseSet :
+    standardSixSphereNorthStableTrivialization.baseSet = standardSixSphereNorthPatch := by
+  simp [standardSixSphereNorthStableTrivialization, standardSixSphereNorthPatch,
+    sixSphereSouthPole, chartAt, ChartedSpace.chartAt]
+
+@[simp]
+public theorem standardSixSphereSouthStableTrivialization_baseSet :
+    standardSixSphereSouthStableTrivialization.baseSet = standardSixSphereSouthPatch := by
+  simp [standardSixSphereSouthStableTrivialization, standardSixSphereSouthPatch,
+    chartAt, ChartedSpace.chartAt]
+
+/-- The canonical stabilized tangent frame induced by the north stereographic chart. -/
+public noncomputable def standardSixSphereNorthStableSections :
+    Fin 7 → (x : SixSphere) → StabilizedTangentFiberSix SixSphere x :=
+  standardSixSphereNorthStableTrivialization.localFrame stabilizedRealModelBasisSix
+
+/-- The canonical stabilized tangent frame induced by the south stereographic chart. -/
+public noncomputable def standardSixSphereSouthStableSections :
+    Fin 7 → (x : SixSphere) → StabilizedTangentFiberSix SixSphere x :=
+  standardSixSphereSouthStableTrivialization.localFrame stabilizedRealModelBasisSix
+
+/-- The north stereographic sections form a smooth local stable frame. -/
+public theorem standardSixSphereNorthStableFrame :
+    IsLocalFrameOn 𝓘(ℝ, RealModel) (RealModel × ℝ) ∞
+      standardSixSphereNorthStableSections standardSixSphereNorthPatch := by
+  simpa only [standardSixSphereNorthStableSections,
+    standardSixSphereNorthStableTrivialization_baseSet] using
+    standardSixSphereNorthStableTrivialization.isLocalFrameOn_localFrame_baseSet
+      𝓘(ℝ, RealModel) ∞ stabilizedRealModelBasisSix
+
+/-- The south stereographic sections form a smooth local stable frame. -/
+public theorem standardSixSphereSouthStableFrame :
+    IsLocalFrameOn 𝓘(ℝ, RealModel) (RealModel × ℝ) ∞
+      standardSixSphereSouthStableSections standardSixSphereSouthPatch := by
+  simpa only [standardSixSphereSouthStableSections,
+    standardSixSphereSouthStableTrivialization_baseSet] using
+    standardSixSphereSouthStableTrivialization.isLocalFrameOn_localFrame_baseSet
+      𝓘(ℝ, RealModel) ∞ stabilizedRealModelBasisSix
+
+/-- The complete two-chart rank-seven clutching presentation for the standard six-sphere. -/
+public noncomputable def standardSixSphereRankSevenClutchingPresentation :
+    SmoothRankSevenClutchingPresentationSix SixSphere where
+  north := standardSixSphereNorthPatch
+  south := standardSixSphereSouthPatch
+  north_isOpen := standardSixSphereNorthPatch_isOpen
+  south_isOpen := standardSixSphereSouthPatch_isOpen
+  cover := standardSixSpherePatch_cover
+  northSections := standardSixSphereNorthStableSections
+  southSections := standardSixSphereSouthStableSections
+  northFrame := standardSixSphereNorthStableFrame
+  southFrame := standardSixSphereSouthStableFrame
+
+/-- The standard sphere satisfies every field of the hemispherical clutching presentation. -/
+public noncomputable def standardSixSphereHemisphericalRankSevenClutchingPresentation :
+    SmoothHemisphericalRankSevenClutchingPresentationSix SixSphere where
+  toClutchingPresentation := standardSixSphereRankSevenClutchingPresentation
+  north_contractible := standardSixSphereNorthPatch_contractible
+  south_contractible := standardSixSphereSouthPatch_contractible
+  equatorMarking := standardSixSphereOverlapEquatorMarking
+
+end SphereSixComplex


### PR DESCRIPTION
Introduces concrete smooth stable framings and stabilized-tangent trivializations, formalizes the rank-seven two-patch clutching/extension adapter, and constructs the full stereographic hemispherical clutching presentation for the standard six-sphere. The arbitrary homotopy-sphere twisted-disk theorem and the relative GL7 extension remain explicit non-axiomatic obligations. Validation: terminal module build passed; full project build passed (9408 jobs); diff check passed; no sorry/admit/proof_wanted declarations; axiom audit reports only propext, Classical.choice, and Quot.sound.