### PR TITLE
Gate stray proof placeholders

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -29,6 +29,8 @@ jobs:
           lake build
       - name: Check import coverage
         run: ./scripts/check-imports.py
+      - name: Check for stray proof placeholders
+        run: ./scripts/check-sorries.py
       - name: Check the axiom trust boundary
         run: CHECK_AXIOMS_SKIP_BUILD=1 ./scripts/check-axioms.sh
       - name: Build Blueprint site

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ justification. Set `CHECK_AXIOMS_SKIP_BUILD=1` to reuse an existing build.
 `SphereSixComplex/` and marks whether it is reachable from `Final` (so the headline theorem may
 come to depend on it), only from `Main`, or from neither.
 
+`./scripts/check-sorries.py` checks that no `sorry`, `admit`, or `native_decide` appears outside
+the two declared boundaries: the paper-specific gluing `sorry` in `Final.lean` and the trusted
+Comparator statements in `Challenge.lean`. It counts them, so a second placeholder in an already
+listed file also fails.
+
 `./scripts/check-imports.py` checks that every module is reachable from `SphereSixComplex.Main`.
 A module outside the build cone is elaborated by nothing and its axioms are invisible to the
 audit, so this keeps the two scripts above honest.

--- a/scripts/check-sorries.py
+++ b/scripts/check-sorries.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Fail if a proof placeholder appears outside the two declared boundaries.
+
+Project policy (#11) is that no `sorry`, `admit`, or `native_decide` survives except:
+
+* the single paper-specific gluing `sorry` in `SphereSixComplex/Final.lean`, and
+* the trusted Comparator challenge statements in `Challenge.lean`.
+
+Both are listed in ALLOWED below, with the exact number of occurrences expected, so that a new
+placeholder anywhere — including a second one in `Final.lean` — is a failure rather than a silent
+regression. Comments and docstrings are ignored, so prose like "germs admit a comparison" does not
+trip the check.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
+
+#: file -> number of placeholder occurrences that are expected and accepted.
+ALLOWED = {
+    "SphereSixComplex/Final.lean": 1,
+    "Challenge.lean": 2,
+}
+
+TOKEN_RE = re.compile(r"(?<![\w.])(sorry|admit|native_decide)(?![\w'])")
+LINE_COMMENT_RE = re.compile(r"--.*$")
+
+
+def strip_comments(source: str) -> str:
+    """Remove block comments and line comments, keeping line structure."""
+    out: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(source):
+        if source.startswith("/-", i):
+            depth += 1
+            i += 2
+        elif source.startswith("-/", i) and depth > 0:
+            depth -= 1
+            i += 2
+        else:
+            out.append(" " if depth > 0 and source[i] != "\n" else source[i])
+            i += 1
+    return LINE_COMMENT_RE.sub("", "".join(out)) if depth == 0 else "".join(out)
+
+
+def sources() -> list[str]:
+    found = ["Challenge.lean", "Solution.lean"]
+    for dirpath, _, filenames in os.walk(os.path.join(ROOT, "SphereSixComplex")):
+        for name in sorted(filenames):
+            if name.endswith(".lean"):
+                found.append(os.path.relpath(os.path.join(dirpath, name), ROOT))
+    return sorted(found)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in sources():
+        with open(os.path.join(ROOT, path), encoding="utf-8") as handle:
+            text = strip_comments(handle.read())
+        hits = [
+            (number, match.group(1))
+            for number, line in enumerate(text.splitlines(), start=1)
+            for match in TOKEN_RE.finditer(LINE_COMMENT_RE.sub("", line))
+        ]
+        budget = ALLOWED.get(path, 0)
+        if len(hits) > budget:
+            for number, token in hits[budget:]:
+                failures.append(f"  {path}:{number}: {token}")
+        elif len(hits) < budget:
+            failures.append(
+                f"  {path}: expected {budget} declared placeholder(s), found {len(hits)}"
+                " — update ALLOWED in scripts/check-sorries.py"
+            )
+
+    if failures:
+        print("Placeholder check FAILED:")
+        print("\n".join(failures))
+        return 1
+
+    total = sum(ALLOWED.values())
+    print(f"Placeholder check passed: {total} declared placeholder(s), none elsewhere.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Third gate, alongside the axiom and import checks from #36 and #106. Relates to #11's "no sorry or admit remains except the intentional Comparator challenge boundary".

`scripts/check-sorries.py` fails if `sorry`, `admit`, or `native_decide` appears outside the declared boundaries:

```
$ ./scripts/check-sorries.py
Placeholder check passed: 3 declared placeholder(s), none elsewhere.
```

Design points worth flagging:

* **Counts, not just files.** `Final.lean` is allowed exactly one and `Challenge.lean` exactly two. A second `sorry` in `Final.lean` fails, rather than hiding behind the first. Deleting one also fails, with a message telling you to update the list — which is the right nudge when `exists_paperGluingData` finally closes.
* **Comments are stripped** before scanning, so prose like "solution germs admit the comparison neighbourhood" (`PuncturedRegularComparison.lean:65`) does not trip it. Block comments and line comments are both handled.
* **`set_option` is deliberately not checked**, even though #11 mentions it: the library uses `backward.isDefEq.respectTransparency` in 69 places and linter options in another 30-odd, so a blanket ban would flag existing, intentional practice. Happy to add a narrower check (say, forbidding only `maxHeartbeats` above some bound) if that is wanted.

Verified it catches a planted `sorry` and passes on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)