### PR TITLE
Build the Section 7 local bases from the elliptic interior alone

### DIFF
--- a/SphereSixComplex/Topology/PaperCuspGeometricSpecialization.lean
+++ b/SphereSixComplex/Topology/PaperCuspGeometricSpecialization.lean
@@ -222,6 +222,37 @@ public noncomputable def withActualGeometricCuspBases
   cuspCollarTwo := A.actualCuspSectionSevenHomologyTwoEquiv
   ellipticInteriorTwo := B.ellipticInteriorTwo
 
+/-- Build the local basis package from the elliptic interior alone.
+
+The cusp collar's own degree-one and degree-two bases are already available geometrically, so the
+elliptic interior's are the only ones the package still has to be given.  `withActualGeometricCuspBases`
+says the same thing but needs a package to start from; this one does not. -/
+public noncomputable def sectionSevenCollarInteriorHomologyBasesOfEllipticInterior
+    (ellipticOne : IntegralSingularHomology 1
+        ((A.openEmbeddingStarData.SectionSevenMayerVietorisCover).stage (2 : Fin 4)) ≃+
+      (Fin 1 → ℤ))
+    (ellipticTwo : IntegralSingularHomology 2
+        ((A.openEmbeddingStarData.SectionSevenMayerVietorisCover).stage (2 : Fin 4)) ≃+
+      (Fin 2 → ℤ)) :
+    A.SectionSevenCollarInteriorHomologyBases where
+  cuspCollarOne := A.actualCuspSectionSevenHomologyOneEquiv
+  ellipticInteriorOne := ellipticOne
+  cuspCollarTwo := A.actualCuspSectionSevenHomologyTwoEquiv
+  ellipticInteriorTwo := ellipticTwo
+
+/-- The package built from the elliptic interior already carries the geometric cusp bases. -/
+public theorem withActualGeometricCuspBases_ofEllipticInterior
+    (ellipticOne : IntegralSingularHomology 1
+        ((A.openEmbeddingStarData.SectionSevenMayerVietorisCover).stage (2 : Fin 4)) ≃+
+      (Fin 1 → ℤ))
+    (ellipticTwo : IntegralSingularHomology 2
+        ((A.openEmbeddingStarData.SectionSevenMayerVietorisCover).stage (2 : Fin 4)) ≃+
+      (Fin 2 → ℤ)) :
+    A.withActualGeometricCuspBases
+        (A.sectionSevenCollarInteriorHomologyBasesOfEllipticInterior ellipticOne ellipticTwo) =
+      A.sectionSevenCollarInteriorHomologyBasesOfEllipticInterior ellipticOne ellipticTwo :=
+  rfl
+
 /-- The actual cusp inclusion has the degree-one and degree-two coordinates required by the
 final Section 7 attachment. -/
 public theorem actualCuspFillingInclusionCoordinates


### PR DESCRIPTION
Independent of my other open PRs; based directly on main.

`SectionSevenCollarInteriorHomologyBases` asks for four equivalences, but two of them --
`cuspCollarOne` and `cuspCollarTwo` -- are already available as
`actualCuspSectionSevenHomologyOneEquiv` / `TwoEquiv`. `withActualGeometricCuspBases` already
substitutes them, but it takes a full package as input, so reading the file it looks as though all
four are still outstanding.

This adds the constructor that takes only the two that are:

```lean
def sectionSevenCollarInteriorHomologyBasesOfEllipticInterior
    (ellipticOne : IntegralSingularHomology 1 (…stage (2 : Fin 4)) ≃+ (Fin 1 → ℤ))
    (ellipticTwo : IntegralSingularHomology 2 (…stage (2 : Fin 4)) ≃+ (Fin 2 → ℤ)) :
    A.SectionSevenCollarInteriorHomologyBases
```

plus a `rfl` lemma saying the result is already in geometric-cusp form, so it composes with the
existing `actualCuspFillingInclusionCoordinates` path unchanged.

No new axioms and no proof content -- it is a packaging change that makes the remaining
`SectionSevenPositiveDegreeHomologyAssembly` obligation precise: the elliptic interior's H₁ and H₂
of `stage 2`, and nothing else at this layer. I could not find any existing construction of those
two, so as far as I can tell they are genuinely open; if someone is already on them, this at least
narrows what they have to produce.

Both gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y