### PR TITLE
Wire every module into Main

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -274,6 +274,13 @@ public import SphereSixComplex.TriangleGroup.FuchsianProperFreeness
 public import SphereSixComplex.TriangleGroup.FuchsianOneFixedCommutation
 public import SphereSixComplex.TriangleGroup.FuchsianTwoFixedCommutation
 public import SphereSixComplex.TriangleGroup.Representation
+public import SphereSixComplex.Topology.ConnectedSumQuotient
+public import SphereSixComplex.Topology.GeometricWangSplitting
+public import SphereSixComplex.Topology.KervaireMilnorSix
+public import SphereSixComplex.Topology.PaperCuspGeometricSpecialization
+public import SphereSixComplex.Topology.SingularSubdivisionIteration
+public import SphereSixComplex.Topology.EstablishedEquivariantUniversalCover
+public import SphereSixComplex.Topology.PaperActualAffineCoreData
 
 /-!
 # A Complex Structure on the Six-Sphere


### PR DESCRIPTION
Housekeeping for #9/#10, found while running the axiom inventory.

Seven modules were reachable from no build target, so `lake build` never checked them *or* the code consuming them, and their axioms did not appear in any `#print axioms` audit:

| module | axioms hidden |
|---|---|
| `Topology.ConnectedSumQuotient` | — |
| `Topology.GeometricWangSplitting` | 1 |
| `Topology.KervaireMilnorSix` | — |
| `Topology.PaperCuspGeometricSpecialization` | 3 |
| `Topology.SingularSubdivisionIteration` | — |
| `Topology.EstablishedEquivariantUniversalCover` | 1 |
| `Topology.PaperActualAffineCoreData` | — |

Importing them from `Main` brings all of it into the build. Afterwards **no module in the library is outside `Main`'s import cone**, and the static inventory goes from "40 axioms, 4 in neither cone" to "41 axioms, 0 in neither" — the extra one being `EstablishedCircleMappingTorusGeometricSections.sections`, which was hidden along with its module.

All seven compile as part of `Main`; this changes no proof.

Worth a look separately: the three in `PaperCuspGeometricSpecialization` (`EstablishedStandardA2CuspSpecialization.degreeOne`/`degreeTwo` and `EstablishedActualCuspRadialClutching.data`) are stated only for the *actual* objects, so they assert how the actual cusp specialization acts in the chosen Wang coordinates rather than a general theorem — I flagged that on #9. Now that they are in the build, they will at least show up in every audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)