### PR TITLE
Reduce smooth rank-seven clutching to topological pi5

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -229,6 +229,7 @@ public import SphereSixComplex.Topology.StableFraming
 public import SphereSixComplex.Topology.StableFramingBufferedRadialClutching
 public import SphereSixComplex.Topology.StableFramingHomotopySixSphere
 public import SphereSixComplex.Topology.StableFramingHomotopySixSphereClutching
+public import SphereSixComplex.Topology.StableFramingSmoothClutchingNullhomotopy
 public import SphereSixComplex.Topology.StableFramingStandardSixSphereCover
 public import SphereSixComplex.Topology.SphereFiniteCWModel
 public import SphereSixComplex.Topology.SphereLoopContraction

--- a/SphereSixComplex/Topology/StableFramingBufferedRadialClutching.lean
+++ b/SphereSixComplex/Topology/StableFramingBufferedRadialClutching.lean
@@ -1,6 +1,6 @@
 module
 
-public import SphereSixComplex.Topology.StableFramingHomotopySixSphereClutching
+public import SphereSixComplex.Topology.StableFramingLocalFrameCoefficients
 public import Mathlib.Analysis.Normed.Module.Ball.RadialEquiv
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 

--- a/SphereSixComplex/Topology/StableFramingGeneralLinearSmoothApproximation.lean
+++ b/SphereSixComplex/Topology/StableFramingGeneralLinearSmoothApproximation.lean
@@ -1,0 +1,168 @@
+module
+
+public import SphereSixComplex.Topology.StableFramingBufferedRadialClutching
+public import Mathlib.Geometry.Manifold.SmoothApprox
+public import Mathlib.Topology.MetricSpace.HausdorffDistance
+
+/-!
+# Relative smooth approximation for rank-seven general-linear maps
+
+A continuous `GL₇(ℝ)`-valued map which is already coefficientwise smooth near a closed set can
+be approximated by a globally coefficientwise-smooth map without changing it on that set.  The
+approximation is chosen closer than half the distance to the closed set of singular matrices, so
+its values remain invertible.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle ContinuousMap Set
+open scoped Bundle ContDiff Manifold Topology
+
+namespace SphereSixComplex
+
+private abbrev StableSevenMatrix := Matrix (Fin 7) (Fin 7) ℝ
+
+private abbrev StableSevenCoordinates := Fin 7 → Fin 7 → ℝ
+
+/-- A coefficient of the linear automorphism is the corresponding transposed matrix entry. -/
+public theorem StableGeneralLinearSeven.coeff_eq_matrixEntry
+    (A : StableGeneralLinearSeven) (i j : Fin 7) :
+    A.coeff i j = (A : Matrix (Fin 7) (Fin 7) ℝ) j i := by
+  simp [StableGeneralLinearSeven.coeff, StableGeneralLinearSeven.toLinearEquiv,
+    Matrix.GeneralLinearGroup.toLin]
+
+private def singularStableSevenMatrices : Set StableSevenCoordinates :=
+  {A | (Matrix.of A).det = 0}
+
+private theorem singularStableSevenMatrices_isClosed :
+    IsClosed singularStableSevenMatrices := by
+  apply isClosed_singleton.preimage
+  have hmatrix : Continuous (fun A : StableSevenCoordinates ↦ Matrix.of A) :=
+    continuous_matrix fun i j ↦ (continuous_apply j).comp (continuous_apply i)
+  exact hmatrix.matrix_det
+
+private theorem singularStableSevenMatrices_nonempty :
+    singularStableSevenMatrices.Nonempty := by
+  refine ⟨0, ?_⟩
+  change (Matrix.of (0 : StableSevenCoordinates)).det = 0
+  simp
+
+/-- Smooth a continuous `GL₇(ℝ)`-valued map relative to a closed set on whose neighborhood it is
+already coefficientwise smooth. -/
+public theorem exists_smoothGLSevenApprox_eqOn
+    (K : C(ℝ × StableClutchingEquatorFiveSphere, StableGeneralLinearSeven))
+    {S U : Set (ℝ × StableClutchingEquatorFiveSphere)}
+    (hS : IsClosed S) (hU : U ∈ 𝓝ˢ S)
+    (hKU : ∀ r c : Fin 7, ContMDiffOn
+      (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) 𝓘(ℝ, ℝ) ∞
+      (fun z ↦ (K z : Matrix (Fin 7) (Fin 7) ℝ) r c) U) :
+    ∃ L : C(ℝ × StableClutchingEquatorFiveSphere, StableGeneralLinearSeven),
+      (∀ i j : Fin 7,
+        ContMDiff
+          (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) 𝓘(ℝ, ℝ) ∞
+          (fun z ↦ (L z).coeff i j)) ∧
+      EqOn L K S := by
+  let Kval : ℝ × StableClutchingEquatorFiveSphere → StableSevenCoordinates :=
+    fun z ↦ (K z : StableSevenMatrix)
+  have approxData :
+      ∃ a : ℝ × StableClutchingEquatorFiveSphere → StableSevenCoordinates,
+        (∀ r c : Fin 7, ContMDiff
+          (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) 𝓘(ℝ, ℝ) ∞
+          (fun z ↦ a z r c)) ∧
+        EqOn a Kval S ∧ ∀ z, (Matrix.of (a z)).det ≠ 0 := by
+    have hKval : Continuous Kval := by
+      have hval : Continuous (fun z ↦ (K z : StableSevenMatrix)) :=
+        Units.continuous_val.comp K.continuous
+      apply continuous_pi
+      intro r
+      apply continuous_pi
+      intro c
+      exact (continuous_apply c).comp ((continuous_apply r).comp hval)
+    have hKUmat : ContMDiffOn
+        (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5)))
+        𝓘(ℝ, StableSevenCoordinates) ∞ Kval U := by
+      rw [contMDiffOn_pi_space]
+      intro r
+      rw [contMDiffOn_pi_space]
+      exact hKU r
+    let ε : ℝ × StableClutchingEquatorFiveSphere → ℝ := fun z ↦
+      Metric.infDist (Kval z) singularStableSevenMatrices / 2
+    have hεcont : Continuous ε :=
+      ((Metric.continuous_infDist_pt singularStableSevenMatrices).comp hKval).div_const 2
+    have hεpos (z : ℝ × StableClutchingEquatorFiveSphere) : 0 < ε z := by
+      apply div_pos
+      · apply (singularStableSevenMatrices_isClosed.notMem_iff_infDist_pos
+          singularStableSevenMatrices_nonempty).mp
+        intro hz
+        apply (K z).det_ne_zero
+        change (Matrix.of (Kval z)).det = 0 at hz
+        have hof : Matrix.of (Kval z) = (K z : StableSevenMatrix) := by
+          apply Matrix.ext
+          intro i j
+          rfl
+        rw [hof] at hz
+        exact hz
+      · norm_num
+    obtain ⟨a, ha_approx, ha_eqOn, -⟩ :=
+      hKval.exists_contMDiff_approx_and_eqOn
+        (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) ⊤
+        hεcont hεpos hS hU hKUmat
+    have ha_det (z : ℝ × StableClutchingEquatorFiveSphere) :
+        (Matrix.of (a z)).det ≠ 0 := by
+      intro hz
+      have hmem : a z ∈ singularStableSevenMatrices := hz
+      have hle : Metric.infDist (Kval z) singularStableSevenMatrices ≤
+          dist (Kval z) (a z) :=
+        Metric.infDist_le_dist_of_mem (x := Kval z) hmem
+      have hlt := ha_approx z
+      change dist (a z) (Kval z) <
+        Metric.infDist (Kval z) singularStableSevenMatrices / 2 at hlt
+      rw [dist_comm] at hlt
+      linarith [Metric.infDist_nonneg (x := Kval z) (s := singularStableSevenMatrices)]
+    refine ⟨a, ?_, ha_eqOn, ha_det⟩
+    intro r c
+    exact contMDiff_pi_space.mp (contMDiff_pi_space.mp a.contMDiff r) c
+  obtain ⟨a, ha_smooth, ha_eqOn, ha_det⟩ := approxData
+  let amat (z : ℝ × StableClutchingEquatorFiveSphere) : StableSevenMatrix :=
+    Matrix.of (a z)
+  let lift (z : ℝ × StableClutchingEquatorFiveSphere) : StableGeneralLinearSeven :=
+    Matrix.GeneralLinearGroup.mkOfDetNeZero (amat z) (ha_det z)
+  have ha_cont : Continuous amat :=
+    continuous_matrix fun r c ↦ (ha_smooth r c).continuous
+  have ha_inv : Continuous
+      (fun z ↦ @Inv.inv StableSevenMatrix Matrix.inv (amat z)) := by
+    rw [continuous_iff_continuousAt]
+    intro z
+    apply (continuousAt_matrix_inv (amat z) ?_).comp ha_cont.continuousAt
+    rw [Ring.inverse_eq_inv']
+    exact continuousAt_inv₀ (ha_det z)
+  have hlift : Continuous lift := by
+    apply Units.continuous_iff.mpr
+    constructor
+    · change Continuous amat
+      exact ha_cont
+    · convert ha_inv using 1
+      funext z
+      simp only [lift, Matrix.GeneralLinearGroup.coe_inv,
+        Matrix.GeneralLinearGroup.mkOfDetNeZero]
+      rfl
+  let L : C(ℝ × StableClutchingEquatorFiveSphere, StableGeneralLinearSeven) :=
+    ⟨lift, hlift⟩
+  refine ⟨L, ?_, ?_⟩
+  · intro i j
+    have hentry := ha_smooth j i
+    simp_rw [StableGeneralLinearSeven.coeff_eq_matrixEntry]
+    change ContMDiff
+      (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) 𝓘(ℝ, ℝ) ∞
+      (fun z ↦ amat z j i)
+    simpa only [amat, Matrix.of_apply] using hentry
+  · intro z hz
+    apply Units.ext
+    change Matrix.of (a z) = (K z : StableSevenMatrix)
+    apply Matrix.ext
+    intro i j
+    simpa only [Matrix.of_apply, Kval] using congrFun (congrFun (ha_eqOn hz) i) j
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StableFramingLocalFrameCoefficients.lean
+++ b/SphereSixComplex/Topology/StableFramingLocalFrameCoefficients.lean
@@ -1,0 +1,209 @@
+module
+
+public import SphereSixComplex.Topology.StableFramingHomotopySixSphereClutching
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+
+/-!
+# Smooth coefficients in a smooth local frame
+
+The coefficient functions of a smooth section in an arbitrary smooth finite local frame are
+smooth.  The proof trivializes the bundle near each point, packages the frame vectors as an
+invertible continuous linear map, and differentiates its inverse.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle ContinuousMap Module
+open scoped Bundle Classical ContDiff Manifold
+
+namespace SphereSixComplex
+
+section GenericLocalFrame
+
+variable
+    {𝕜 E H M F ι : Type*}
+    [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+    [TopologicalSpace M] [ChartedSpace H M]
+    {n : ℕ∞ω} [IsManifold I n M]
+    [NormedAddCommGroup F] [NormedSpace 𝕜 F] [FiniteDimensional 𝕜 F]
+    {V : M → Type*} [TopologicalSpace (TotalSpace F V)]
+    [∀ x, AddCommGroup (V x)] [∀ x, Module 𝕜 (V x)]
+    [∀ x, TopologicalSpace (V x)]
+    [FiberBundle F V] [VectorBundle 𝕜 F V]
+    [ContMDiffVectorBundle n F V I]
+    [Fintype ι]
+
+private def localFrameCoordinateMap
+    (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M))
+    (s : ι → (x : M) → V x) (y : M) : (ι → 𝕜) →L[𝕜] F :=
+  ∑ i, (ContinuousLinearMap.proj i).smulRight (e ((T% (s i)) y)).2
+
+set_option linter.unusedSectionVars false in
+private theorem localFrameCoordinateMap_apply
+    (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M))
+    (s : ι → (x : M) → V x) (y : M) (c : ι → 𝕜) :
+    localFrameCoordinateMap e s y c =
+      ∑ i, c i • (e ((T% (s i)) y)).2 := by
+  simp [localFrameCoordinateMap]
+
+set_option linter.unusedSectionVars false in
+private theorem localFrameCoordinateMap_contMDiffAt
+    {u : Set M} {s : ι → (x : M) → V x}
+    (hs : IsLocalFrameOn I F n s u) (hu : IsOpen u)
+    {x : M} (hx : x ∈ u)
+    (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M))
+    [MemTrivializationAtlas e] (hxe : x ∈ e.baseSet) :
+    ContMDiffAt I 𝓘(𝕜, (ι → 𝕜) →L[𝕜] F) n
+      (localFrameCoordinateMap (𝕜 := 𝕜) e s) x := by
+  unfold localFrameCoordinateMap
+  apply ContMDiffAt.sum
+  intro i _
+  apply ContDiff.comp_contMDiffAt
+    (g := ContinuousLinearMap.smulRightL 𝕜 (ι → 𝕜) F
+      (ContinuousLinearMap.proj i))
+    (ContinuousLinearMap.contDiff _)
+  simpa using
+    (e.contMDiffAt_section_iff hxe).mp
+      (hs.contMDiffAt hu hx i)
+
+private def localFrameCoordinateEquivAt
+    {u : Set M} {s : ι → (x : M) → V x}
+    (hs : IsLocalFrameOn I F n s u) {x : M} (hx : x ∈ u)
+    (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M))
+    [MemTrivializationAtlas e] (hxe : x ∈ e.baseSet) :
+    (ι → 𝕜) ≃L[𝕜] F :=
+  ((hs.toBasisAt hx).equivFun.symm.trans
+    (e.linearEquivAt 𝕜 x hxe)).toContinuousLinearEquiv
+
+set_option linter.unusedSectionVars false in
+private theorem localFrameCoordinateMap_eq_equivAt
+    {u : Set M} {s : ι → (x : M) → V x}
+    (hs : IsLocalFrameOn I F n s u) {x : M} (hx : x ∈ u)
+    (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M))
+    [MemTrivializationAtlas e] (hxe : x ∈ e.baseSet) :
+    localFrameCoordinateMap (𝕜 := 𝕜) e s x =
+      (localFrameCoordinateEquivAt hs hx e hxe : (ι → 𝕜) →L[𝕜] F) := by
+  apply ContinuousLinearMap.ext
+  intro c
+  rw [localFrameCoordinateMap_apply]
+  change
+    (∑ i, c i • (e ((T% (s i)) x)).2) =
+      e.linearEquivAt 𝕜 x hxe ((hs.toBasisAt hx).equivFun.symm c)
+  rw [Basis.equivFun_symm_apply, map_sum]
+  simp only [map_smul, hs.toBasisAt_coe hx]
+  congr
+
+/-- A coefficient of a smooth section in a smooth finite local frame is smooth at every point of
+the frame domain. -/
+public theorem localFrame_coeff_contMDiffAt
+    {u : Set M} {s : ι → (x : M) → V x}
+    (hs : IsLocalFrameOn I F n s u) (hu : IsOpen u)
+    {x : M} (hx : x ∈ u) {t : (x : M) → V x}
+    (ht : ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (T% t) x)
+    (i : ι) :
+    ContMDiffAt I 𝓘(𝕜, 𝕜) n (fun y ↦ hs.coeff i y (t y)) x := by
+  let e := trivializationAt F V x
+  let hxe : x ∈ e.baseSet := FiberBundle.mem_baseSet_trivializationAt' x
+  have hA :
+      ContMDiffAt I 𝓘(𝕜, (ι → 𝕜) →L[𝕜] F) n
+        (localFrameCoordinateMap (𝕜 := 𝕜) e s) x :=
+    localFrameCoordinateMap_contMDiffAt hs hu hx e hxe
+  have hAinv : (localFrameCoordinateMap (𝕜 := 𝕜) e s x).IsInvertible := by
+    rw [localFrameCoordinateMap_eq_equivAt hs hx e hxe]
+    exact ContinuousLinearMap.isInvertible_equiv
+  have hInv :
+      ContMDiffAt I 𝓘(𝕜, F →L[𝕜] (ι → 𝕜)) n
+        (ContinuousLinearMap.inverse ∘
+          localFrameCoordinateMap (𝕜 := 𝕜) e s) x :=
+    hAinv.contDiffAt_map_inverse.comp_contMDiffAt hA
+  have htCoord :
+      ContMDiffAt I 𝓘(𝕜, F) n (fun y ↦ (e ((T% t) y)).2) x := by
+    simpa using (e.contMDiffAt_section_iff hxe).mp ht
+  have hCoeffVec :
+      ContMDiffAt I 𝓘(𝕜, ι → 𝕜) n
+        (fun y ↦ ContinuousLinearMap.inverse
+          (localFrameCoordinateMap (𝕜 := 𝕜) e s y)
+          (e ((T% t) y)).2) x :=
+    hInv.clm_apply htCoord
+  have hCoeff :
+      ContMDiffAt I 𝓘(𝕜, 𝕜) n
+        ((ContinuousLinearMap.proj i) ∘
+          (fun y ↦ ContinuousLinearMap.inverse
+            (localFrameCoordinateMap (𝕜 := 𝕜) e s y)
+            (e ((T% t) y)).2)) x :=
+    (ContinuousLinearMap.proj i).contDiff.comp_contMDiffAt hCoeffVec
+  apply hCoeff.congr_of_eventuallyEq
+  filter_upwards
+    [Filter.inter_mem (hu.mem_nhds hx) (e.open_baseSet.mem_nhds hxe)] with y hy
+  have hyu : y ∈ u := hy.1
+  have hye : y ∈ e.baseSet := hy.2
+  simp only [Function.comp_apply, ContinuousLinearMap.proj_apply]
+  rw [localFrameCoordinateMap_eq_equivAt hs hyu e hye]
+  simp only [ContinuousLinearMap.inverse_equiv]
+  rw [hs.coeff_apply_of_mem hyu]
+  change
+    (hs.toBasisAt hyu).repr (t y) i =
+      ((localFrameCoordinateEquivAt hs hyu e hye).symm
+        (e ((T% t) y)).2) i
+  simp [localFrameCoordinateEquivAt, hye]
+
+/-- A coefficient of a smooth section in a smooth finite local frame is smooth throughout the
+frame domain. -/
+public theorem localFrame_coeff_contMDiffOn
+    {u : Set M} {s : ι → (x : M) → V x}
+    (hs : IsLocalFrameOn I F n s u) (hu : IsOpen u)
+    {t : (x : M) → V x}
+    (ht : ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (T% t) u)
+    (i : ι) :
+    ContMDiffOn I 𝓘(𝕜, 𝕜) n (fun y ↦ hs.coeff i y (t y)) u := by
+  intro x hx
+  exact
+    (localFrame_coeff_contMDiffAt hs hu hx
+      ((ht x hx).contMDiffAt (hu.mem_nhds hx)) i).contMDiffWithinAt
+
+end GenericLocalFrame
+
+namespace SmoothRankSevenClutchingPresentationSix
+
+variable {M : Type*} [TopologicalSpace M] [ChartedSpace RealModel M]
+  [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+
+/-- A scalar coefficient of the north-to-south transition, defined without pointwise overlap
+membership proofs. -/
+public noncomputable def coordinateTransitionCoeff
+    (p : SmoothRankSevenClutchingPresentationSix M) (i j : Fin 7) (x : M) : ℝ :=
+  (p.southFrame.mono
+    (show p.north ∩ p.south ⊆ p.south from Set.inter_subset_right)).coeff j x
+      (p.northSections i x)
+
+/-- Each coordinate transition coefficient is smooth on the frame overlap. -/
+public theorem contMDiffOn_coordinateTransitionCoeff
+    (p : SmoothRankSevenClutchingPresentationSix M) (i j : Fin 7) :
+    ContMDiffOn 𝓘(ℝ, RealModel) 𝓘(ℝ, ℝ) ∞
+      (p.coordinateTransitionCoeff i j) (p.north ∩ p.south) := by
+  apply localFrame_coeff_contMDiffOn
+    (p.southFrame.mono
+      (show p.north ∩ p.south ⊆ p.south from Set.inter_subset_right))
+    (p.north_isOpen.inter p.south_isOpen)
+    ((p.northFrame.contMDiffOn i).mono Set.inter_subset_left)
+
+/-- On the overlap, the proof-independent coefficient agrees with the corresponding coefficient
+of `coordinateTransition`. -/
+public theorem coordinateTransition_apply_basis_eq_coeff
+    (p : SmoothRankSevenClutchingPresentationSix M)
+    (x : M) (hxN : x ∈ p.north) (hxS : x ∈ p.south)
+    (i j : Fin 7) :
+    p.coordinateTransition x hxN hxS ((Pi.basisFun ℝ (Fin 7)) i) j =
+      p.coordinateTransitionCoeff i j x := by
+  unfold coordinateTransitionCoeff
+  rw [IsLocalFrameOn.coeff_apply_of_mem
+    (hx := show x ∈ p.north ∩ p.south from ⟨hxN, hxS⟩)]
+  simp [coordinateTransition, IsLocalFrameOn.toBasisAt]
+
+end SmoothRankSevenClutchingPresentationSix
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/StableFramingSmoothClutchingNullhomotopy.lean
+++ b/SphereSixComplex/Topology/StableFramingSmoothClutchingNullhomotopy.lean
@@ -1,0 +1,483 @@
+module
+
+public import SphereSixComplex.Topology.StableFramingGeneralLinearSmoothApproximation
+public import Mathlib.Analysis.SpecialFunctions.SmoothTransition
+public import Mathlib.Topology.Homotopy.Contractible
+
+/-!
+# Smooth nullhomotopies for rank-seven clutching maps
+
+This file separates the remaining rank-seven clutching theorem into its geometric and homotopy-
+group inputs.  A smooth nullhomotopy with the usual endpoint equalities is reparametrized by
+`Real.smoothTransition`, making it constant on collars of both endpoints.  The radial-cone
+construction from `StableFramingBufferedRadialClutching` can then turn it into an exact gauge
+extension.
+
+The final reduction has two independent hypotheses: every marked homotopy six-sphere admits a
+buffered radial presentation with smooth equatorial transition, and every smooth map
+`S⁵ → GL₇(ℝ)` is smoothly nullhomotopic.  The second is the precise smooth representative-level
+form of the required `π₅(GL₇(ℝ)) = 0` calculation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle ContinuousMap Module Set
+open scoped Bundle ContDiff Manifold Topology
+
+namespace SphereSixComplex
+
+/-- A smooth reparametrization which is zero up to `1 / 4` and one from `1` onwards. -/
+public noncomputable def collaredNullhomotopyParameter (t : ℝ) : ℝ :=
+  Real.smoothTransition ((4 * t - 1) / 3)
+
+/-- The collar reparametrization is infinitely smooth. -/
+public theorem contDiff_collaredNullhomotopyParameter :
+    ContDiff ℝ ∞ collaredNullhomotopyParameter := by
+  unfold collaredNullhomotopyParameter
+  fun_prop
+
+/-- The collar reparametrization is zero on its lower collar. -/
+public theorem collaredNullhomotopyParameter_eq_zero
+    (t : ℝ) (ht : t ≤ (1 / 4 : ℝ)) : collaredNullhomotopyParameter t = 0 := by
+  unfold collaredNullhomotopyParameter
+  apply Real.smoothTransition.zero_of_nonpos
+  linarith
+
+/-- The collar reparametrization is one on its upper collar. -/
+public theorem collaredNullhomotopyParameter_eq_one
+    (t : ℝ) (ht : 1 ≤ t) : collaredNullhomotopyParameter t = 1 := by
+  unfold collaredNullhomotopyParameter
+  apply Real.smoothTransition.one_of_one_le
+  linarith
+
+/-- A coefficientwise-smooth nullhomotopy of an equatorial `GL₇(ℝ)` map.
+
+Unlike `SmoothCollaredGLSevenNullhomotopy`, this structure asks only for the ordinary endpoint
+equalities at parameters zero and one. -/
+public structure SmoothGLSevenNullhomotopy
+    (g : StableClutchingEquatorFiveSphere → StableGeneralLinearSeven) where
+  base : StableGeneralLinearSeven
+  homotopy : C(ℝ × StableClutchingEquatorFiveSphere, StableGeneralLinearSeven)
+  contMDiff_coeff (i j : Fin 7) :
+    ContMDiff
+      (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) 𝓘(ℝ, ℝ) ∞
+      (fun z ↦ (homotopy z).coeff i j)
+  eq_base (u : StableClutchingEquatorFiveSphere) : homotopy (0, u) = base
+  eq_equator (u : StableClutchingEquatorFiveSphere) : homotopy (1, u) = g u
+
+namespace SmoothGLSevenNullhomotopy
+
+variable {g : StableClutchingEquatorFiveSphere → StableGeneralLinearSeven}
+
+/-- Reparametrize a smooth nullhomotopy so that it is constant on collars of both endpoints. -/
+public noncomputable def toCollared
+    (H : SmoothGLSevenNullhomotopy g) : SmoothCollaredGLSevenNullhomotopy g where
+  base := H.base
+  homotopy :=
+    { toFun := fun z ↦ H.homotopy (collaredNullhomotopyParameter z.1, z.2)
+      continuous_toFun := H.homotopy.continuous.comp
+        ((contDiff_collaredNullhomotopyParameter.continuous.comp continuous_fst).prodMk
+          continuous_snd) }
+  contMDiff_coeff i j := by
+    have hpair : ContMDiff
+        (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5)))
+        (𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))) ∞
+        (fun z : ℝ × StableClutchingEquatorFiveSphere ↦
+          (collaredNullhomotopyParameter z.1, z.2)) :=
+      (contDiff_collaredNullhomotopyParameter.contMDiff.comp contMDiff_fst).prodMk
+        contMDiff_snd
+    exact (H.contMDiff_coeff i j).comp hpair
+  eq_base t u ht := by
+    change H.homotopy (collaredNullhomotopyParameter t, u) = H.base
+    rw [collaredNullhomotopyParameter_eq_zero t ht, H.eq_base]
+  eq_equator t u ht := by
+    change H.homotopy (collaredNullhomotopyParameter t, u) = g u
+    rw [collaredNullhomotopyParameter_eq_one t ht, H.eq_equator]
+
+/-- Cone an ordinary smooth nullhomotopy over the radial disk after adding endpoint collars. -/
+public noncomputable def toDiskFill
+    (H : SmoothGLSevenNullhomotopy g) : SmoothRadialGLSevenDiskFill g :=
+  H.toCollared.toDiskFill
+
+end SmoothGLSevenNullhomotopy
+
+private abbrev StableGLSevenMatrix := Matrix (Fin 7) (Fin 7) ℝ
+
+private abbrev StableGLSevenHomotopyDomain :=
+  ℝ × StableClutchingEquatorFiveSphere
+
+private abbrev StableGLSevenHomotopyModel :=
+  𝓘(ℝ, ℝ).prod 𝓘(ℝ, EuclideanSpace ℝ (Fin 5))
+
+/-- Coefficientwise smoothness of a `GL₇(ℝ)`-valued map implies continuity. -/
+public theorem continuous_stableGeneralLinearSeven_of_contMDiff_coeff
+    (g : StableClutchingEquatorFiveSphere → StableGeneralLinearSeven)
+    (hg : ∀ i j : Fin 7,
+      ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞ (fun u ↦ (g u).coeff i j)) :
+    Continuous g := by
+  let gval : StableClutchingEquatorFiveSphere → StableGLSevenMatrix :=
+    fun u ↦ (g u : StableGLSevenMatrix)
+  have hval : Continuous gval := by
+    apply continuous_matrix
+    intro r c
+    simpa only [StableGeneralLinearSeven.coeff_eq_matrixEntry] using (hg c r).continuous
+  have hinv : Continuous
+      (fun u ↦ @Inv.inv StableGLSevenMatrix Matrix.inv (gval u)) := by
+    rw [continuous_iff_continuousAt]
+    intro u
+    apply (continuousAt_matrix_inv (gval u) ?_).comp hval.continuousAt
+    rw [Ring.inverse_eq_inv']
+    exact continuousAt_inv₀ (g u).det_ne_zero
+  apply Units.continuous_iff.mpr
+  constructor
+  · exact hval
+  · convert hinv using 1
+    funext u
+    simp only [gval, Matrix.GeneralLinearGroup.coe_inv]
+
+/-- A continuous nullhomotopy of a coefficientwise-smooth `S⁵ → GL₇(ℝ)` map can be smoothed
+relative to its endpoint slices. -/
+public theorem smoothGLSevenNullhomotopy_of_nullhomotopic
+    (g : C(StableClutchingEquatorFiveSphere, StableGeneralLinearSeven))
+    (hg : ∀ i j : Fin 7,
+      ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞ (fun u ↦ (g u).coeff i j))
+    (hnull : g.Nullhomotopic) :
+    Nonempty (SmoothGLSevenNullhomotopy (fun u ↦ g u)) := by
+  obtain ⟨base, ⟨F⟩⟩ := hnull
+  let κ : ℝ → ℝ := fun t ↦ collaredNullhomotopyParameter (2 * t)
+  have hκcont : Continuous κ := by
+    exact contDiff_collaredNullhomotopyParameter.continuous.comp
+      (continuous_const.mul continuous_id)
+  let K : C(StableGLSevenHomotopyDomain, StableGeneralLinearSeven) :=
+    { toFun := fun z ↦ F.extend (1 - κ z.1) z.2
+      continuous_toFun := F.extend.uncurry.continuous.comp
+        ((continuous_const.sub (hκcont.comp continuous_fst)).prodMk continuous_snd) }
+  let S : Set StableGLSevenHomotopyDomain :=
+    ({0} ×ˢ (univ : Set StableClutchingEquatorFiveSphere)) ∪
+      ({1} ×ˢ (univ : Set StableClutchingEquatorFiveSphere))
+  let U : Set StableGLSevenHomotopyDomain :=
+    (Iio (1 / 8 : ℝ) ×ˢ (univ : Set StableClutchingEquatorFiveSphere)) ∪
+      (Ioi (1 / 2 : ℝ) ×ˢ (univ : Set StableClutchingEquatorFiveSphere))
+  have hS : IsClosed S := by
+    exact (isClosed_singleton.prod isClosed_univ).union
+      (isClosed_singleton.prod isClosed_univ)
+  have hUopen : IsOpen U := by
+    exact (isOpen_Iio.prod isOpen_univ).union (isOpen_Ioi.prod isOpen_univ)
+  have hSU : S ⊆ U := by
+    intro z hz
+    rcases hz with hz | hz
+    · left
+      rcases hz with ⟨hz, hu⟩
+      have hz0 : z.1 = 0 := by simpa only [mem_singleton_iff] using hz
+      refine ⟨?_, hu⟩
+      rw [hz0]
+      norm_num
+    · right
+      rcases hz with ⟨hz, hu⟩
+      have hz1 : z.1 = 1 := by simpa only [mem_singleton_iff] using hz
+      refine ⟨?_, hu⟩
+      rw [hz1]
+      norm_num
+  have hU : U ∈ 𝓝ˢ S := hUopen.mem_nhdsSet.mpr hSU
+  have hK_lower (z : StableGLSevenHomotopyDomain)
+      (hz : z ∈ Iio (1 / 8 : ℝ) ×ˢ (univ : Set StableClutchingEquatorFiveSphere)) :
+      K z = base := by
+    change F.extend (1 - κ z.1) z.2 = base
+    have hκ : κ z.1 = 0 := by
+      apply collaredNullhomotopyParameter_eq_zero
+      norm_num at hz ⊢
+      linarith [hz]
+    rw [hκ]
+    exact F.extend_apply_of_one_le (by norm_num) z.2
+  have hK_upper (z : StableGLSevenHomotopyDomain)
+      (hz : z ∈ Ioi (1 / 2 : ℝ) ×ˢ (univ : Set StableClutchingEquatorFiveSphere)) :
+      K z = g z.2 := by
+    change F.extend (1 - κ z.1) z.2 = g z.2
+    have hκ : κ z.1 = 1 := by
+      apply collaredNullhomotopyParameter_eq_one
+      norm_num at hz ⊢
+      linarith [hz]
+    rw [hκ]
+    exact F.extend_apply_of_le_zero (by norm_num) z.2
+  have hKU : ∀ r c : Fin 7, ContMDiffOn StableGLSevenHomotopyModel 𝓘(ℝ, ℝ) ∞
+      (fun z ↦ (K z : StableGLSevenMatrix) r c) U := by
+    intro r c
+    have hlower : ContMDiffOn StableGLSevenHomotopyModel 𝓘(ℝ, ℝ) ∞
+        (fun z ↦ (K z : StableGLSevenMatrix) r c)
+        (Iio (1 / 8 : ℝ) ×ˢ (univ : Set StableClutchingEquatorFiveSphere)) := by
+      apply contMDiffOn_const.congr
+      intro z hz
+      exact congrArg (fun A : StableGeneralLinearSeven ↦ (A : StableGLSevenMatrix) r c)
+        (hK_lower z hz)
+    have hg_entry : ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞
+        (fun u ↦ (g u : StableGLSevenMatrix) r c) := by
+      simpa only [StableGeneralLinearSeven.coeff_eq_matrixEntry] using hg c r
+    have hupper : ContMDiffOn StableGLSevenHomotopyModel 𝓘(ℝ, ℝ) ∞
+        (fun z ↦ (K z : StableGLSevenMatrix) r c)
+        (Ioi (1 / 2 : ℝ) ×ˢ (univ : Set StableClutchingEquatorFiveSphere)) := by
+      apply (hg_entry.comp contMDiff_snd).contMDiffOn.congr
+      intro z hz
+      exact congrArg (fun A : StableGeneralLinearSeven ↦ (A : StableGLSevenMatrix) r c)
+        (hK_upper z hz)
+    exact hlower.union_of_isOpen hupper
+      (isOpen_Iio.prod isOpen_univ) (isOpen_Ioi.prod isOpen_univ)
+  obtain ⟨L, hLsmooth, hLK⟩ :=
+    exists_smoothGLSevenApprox_eqOn K hS hU hKU
+  refine ⟨{
+    base := base
+    homotopy := L
+    contMDiff_coeff := hLsmooth
+    eq_base := ?_
+    eq_equator := ?_ }⟩
+  · intro u
+    rw [hLK (x := ((0 : ℝ), u)) (by left; simp)]
+    apply hK_lower
+    norm_num
+  · intro u
+    rw [hLK (x := ((1 : ℝ), u)) (by right; simp)]
+    apply hK_upper
+    norm_num
+
+namespace SmoothBufferedRadialRankSevenClutchingPresentationSix
+
+variable {M : Type*} [TopologicalSpace M] [ChartedSpace RealModel M]
+  [IsManifold 𝓘(ℝ, RealModel) ∞ M]
+
+/-- The equatorial transition of a buffered presentation is coefficientwise smooth. -/
+public def EquatorTransitionIsSmooth
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M) : Prop :=
+  ∀ i j : Fin 7,
+    ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞ (fun u ↦ (q.equatorTransition u).coeff i j)
+
+/-- A fixed-radius section of the outer radial collar, used to read off the equatorial
+transition. -/
+public noncomputable def equatorSection
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M)
+    (u : StableClutchingEquatorFiveSphere) : M :=
+  q.southCoordinates.symm ((3 / 2 : ℝ) • (u : RealModel))
+
+/-- The fixed-radius equator section is smooth. -/
+public theorem equatorSection_contMDiff
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M) :
+    ContMDiff (𝓡 5) 𝓘(ℝ, RealModel) ∞ q.equatorSection := by
+  let _ : Fact (finrank ℝ RealModel = 5 + 1) := ⟨by simp [RealModel]⟩
+  have hc : ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞
+      (fun _ : StableClutchingEquatorFiveSphere ↦ (3 / 2 : ℝ)) :=
+    contMDiff_const
+  have hscale : ContMDiff (𝓡 5) 𝓘(ℝ, RealModel) ∞
+      (fun u : StableClutchingEquatorFiveSphere ↦ (3 / 2 : ℝ) • (u : RealModel)) :=
+    hc.smul (contMDiff_coe_sphere (E := RealModel) (n := 5))
+  have hsymm : ContMDiff 𝓘(ℝ, RealModel) 𝓘(ℝ, RealModel) ∞
+      q.southCoordinates.symm := by
+    rw [← contMDiffOn_univ]
+    simpa only [q.southCoordinates_target] using
+      q.southCoordinates_symm_contMDiffOn
+  exact hsymm.comp hscale
+
+/-- The fixed-radius section lies in the small southern patch. -/
+public theorem equatorSection_mem_south
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M)
+    (u : StableClutchingEquatorFiveSphere) :
+    q.equatorSection u ∈ q.toBufferedPresentation.south := by
+  let y : RealModel := (3 / 2 : ℝ) • (u : RealModel)
+  have htarget : y ∈ q.southCoordinates.target := by
+    rw [q.southCoordinates_target]
+    exact mem_univ y
+  have happly : q.southCoordinates (q.equatorSection u) = y := by
+    exact q.southCoordinates.right_inv htarget
+  have hu : ‖(u : RealModel)‖ = 1 := mem_sphere_zero_iff_norm.mp u.property
+  have hy : ‖y‖ = 3 / 2 := by
+    simp [y, norm_smul, hu]
+  rw [q.south_eq_coordinate_ball]
+  change q.southCoordinates (q.equatorSection u) ∈ Metric.ball (0 : RealModel) 2
+  rw [happly, Metric.mem_ball, dist_zero_right, hy]
+  norm_num
+
+/-- The fixed-radius section lies in the small northern patch. -/
+public theorem equatorSection_mem_north
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M)
+    (u : StableClutchingEquatorFiveSphere) :
+    q.equatorSection u ∈ q.toBufferedPresentation.north := by
+  have hxS := q.equatorSection_mem_south u
+  apply (q.overlap_is_outer_collar (q.equatorSection u) hxS).mpr
+  let y : RealModel := (3 / 2 : ℝ) • (u : RealModel)
+  have htarget : y ∈ q.southCoordinates.target := by
+    rw [q.southCoordinates_target]
+    exact mem_univ y
+  have happly : q.southCoordinates (q.equatorSection u) = y := by
+    exact q.southCoordinates.right_inv htarget
+  have hu : ‖(u : RealModel)‖ = 1 := mem_sphere_zero_iff_norm.mp u.property
+  have hy : ‖y‖ = 3 / 2 := by
+    simp [y, norm_smul, hu]
+  rw [happly, hy]
+  norm_num
+
+private theorem stableClutchingDirection_threeHalves_smul
+    (u : StableClutchingEquatorFiveSphere)
+    (h : 0 < ‖((3 / 2 : ℝ) • (u : RealModel))‖ ^ 2) :
+    stableClutchingDirectionOfNormSqPositive ((3 / 2 : ℝ) • (u : RealModel)) h = u := by
+  have hu : ‖(u : RealModel)‖ = 1 := mem_sphere_zero_iff_norm.mp u.property
+  apply Subtype.ext
+  simp [stableClutchingDirectionOfNormSqPositive, stableClutchingDirection,
+    homeomorphUnitSphereProd_apply_fst_coe, norm_smul, hu]
+  rw [smul_smul]
+  norm_num
+
+/-- The angular coordinate of the fixed-radius section is the original equator point. -/
+public theorem equatorSection_direction
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M)
+    (u : StableClutchingEquatorFiveSphere) :
+    stableClutchingDirectionOfNormSqPositive
+      (q.southCoordinates (q.equatorSection u))
+      (zero_lt_one.trans ((q.overlap_is_outer_collar (q.equatorSection u)
+        (q.equatorSection_mem_south u)).mp (q.equatorSection_mem_north u))) = u := by
+  let y : RealModel := (3 / 2 : ℝ) • (u : RealModel)
+  have htarget : y ∈ q.southCoordinates.target := by
+    rw [q.southCoordinates_target]
+    exact mem_univ y
+  have happly : q.southCoordinates (q.equatorSection u) = y := by
+    exact q.southCoordinates.right_inv htarget
+  have hypos : 0 < ‖y‖ ^ 2 := by
+    have hu : ‖(u : RealModel)‖ = 1 := mem_sphere_zero_iff_norm.mp u.property
+    simp [y, norm_smul, hu]
+  calc
+    stableClutchingDirectionOfNormSqPositive
+        (q.southCoordinates (q.equatorSection u)) _ =
+        stableClutchingDirectionOfNormSqPositive y hypos := by
+          congr 1
+    _ = u := stableClutchingDirection_threeHalves_smul u hypos
+
+/-- Smooth local frames force the angular transition of every buffered radial presentation to be
+coefficientwise smooth; this is not an additional geometric hypothesis. -/
+public theorem equatorTransition_isSmooth
+    (q : SmoothBufferedRadialRankSevenClutchingPresentationSix M) :
+    q.EquatorTransitionIsSmooth := by
+  intro i j
+  let p := q.toClutchingPresentation
+  have hcoeff := p.contMDiffOn_coordinateTransitionCoeff i j
+  have hsection := q.equatorSection_contMDiff
+  have hcomposed : ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞
+      (fun u ↦ p.coordinateTransitionCoeff i j (q.equatorSection u)) := by
+    rw [← contMDiffOn_univ]
+    apply hcoeff.comp hsection.contMDiffOn
+    intro u _
+    exact ⟨q.equatorSection_mem_north u, q.equatorSection_mem_south u⟩
+  have heq (u : StableClutchingEquatorFiveSphere) :
+      p.coordinateTransitionCoeff i j (q.equatorSection u) =
+        (q.equatorTransition u).coeff i j := by
+    have htrans := q.transition_eq_radial (q.equatorSection u)
+      (q.equatorSection_mem_north u) (q.equatorSection_mem_south u)
+    have heval := congrArg
+      (fun A : StableFrameCoordinatesSix ≃ₗ[ℝ] StableFrameCoordinatesSix ↦
+        A ((Pi.basisFun ℝ (Fin 7)) i) j) htrans
+    change
+      p.coordinateTransition (q.equatorSection u)
+          (q.equatorSection_mem_north u) (q.equatorSection_mem_south u)
+          ((Pi.basisFun ℝ (Fin 7)) i) j = _ at heval
+    have hcoeffEq := p.coordinateTransition_apply_basis_eq_coeff
+      (q.equatorSection u) (q.equatorSection_mem_north u)
+      (q.equatorSection_mem_south u) i j
+    have heval' : p.coordinateTransitionCoeff i j (q.equatorSection u) = _ :=
+      hcoeffEq.symm.trans heval
+    rw [q.equatorSection_direction] at heval'
+    simpa only [StableGeneralLinearSeven.coeff] using heval'
+  apply hcomposed.congr
+  intro u
+  exact (heq u).symm
+
+end SmoothBufferedRadialRankSevenClutchingPresentationSix
+
+/-- The remaining geometric input stripped of automatic regularity: every marked homotopy
+six-sphere admits a buffered radial rank-seven clutching presentation. -/
+public def HomotopySixSphereBufferedRadialRankSevenClutchingPresentation : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    Nonempty (SmoothBufferedRadialRankSevenClutchingPresentationSix S.carrier)
+
+/-- The geometric input: a buffered radial presentation with smooth equatorial transition for
+every marked homotopy six-sphere. -/
+public def HomotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation : Prop :=
+  ∀ S : OrientedMarkedSmoothHomotopySixSphere.{0},
+    ∃ q : SmoothBufferedRadialRankSevenClutchingPresentationSix S.carrier,
+      q.EquatorTransitionIsSmooth
+
+/-- Existence of buffered radial presentations supplies their equatorial smoothness
+automatically. -/
+public theorem
+    homotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation_of_buffered
+    (h : HomotopySixSphereBufferedRadialRankSevenClutchingPresentation) :
+    HomotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation := by
+  intro S
+  obtain ⟨q⟩ := h S
+  exact ⟨q, q.equatorTransition_isSmooth⟩
+
+/-- The smooth representative-level form of `π₅(GL₇(ℝ)) = 0`. -/
+public def SmoothGLSevenFiveSphereNullhomotopyVanishing : Prop :=
+  ∀ g : StableClutchingEquatorFiveSphere → StableGeneralLinearSeven,
+    (∀ i j : Fin 7,
+      ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞ (fun u ↦ (g u).coeff i j)) →
+    Nonempty (SmoothGLSevenNullhomotopy g)
+
+/-- The purely topological representative-level form of `π₅(GL₇(ℝ)) = 0`. -/
+public def TopologicalGLSevenFiveSphereNullhomotopyVanishing : Prop :=
+  ∀ g : C(StableClutchingEquatorFiveSphere, StableGeneralLinearSeven), g.Nullhomotopic
+
+/-- Topological `π₅(GL₇)` vanishing implies the smooth representative-level formulation. -/
+public theorem smoothGLSevenFiveSphereNullhomotopyVanishing_of_topological
+    (htop : TopologicalGLSevenFiveSphereNullhomotopyVanishing) :
+    SmoothGLSevenFiveSphereNullhomotopyVanishing := by
+  intro g hg
+  let gc : C(StableClutchingEquatorFiveSphere, StableGeneralLinearSeven) :=
+    ⟨g, continuous_stableGeneralLinearSeven_of_contMDiff_coeff g hg⟩
+  apply smoothGLSevenNullhomotopy_of_nullhomotopic gc
+  · intro i j
+    change ContMDiff (𝓡 5) 𝓘(ℝ, ℝ) ∞ (fun u ↦ (g u).coeff i j)
+    exact hg i j
+  · exact htop gc
+
+/-- The geometric presentation theorem and smooth `π₅(GL₇)` vanishing supply collared
+nullhomotopies for every marked homotopy six-sphere. -/
+public theorem
+    homotopySixSphereBufferedRadialRankSevenCollaredNullhomotopyVanishing_of_smooth_piFive
+    (hgeometry : HomotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation)
+    (hpiFive : SmoothGLSevenFiveSphereNullhomotopyVanishing) :
+    HomotopySixSphereBufferedRadialRankSevenCollaredNullhomotopyVanishing := by
+  intro S
+  obtain ⟨q, hq⟩ := hgeometry S
+  obtain ⟨H⟩ := hpiFive q.equatorTransition hq
+  exact ⟨q, ⟨H.toCollared⟩⟩
+
+/-- The original exact hemispherical clutching-extension theorem follows from the geometric
+presentation theorem and smooth `π₅(GL₇)` vanishing. -/
+public theorem
+    homotopySixSphereHemisphericalRankSevenClutchingVanishing_of_smooth_piFive
+    (hgeometry : HomotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation)
+    (hpiFive : SmoothGLSevenFiveSphereNullhomotopyVanishing) :
+    HomotopySixSphereHemisphericalRankSevenClutchingVanishing :=
+  homotopySixSphereHemisphericalRankSevenClutchingVanishing_of_collaredNullhomotopy
+    (homotopySixSphereBufferedRadialRankSevenCollaredNullhomotopyVanishing_of_smooth_piFive
+      hgeometry hpiFive)
+
+/-- The geometric presentation theorem and topological `π₅(GL₇)` vanishing supply the original
+exact hemispherical clutching-extension theorem. -/
+public theorem
+    homotopySixSphereHemisphericalRankSevenClutchingVanishing_of_topological_piFive
+    (hgeometry : HomotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation)
+    (hpiFive : TopologicalGLSevenFiveSphereNullhomotopyVanishing) :
+    HomotopySixSphereHemisphericalRankSevenClutchingVanishing :=
+  homotopySixSphereHemisphericalRankSevenClutchingVanishing_of_smooth_piFive hgeometry
+    (smoothGLSevenFiveSphereNullhomotopyVanishing_of_topological hpiFive)
+
+/-- Buffered radial presentation existence and the purely topological `π₅(GL₇)` calculation imply
+the original exact hemispherical clutching-extension theorem. -/
+public theorem
+    homotopySixSphereHemisphericalRankSevenClutchingVanishing_of_buffered_and_topological_piFive
+    (hgeometry : HomotopySixSphereBufferedRadialRankSevenClutchingPresentation)
+    (hpiFive : TopologicalGLSevenFiveSphereNullhomotopyVanishing) :
+    HomotopySixSphereHemisphericalRankSevenClutchingVanishing :=
+  homotopySixSphereHemisphericalRankSevenClutchingVanishing_of_topological_piFive
+    (homotopySixSphereSmoothBufferedRadialRankSevenClutchingPresentation_of_buffered hgeometry)
+    hpiFive
+
+end SphereSixComplex


### PR DESCRIPTION
## Summary

- prove that coefficients of a smooth section in an arbitrary smooth finite local frame are smooth, using smooth inversion of the frame-coordinate linear map
- deduce that every buffered radial presentation has a coefficientwise-smooth equatorial transition
- add relative smooth approximation for continuous `GL₇(ℝ)`-valued maps while preserving exact values on a closed set and preserving invertibility
- turn any continuous nullhomotopy of a smooth `S⁵ → GL₇(ℝ)` map into the collared smooth nullhomotopy required by the radial disk-fill construction
- reduce the exact hemispherical clutching-extension theorem to buffered-presentation existence plus the purely topological statement `π₅(GL₇(ℝ)) = 0`

This PR is stacked on #75. It removes the transition-smoothness and smooth-approximation obligations; it does not yet prove the remaining buffered-presentation existence theorem or the topological `π₅(GL₇(ℝ))` calculation.

## Verification

- `lake build` — passed, 9,412 jobs, using the warm upstream cache
- direct elaboration of all three new modules — passed
- `git diff --check` — passed
- no `sorry`, `admit`, or new axioms in the changed files
- axiom audit of the new reduction chain reports only `propext`, `Classical.choice`, and `Quot.sound`
