### PR TITLE
Prove the eval statement in Solution

### DIFF
--- a/Solution.lean
+++ b/Solution.lean
@@ -2,8 +2,28 @@ module
 
 public import SphereSixComplex.Final
 
+open scoped ContDiff Manifold
+
 open SphereSixComplex
 
 /-- Comparator wrapper around the completed project theorem. -/
 public theorem sphere_six_admits_complex_structure : AdmitsComplexStructure SixSphere := by
   exact SphereSixComplex.sphere_six_admits_complex_structure
+
+/-- The unit `n`-sphere, defined as `Metric.sphere 0 1` in `EuclideanSpace ℝ (Fin (n + 1))`. -/
+public abbrev unitSphere (n : ℕ) : Set (EuclideanSpace ℝ (Fin (n + 1))) := Metric.sphere 0 1
+
+/--
+Does the 6-sphere admit a complex structure, i.e. an atlas of holomorphically compatible charts
+relating it to `EuclideanSpace ℂ (Fin 3)`?
+
+The project theorem is stronger in two ways: its atlas is smooth to all orders, and it is
+compatible with the standard smooth structure. Forgetting both gives the statement below.
+-/
+public theorem mathoverflow_1973 :
+    ∃ atlas : ChartedSpace (EuclideanSpace ℂ (Fin 3)) (unitSphere 6),
+      IsManifold 𝓘(ℂ, EuclideanSpace ℂ (Fin 3)) 1 (unitSphere 6) := by
+  obtain ⟨c, hc, -⟩ := SphereSixComplex.sphere_six_admits_complex_structure
+  refine ⟨c, ?_⟩
+  have hinf : IsManifold 𝓘(ℂ, ComplexModel) ∞ SixSphere := hc
+  infer_instance


### PR DESCRIPTION
#93 added a second, verbatim-copied statement of the question to `Challenge.lean` (`mathoverflow_1973`), but `Solution.lean` only answered the first. This answers both.

The project theorem is stronger in two ways — its atlas is smooth to all orders, and it is compatible with the standard smooth structure — so the eval statement follows by forgetting both:

```lean
public theorem mathoverflow_1973 :
    ∃ atlas : ChartedSpace (EuclideanSpace ℂ (Fin 3)) (unitSphere 6),
      IsManifold 𝓘(ℂ, EuclideanSpace ℂ (Fin 3)) 1 (unitSphere 6) := by
  obtain ⟨c, hc, -⟩ := SphereSixComplex.sphere_six_admits_complex_structure
  refine ⟨c, ?_⟩
  have hinf : IsManifold 𝓘(ℂ, ComplexModel) ∞ SixSphere := hc
  infer_instance
```

`SixSphere` is `↥(Metric.sphere (0 : EuclideanSpace ℝ (Fin 7)) 1)` and `unitSphere 6` is the same set, so the two are the same type and no transport is needed; the only real step is weakening `∞` to `1` through Mathlib's instance.

```
#print axioms mathoverflow_1973
-- [propext, sorryAx, Classical.choice, Quot.sound,
--  establishedGeneralizedTopologicalPoincareSix,
--  establishedHomologyToHomotopySixSphere,
--  establishedMarkedSmoothSixSphereClassesTrivial]
```

i.e. exactly the main endpoint's dependencies — as expected, since it is derived from it.

**One decision for you:** `comparator.json` still lists only `sphere_six_admits_complex_structure` in `theorem_names`, so Comparator will not check this one. Adding `"mathoverflow_1973"` there would make the eval statement part of the compared boundary; I have not touched that file since it is the trust configuration and the call is yours. (`unitSphere` is a reducible `abbrev` in both modules, so the statements should elaborate to the same type without needing an entry in `definition_names` — worth confirming with an actual Comparator run, which I could not do locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)