### PR TITLE
Correct the axiom count in the README status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ recognition foundations. The Blueprint records the remaining paper-specific obli
    the three star filling relations. Both come from a filling cover square (issues #1, #2).
 2. `SectionSevenPositiveDegreeHomologyAssembly`: the actual H₁/H₂ bases and compatibility
    squares of Section 7 (issues #6, #7).
-3. `SectionSevenStageTopDegreeVanishing`, which reduces to each collar source having no sixth
-   integral homology.
+3. `SectionSevenStageTopDegreeVanishing`, supplied by
+   `sectionSevenStageTopDegreeVanishing_actual`. Its dimension argument is proved; the cusp collar
+   step rests on the fibre identification recorded in `EstablishedActualCuspRadialClutching.data`.
 
-Past that, the headline theorem rests on four axioms: the general integral Mayer--Vietoris exact
-sequence, and the three classical recognition inputs (Hurewicz--Whitehead for smooth manifolds,
-the generalized topological Poincare theorem in dimension six, and the triviality of the group of
-smooth structures on the six-sphere). `./scripts/check-axioms.sh` prints and enforces exactly that
-list.
+Past the paper-specific construction, the final recognition step uses three external axioms absent
+from Mathlib: integral Mayer--Vietoris, Hurewicz--Whitehead for smooth manifolds, and the
+standard-model smooth Poincare theorem in dimension six.
+
+While `exists_paperGluingData` remains a `sorry`, `./scripts/check-axioms.sh` sees only the two
+recognition axioms plus `sorryAx`; `./scripts/axiom_inventory.py` statically lists the broader
+construction cone that becomes reachable when the placeholder is discharged.
 
 ## Build
 


### PR DESCRIPTION
`aff68ac` consolidated the recognition inputs: the generalized topological Poincare theorem and
the triviality of the group of smooth structures on the six-sphere are now theorems derived from
`establishedSmoothPoincareSixStandardModel`. The README still claimed four axioms; the enforced
allowlist has three.

While correcting that, this also records a caveat that is easy to misread in the other direction:
`sorry` short-circuits `#print axioms`, so while `exists_paperGluingData` is a placeholder the
headline theorem's cone reaches none of the `established*` construction axioms. The enforced list
is small partly because the construction is not yet wired in, and it will grow when the last
`sorry` is discharged. `scripts/axiom_inventory.py` already reports the static counterpart (39
axioms today), so this is documentation only -- no gate behaviour changes.

Docs only; no Lean files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y