### PR TITLE
Record the cusp clutching fibre as a four-torus

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -296,6 +296,7 @@ public import SphereSixComplex.Topology.PaperActualAffineCoreData
 public import SphereSixComplex.Topology.SectionSevenStageTopDegree
 public import SphereSixComplex.Topology.CuspCollarTopDegreeVanishing
 public import SphereSixComplex.Topology.EllipticCollarTopDegreeVanishing
+public import SphereSixComplex.Topology.PaperCuspCollarFourTorusFibre
 public import SphereSixComplex.Topology.EstablishedChosenAffineFillings
 public import SphereSixComplex.Topology.EstablishedAffineStarBridge
 public import SphereSixComplex.Topology.PaperActualAffineFillingCoverModels

--- a/SphereSixComplex/Topology/PaperCuspCollarFourTorusFibre.lean
+++ b/SphereSixComplex/Topology/PaperCuspCollarFourTorusFibre.lean
@@ -1,0 +1,51 @@
+module
+
+public import SphereSixComplex.Topology.EllipticCollarTopDegreeVanishing
+public import SphereSixComplex.Topology.PaperCuspGeometricSpecialization
+
+/-!
+# The cusp collar's four-torus fibre
+
+The radial clutching data records its fibre as the additive four-torus of a full-rank period
+parameter, so the fibre inherits the standard four-torus cell model and with it the vanishing of
+its fifth and sixth homology.  That is the last hypothesis of the Section 7 top-degree obligation.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace SphereSixComplex.Geometry.PaperAnalyticData
+
+open SphereSixComplex.Geometry.CuspPuncturedCollarBridge
+open SphereSixComplex.Geometry.EllipticFamilySpecialization
+
+variable (A : PaperAnalyticData)
+
+/-- The cusp collar has no sixth integral singular homology. -/
+public theorem subsingleton_homology_six_actualCuspCollar :
+    Subsingleton (IntegralSingularHomology 6 (A.starCollarSourceType 0)) := by
+  let G := A.actualCuspRadialClutchingData
+  let _ := G.fiberTopology
+  have hT : FourTorusCellModel (AdditiveTorus G.fiberParameter) :=
+    EstablishedFiniteCWTopology.additiveTorusFourTorusCellModel _ G.fiberFullRank
+  have h5 : Subsingleton (IntegralSingularHomology 5 G.Fiber) :=
+    OpenEmbeddingStarData.subsingleton_homology_of_homeomorph 5 G.fiberHomeomorph.symm
+      hT.subsingleton_homology_five
+  have h6 : Subsingleton (IntegralSingularHomology 6 G.Fiber) :=
+    OpenEmbeddingStarData.subsingleton_homology_of_homeomorph 6 G.fiberHomeomorph.symm
+      hT.subsingleton_homology_six
+  exact subsingleton_homology_six_of_radialMappingTorus G.clutching
+    A.starCuspWitness.localWitness.radius_pos G.totalHomeomorph h5 h6
+
+/-- The Section 7 top-degree obligation for the actual star, with no hypotheses left. -/
+public theorem sectionSevenStageTopDegreeVanishing_actual :
+    A.openEmbeddingStarData.SectionSevenStageTopDegreeVanishing :=
+  A.sectionSevenStageTopDegreeVanishing_of_actualCuspCollar
+    A.subsingleton_homology_six_actualCuspCollar
+
+end SphereSixComplex.Geometry.PaperAnalyticData
+
+end
+
+end

--- a/SphereSixComplex/Topology/PaperCuspGeometricSpecialization.lean
+++ b/SphereSixComplex/Topology/PaperCuspGeometricSpecialization.lean
@@ -41,6 +41,13 @@ public structure ActualCuspRadialClutchingData
       OpenRadialInterval W.localWitness.radius × CircleMappingTorus clutching
   monodromyCoordinates : let _ := fiberTopology
     CuspMonodromyCoordinates clutching
+  /-- The fibre named in this structure's summary, recorded rather than left implicit: it is the
+  additive four-torus of a full-rank period parameter.  The same three fields appear on
+  `AdditiveFourTorusBundleRealization`, which records the identification for the bundle picture. -/
+  fiberParameter : SphereSixComplex.Periods.Parameters
+  fiberFullRank : SphereSixComplex.Geometry.ComplexTorus.FullRank fiberParameter
+  fiberHomeomorph : let _ := fiberTopology
+    Fiber ≃ₜ SphereSixComplex.Geometry.EllipticFamilySpecialization.AdditiveTorus fiberParameter
 
 namespace EstablishedActualCuspRadialClutching
 


### PR DESCRIPTION
**Stacked on #117, and it widens an established axiom -- flagging that up front so it is an easy
no.** Everything else I have sent avoids touching the boundary; this one does not, and I would
rather propose it concretely than leave the last step described only in prose on #9.

`ActualCuspRadialClutchingData` calls its fibre a four-torus in its own summary ("the identified
`M₀` monodromy coordinates on its four-torus fibre") but records nothing that says so.
`CuspMonodromyCoordinates` pins the fibre's H₀, H₁ and H₂ and stops there, so its fifth and sixth
homology are unreachable and the cusp collar was the one collar left open.

The three fields added are exactly the ones `AdditiveFourTorusBundleRealization` already carries
for the bundle picture:

```lean
  fiberParameter : Periods.Parameters
  fiberFullRank : ComplexTorus.FullRank fiberParameter
  fiberHomeomorph : Fiber ≃ₜ AdditiveTorus fiberParameter
```

With them the fibre inherits `additiveTorusFourTorusCellModel`, so its fifth and sixth homology
vanish, the cusp collar follows from `subsingleton_homology_six_of_radialMappingTorus` (#117), and
the whole obligation closes:

```lean
theorem sectionSevenStageTopDegreeVanishing_actual :
    A.openEmbeddingStarData.SectionSevenStageTopDegreeVanishing
```

no hypotheses. `#print axioms` lists 19 project axioms, all already in the library, and no
`sorryAx`. That is one of the three inputs to `toPaperGluingData_of_positiveDegree` fully
discharged.

**The trade.** This makes the clutching axiom assert more than it did. It is faithful to what the
axiom's own docstring already claims, and it adds no new axiom -- the cell model comes from
`additiveTorusFourTorusCellModel`, which is already assumed. But it is still a wider boundary, and
the honest alternative is to construct the fibre identification geometrically from the punctured
cusp quotient and leave the axiom untouched. If you prefer that, drop this PR and keep #117; the
general lemma there is written to accept the identification from wherever it eventually comes.

Only `EstablishedActualCuspRadialClutching.data` constructs the structure, so nothing else needed
updating. All three dependent modules recompile; both gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y