### PR TITLE
Update the small-chain excision Blueprint status

### DIFF
--- a/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
+++ b/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
@@ -631,7 +631,7 @@ collapsed basepoint tracked through a reduced-chain isomorphism. The canonical r
 is explicit; proving it is a homology isomorphism is precisely the remaining excision step.
 :::
 
-:::theorem "singular-small-chain-excision" (parent := "disk-boundary-collapse") (lean := "SphereSixComplex.CoverSmallChainRetractionData.approximation, SphereSixComplex.coverSmallIntegralSingularHomologyIso, SphereSixComplex.diskSevenExcisionCover_isOpen, SphereSixComplex.diskSevenExcisionCover_iUnion, SphereSixComplex.diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_comp_inclusion, SphereSixComplex.DiskSevenSmallChainApproximation, SphereSixComplex.simplexSubdivisionLastVertex, SphereSixComplex.subdivisionLastVertex, SphereSixComplex.subdivisionLastVertexLiftChainMap_comp_inclusion, SphereSixComplex.barycentricOuterFaceIdentity, SphereSixComplex.barycentricSubdivisionChainMapCanonical, SphereSixComplex.standardSimplexZeroConeComponent_boundary_succ, SphereSixComplex.canonicalBarycentricLastVertexPrism_boundary, SphereSixComplex.barycentricLastVertexPrismDataCanonical, SphereSixComplex.barycentricSubdivisionLastVertexHomotopyCanonical")
+:::theorem "singular-small-chain-excision" (parent := "disk-boundary-collapse") (lean := "SphereSixComplex.CoverSmallChainRetractionData.approximation, SphereSixComplex.coverSmallIntegralSingularHomologyIso, SphereSixComplex.coverSmallAffineSubdivisionEventuallySmall_of_openCover, SphereSixComplex.coverSmallChainQuasiIsomorphism_of_openCover, SphereSixComplex.coverSmallChainApproximation_of_openCover, SphereSixComplex.coverSmallChainRetractionData_of_openCover, SphereSixComplex.diskSevenExcisionCover_isOpen, SphereSixComplex.diskSevenExcisionCover_iUnion, SphereSixComplex.diskBoundaryToDiskSevenCoverSmallIntegralSingularChains_comp_inclusion, SphereSixComplex.DiskSevenSmallChainApproximation, SphereSixComplex.simplexSubdivisionLastVertex, SphereSixComplex.subdivisionLastVertex, SphereSixComplex.subdivisionLastVertexLiftChainMap_comp_inclusion, SphereSixComplex.barycentricOuterFaceIdentity, SphereSixComplex.barycentricSubdivisionChainMapCanonical, SphereSixComplex.standardSimplexZeroConeComponent_boundary_succ, SphereSixComplex.canonicalBarycentricLastVertexPrism_boundary, SphereSixComplex.barycentricLastVertexPrismDataCanonical, SphereSixComplex.barycentricSubdivisionLastVertexHomotopyCanonical")
 The cover-small singular subcomplex and its monomorphic inclusion into all singular chains are
 explicit. Retraction data yields a chain-homotopy equivalence and homology isomorphisms. For the
 seven-disk, the boundary factors through the small chains for an explicit open two-set cover. The
@@ -639,8 +639,11 @@ global subdivision last-vertex map, induced chain map, and subcomplex lifts are 
 Mathlib's left-Kan-extension API. Signed maximal-flag chains give the canonical natural barycentric
 subdivision chain map. A universal standard-simplex prism boundary identity now produces the actual
 Mathlib chain homotopy from last-vertex-after-subdivision to the identity. The prism is constructed
-recursively by the classical zero-vertex cone contraction in every degree. Only the
-Lebesgue-number subdivision iteration remains for small-chain excision.
+recursively by the classical zero-vertex cone contraction in every degree. Affine mesh and
+Lebesgue-number control now prove eventual smallness for every open cover, hence
+the cover-small inclusion is a quasi-isomorphism and a chain-homotopy equivalence with explicit
+retraction data. The canonical relative-to-reduced comparison for $`(D^7,S^6)` remains a separate
+excision obligation.
 :::
 
 :::theorem "sphere-stereographic-simple-connectivity" (parent := "standard-six-sphere") (lean := "SphereSixComplex.sixSphere_compl_singleton_simplyConnected, SphereSixComplex.sixSphere_simplyConnected_iff_loops_nullhomotopic")


### PR DESCRIPTION
## Summary

- Link the `singular-small-chain-excision` Blueprint node to the four current generic open-cover endpoints.
- Replace the stale statement that Lebesgue-number subdivision iteration remains with the proved eventual-smallness, quasi-isomorphism, chain-homotopy-equivalence, and retraction-data results.
- Keep the canonical relative-to-reduced comparison for `(D^7, S^6)` identified as a separate unresolved excision obligation.

## Scope

This is a one-node Blueprint status correction. It changes no Lean source, imports, README content, Section 7 implementation, dependency pin, or workflow. It does not attempt the optional proof refactors or pre-existing import-layer cleanup noted during review of #112.

## Trust boundary

The source inventory is unchanged on base and head: **39 axioms — 3 in the Final cone, 36 further in the Main cone, 0 in neither**. This documentation-only PR makes no trust-boundary reduction claim.

Base: `17b01e97d509159197d737ae12f5a423979020b9`  
Head: `6393d17d9a8e8e2b3228c467bd99f9cca7cc798e`

## Validation

Local static checks:

- `git diff HEAD^ HEAD --check` — passed.
- `python3 scripts/check-imports.py` — `Import check passed: all 499 modules are reachable from SphereSixComplex.Main.`
- `python3 scripts/check-sorries.py` — `Placeholder check passed: 3 declared placeholder(s), none elsewhere.`
- `python3 scripts/axiom_inventory.py` — `39 axioms: 3 in the Final cone, 36 further in the Main cone, 0 in neither.`
- Exact-name scan — each of the four added Blueprint references resolves to one public declaration, and `SphereSixComplex.Main` imports `SingularExcisionOpenCover`.
- Diff scan — one file, 6 insertions and 3 deletions; no forbidden declaration, placeholder, debug token, dependency, import, or workflow change.
- Independent reject-first review — no actionable findings; recommendation `approve`, including a recheck after rebasing onto the recorded base.

Not run locally:

- `lake build` and `blueprint/scripts/ci-pages.sh` were not run because neither the root nor Blueprint worktree has a provisioned `.lake` cache. Lean and Verso validation are pending PR CI.

## Tracking

Part of #10; follows #43 and #112; relates to #9.
