### PR TITLE
Read homology vanishing off a finite CW model's cell counts

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -196,6 +196,7 @@ public import SphereSixComplex.Topology.PaperCuspCentralFiberCWModel
 public import SphereSixComplex.Topology.CuspToricCellularAlgebra
 public import SphereSixComplex.Topology.CuspToricCellularHomologyBridge
 public import SphereSixComplex.Topology.CellularDimensionVanishing
+public import SphereSixComplex.Topology.FiniteCWModelVanishing
 public import SphereSixComplex.Topology.PaperCuspCentralFiberHomology
 public import SphereSixComplex.Topology.PaperCuspPhaseSpreading
 public import SphereSixComplex.Topology.PaperCuspSpecializationAlgebra

--- a/SphereSixComplex/Topology/FiniteCWModelVanishing.lean
+++ b/SphereSixComplex/Topology/FiniteCWModelVanishing.lean
@@ -1,0 +1,55 @@
+module
+
+public import SphereSixComplex.Topology.CellularDimensionVanishing
+public import SphereSixComplex.Topology.SectionSevenLocalEulerModels
+
+/-!
+# Vanishing from a finite CW model's cell counts
+
+A `FiniteCWModelSix` records a genuine CW structure on a homotopy-equivalent carrier, so a degree
+whose cell count is zero carries no cells at all and hence no homology.  For a `FourTorusCellModel`
+that is degrees five and six, which is exactly what the Section 7 collar obligation asks of a
+four-torus fibre.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace SphereSixComplex
+
+variable {X : Type} [TopologicalSpace X]
+
+/-- A degree with no cells in the chosen finite model carries no integral singular homology. -/
+public theorem FiniteCWModelSix.subsingleton_homology_of_cellCount_eq_zero
+    (M : FiniteCWModelSix X) (n : ℕ) (h : M.cellCount n = 0) :
+    Subsingleton (IntegralSingularHomology n X) := by
+  let _ := M.topology
+  let _ := M.cwComplex
+  let _ := M.finite
+  have hfin : Finite (Topology.CWComplex.cell (Set.univ : Set M.Carrier) n) :=
+    Topology.CWComplex.FiniteType.finite_cell (C := (Set.univ : Set M.Carrier)) n
+  have hempty : IsEmpty (Topology.CWComplex.cell (Set.univ : Set M.Carrier) n) := by
+    rcases Nat.card_eq_zero.mp h with hx | hx
+    · exact hx
+    · exact absurd hx (not_infinite_iff_finite.mpr hfin)
+  have hcarrier : Subsingleton (IntegralSingularHomology n M.Carrier) :=
+    subsingleton_integralSingularHomology_of_isEmpty_cell M.Carrier n
+  exact ⟨fun _ _ => (integralSingularHomologyEquivOfHomotopyEquiv n M.homotopyEquiv).injective
+    (Subsingleton.elim _ _)⟩
+
+/-- A four-torus cell model has no fifth or sixth integral singular homology. -/
+public theorem FourTorusCellModel.subsingleton_homology_five
+    (M : FourTorusCellModel X) : Subsingleton (IntegralSingularHomology 5 X) :=
+  M.toFiniteCWModelSix.subsingleton_homology_of_cellCount_eq_zero 5 M.cellsFive
+
+/-- A four-torus cell model has no sixth integral singular homology. -/
+public theorem FourTorusCellModel.subsingleton_homology_six
+    (M : FourTorusCellModel X) : Subsingleton (IntegralSingularHomology 6 X) :=
+  M.toFiniteCWModelSix.subsingleton_homology_of_cellCount_eq_zero 6 M.cellsSix
+
+end SphereSixComplex
+
+end
+
+end


### PR DESCRIPTION
Builds on the vanishing lemma merged in #113.

`FiniteCWModelSix` already carries everything needed: a genuine `Topology.CWComplex` structure on a
homotopy-equivalent carrier, `Finite`, and `cellCount n = Nat.card (cell n)`. So a degree whose
count is zero has no cells (finiteness rules out the `Infinite` branch of `Nat.card_eq_zero`) and
therefore no homology, transported back along the model's homotopy equivalence:

```lean
theorem FiniteCWModelSix.subsingleton_homology_of_cellCount_eq_zero
    (M : FiniteCWModelSix X) (n : ℕ) (h : M.cellCount n = 0) :
    Subsingleton (IntegralSingularHomology n X)
```

`FourTorusCellModel` has `cellsFive` and `cellsSix` on record, so its fifth and sixth homology
follow immediately. That is exactly the shape the Section 7 collar obligation asks of a four-torus
fibre: with #114, a cusp collar whose fibre carries a `FourTorusCellModel` has no sixth homology,
with no further input.

The one link still missing for the actual cusp collar is geometric, and it is a single field:
`ActualCuspRadialClutchingData` describes its fibre as a four-torus in the docstring but does not
record it, so there is nothing to feed `additiveTorusFourTorusCellModel`. Either a
`FourTorusCellModel Fiber` field on that structure, or a homeomorphism from `Fiber` to an
`AdditiveTorus`, would close it. That is a change to an established boundary, so I have left it
alone.

`#print axioms` on both new statements gives `[propext, Classical.choice, Quot.sound,
integralCWCellularChainModel]` -- no new axioms, no `sorry`. Both gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y