### PR TITLE
Run the trust gates in CI

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           lake exe cache get
           lake build
+      - name: Check import coverage
+        run: ./scripts/check-imports.py
+      - name: Check the axiom trust boundary
+        run: CHECK_AXIOMS_SKIP_BUILD=1 ./scripts/check-axioms.sh
       - name: Build Blueprint site
         working-directory: blueprint
         run: ./scripts/ci-pages.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ justification. Set `CHECK_AXIOMS_SKIP_BUILD=1` to reuse an existing build.
 `SphereSixComplex/` and marks whether it is reachable from `Final` (so the headline theorem may
 come to depend on it), only from `Main`, or from neither.
 
+`./scripts/check-imports.py` checks that every module is reachable from `SphereSixComplex.Main`.
+A module outside the build cone is elaborated by nothing and its axioms are invisible to the
+audit, so this keeps the two scripts above honest.
+
+Both gates run in CI after `lake build`.
+
 ## Comparator
 
 ```sh

--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -274,6 +274,13 @@ public import SphereSixComplex.TriangleGroup.FuchsianProperFreeness
 public import SphereSixComplex.TriangleGroup.FuchsianOneFixedCommutation
 public import SphereSixComplex.TriangleGroup.FuchsianTwoFixedCommutation
 public import SphereSixComplex.TriangleGroup.Representation
+public import SphereSixComplex.Topology.ConnectedSumQuotient
+public import SphereSixComplex.Topology.GeometricWangSplitting
+public import SphereSixComplex.Topology.KervaireMilnorSix
+public import SphereSixComplex.Topology.PaperCuspGeometricSpecialization
+public import SphereSixComplex.Topology.SingularSubdivisionIteration
+public import SphereSixComplex.Topology.EstablishedEquivariantUniversalCover
+public import SphereSixComplex.Topology.PaperActualAffineCoreData
 
 /-!
 # A Complex Structure on the Six-Sphere

--- a/scripts/check-imports.py
+++ b/scripts/check-imports.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fail if any module of the library is unreachable from `SphereSixComplex.Main`.
+
+A module outside every build target is checked by nothing: `lake build` never elaborates it, and
+its axioms are invisible to `#print axioms`. This guards against that regressing.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+import re
+import sys
+
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
+LIB = "SphereSixComplex"
+ROOT_MODULE = f"{LIB}.Main"
+
+IMPORT_RE = re.compile(r"^\s*(?:public\s+)?import\s+(?:all\s+)?([\w.]+)")
+
+
+def main() -> int:
+    imports: dict[str, set[str]] = collections.defaultdict(set)
+    modules: set[str] = set()
+    for dirpath, _, filenames in os.walk(os.path.join(ROOT, LIB)):
+        for name in sorted(filenames):
+            if not name.endswith(".lean"):
+                continue
+            path = os.path.relpath(os.path.join(dirpath, name), ROOT)
+            module = path[: -len(".lean")].replace(os.sep, ".")
+            modules.add(module)
+            with open(os.path.join(ROOT, path), encoding="utf-8") as handle:
+                for line in handle:
+                    match = IMPORT_RE.match(line)
+                    if match and match.group(1).startswith(LIB):
+                        imports[module].add(match.group(1))
+
+    seen: set[str] = set()
+    stack = [ROOT_MODULE]
+    while stack:
+        module = stack.pop()
+        if module in seen:
+            continue
+        seen.add(module)
+        stack.extend(imports.get(module, ()))
+
+    orphans = sorted(modules - seen)
+    if orphans:
+        print(f"Import check FAILED: {len(orphans)} module(s) unreachable from {ROOT_MODULE}:")
+        for module in orphans:
+            print(f"  {module}")
+        print()
+        print(f"Nothing checks these modules. Import them from {LIB}/Main.lean, or delete them.")
+        return 1
+
+    print(f"Import check passed: all {len(modules)} modules are reachable from {ROOT_MODULE}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #104 (its commit is the first of the two here; the import check fails without it, which is rather the point).

Two gates now run in the pages workflow immediately after `lake build`:

**`scripts/check-imports.py`** — fails if any module of the library is unreachable from `SphereSixComplex.Main`. This is the hole #104 closes: a module outside every build target is elaborated by nothing, so `lake build` does not check it *and* its axioms never show up in a `#print axioms` audit. Seven modules were in that state, hiding five axioms. Without a gate the situation just recurs, since nothing about adding a module reminds you to import it.

```
$ ./scripts/check-imports.py
Import check passed: all 472 modules are reachable from SphereSixComplex.Main.
```

**`scripts/check-axioms.sh`** (from #36) — run with `CHECK_AXIOMS_SKIP_BUILD=1` so it reuses the build the workflow already did, and fails if the final theorem acquires a dependency outside `scripts/allowed-axioms.txt`. Widening the trust boundary then requires editing that file, with its written justification, in the same PR.

Both pass locally on this branch. The README section on the trust boundary is updated to mention them.

Relates to #9 (axiom inventory) and #11 (final trust gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)