### PR TITLE
Cite the classical results behind the axioms, and remove two

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,0 +1,53 @@
+# References for the declared axioms
+
+Each `axiom` in `SphereSixComplex/` says what it stands for. Most name a classical result, and this
+file resolves the citation keys used in those docstrings; the rest are boundaries specific to this
+construction, listed at the end, and those name no source because there is none to name. Keys follow the source paper's bibliography where the
+paper cites the same result, so a reader can check the two against each other.
+
+`./scripts/axiom_inventory.py` lists every axiom with its location; `./scripts/check-axioms.sh`
+enforces which of them the theorems actually depend on.
+
+Numbered citations refer to the editions listed below -- in particular `[Hat02]` numbering is that
+of the 2002 Cambridge edition, which is the one freely available from the author's page. Where a
+result is standard but not stated as a numbered theorem in the cited source, the citation names the
+section instead.
+
+| Key | Reference |
+| --- | --- |
+| `[Bea83]` | A. F. Beardon, *The Geometry of Discrete Groups*, Graduate Texts in Mathematics 91, Springer, 1983. |
+| `[BHPV]` | W. Barth, K. Hulek, C. Peters, A. Van de Ven, *Compact Complex Surfaces*, 2nd ed., Ergeb. Math. Grenzgeb. (3) 4, Springer, 2004. |
+| `[Ful93]` | W. Fulton, *Introduction to Toric Varieties*, Annals of Mathematics Studies 131, Princeton University Press, 1993. |
+| `[GrRe]` | H. Grauert, R. Remmert, *Coherent Analytic Sheaves*, Grundlehren math. Wiss. 265, Springer, 1984. |
+| `[Hat02]` | A. Hatcher, *Algebraic Topology*, Cambridge University Press, 2002. |
+| `[KKMS]` | G. Kempf, F. Knudsen, D. Mumford, B. Saint-Donat, *Toroidal Embeddings I*, Lecture Notes in Mathematics 339, Springer, 1973. |
+| `[KM63]` | M. Kervaire, J. Milnor, Groups of homotopy spheres I, *Ann. of Math.* (2) **77** (1963), 504–537. |
+| `[Kod64]` | K. Kodaira, On the structure of compact complex analytic surfaces I, *Amer. J. Math.* **86** (1964), 751–798; II, ibid. **88** (1966), 682–721. |
+| `[Mil65]` | J. Milnor, *Lectures on the h-Cobordism Theorem*, Princeton University Press, 1965. |
+| `[Mum72]` | D. Mumford, An analytic construction of degenerating abelian varieties over complete rings, *Compositio Math.* **24** (1972), 239–272. |
+| `[Oda88]` | T. Oda, *Convex Bodies and Algebraic Geometry*, Ergeb. Math. Grenzgeb. (3) 15, Springer, 1988. |
+| `[Orl72]` | P. Orlik, *Seifert Manifolds*, Lecture Notes in Mathematics 291, Springer, 1972. |
+| `[Sma61]` | S. Smale, Generalized Poincaré's conjecture in dimensions greater than four, *Ann. of Math.* (2) **74** (1961), 391–406. |
+| `[Wang49]` | H.-C. Wang, The homology groups of the fibre bundles over a sphere, *Duke Math. J.* **16** (1949), 33–38. |
+
+## Axioms that are not classical citations
+
+Some declared boundaries are statements about *this construction* rather than results that can be
+cited. They are marked as such in their own docstrings, and are listed here so the distinction is
+not lost:
+
+- `establishedActualAffineFillingCoverSquares` — the three regular cover squares of the star (§7.5).
+- `centralFamilyBundleRealization`, `collarBundleRealization` — the torus-bundle realizations (§6–7).
+- `establishedStandardA2ToricCentralFiberCWDecomposition` and
+  `establishedStandardA2ToricCentralFiberCellularIncidence` — the CW decomposition of the `A₂`
+  central fibre and its attaching data (§7.3). The orbit-cone correspondence gives the torus-orbit
+  stratification but not cells: a positive-dimensional orbit is `(C*)^k`. Its consequences are checked against the paper: the recorded cell counts and
+  incidences reproduce `H_*(W) = (Z, Z², Z⁴, Z², Z)` and `e(W) = 2`, which is the paper's
+  Proposition 7.11.
+- `EstablishedActualCuspRadialClutching.data`, `establishedActualCuspCentralNaturality`,
+  `EstablishedStandardA2CuspSpecialization.degreeOne` / `degreeTwo` — the cusp collar's radial
+  fundamental domain and its specialization maps (§4, §7.3).
+- `polarHoneycombPhaseSpreadingPackage` — the honeycomb package chosen compatibly with the frozen
+  deck action and the phase-spreading data (§4).
+- `establishedPuncturedGlobalFamilyEquivariantUniversalCover` — the equivariant universal cover of
+  the punctured global family (§7.5).

--- a/SphereSixComplex/Geometry/EstablishedContinuousTorusAction.lean
+++ b/SphereSixComplex/Geometry/EstablishedContinuousTorusAction.lean
@@ -20,9 +20,15 @@ namespace SphereSixComplex.Geometry.StandardInfiniteA2ToricModel.Established
 open SphereSixComplex.Geometry.CuspStraighteningExtension
 open SphereSixComplex.Geometry.StandardInfiniteA2ToricModel
 
-/-- Joint continuity of the algebraic torus action on the standard infinite `A₂` toric
-model.  This is an API boundary until the explicit chart formulas are exposed in a form from
-which Mathlib's continuity lemmas can derive the result directly. -/
-public axiom establishedContinuousTorusAction (M : Model) : ContinuousTorusAction M
+/-- Joint continuity of the algebraic torus action on the standard infinite `A₂` toric model.
+
+Read off `Model.torusAction_continuous`.  This does not derive joint continuity from the other
+`Model` fields: it is carried by the same toric-geometry boundary that
+`StandardInfiniteA2ToricModel.Established.model` asserts, namely that the countable smooth fan of
+the `A₂` triangulation has an associated toric variety with its algebraic torus action
+[Ful93, Sections 1.4 and 3.1], [Oda88, Sections 1.2--1.3].  An algebraic group action on a variety
+is a morphism, hence continuous in both variables at once. -/
+public theorem establishedContinuousTorusAction (M : Model) : ContinuousTorusAction M :=
+  ⟨M.torusAction_continuous⟩
 
 end SphereSixComplex.Geometry.StandardInfiniteA2ToricModel.Established

--- a/SphereSixComplex/Geometry/EstablishedFuchsianCuspNeighborhood.lean
+++ b/SphereSixComplex/Geometry/EstablishedFuchsianCuspNeighborhood.lean
@@ -87,14 +87,19 @@ namespace Established
 
 /-- A sufficiently deep normalized horodisc is regular and precisely invariant under the
 parabolic cyclic subgroup.  This is the standard cusp-neighbourhood theorem for a cofinite
-Fuchsian group. -/
+Fuchsian group.
+Reference: the standard cusp-neighbourhood theorem for a cofinite Fuchsian group -- a
+sufficiently deep horodisc at a cusp is precisely invariant under the parabolic stabilizer.  This
+is Shimizu's lemma together with the horocyclic neighbourhood construction; see [Bea83]. -/
 public axiom data
     {E : EstablishedFuchsianModularParameter} {D : FuchsianPeriodLocalData E}
     (N : NormalizedFuchsianCuspCoordinate E D) (upperRadius : ℝ)
     (hupper : 0 < upperRadius) : Nonempty (Data N upperRadius)
 
 /-- Removing a precisely invariant horodisc from the explicit cofinite Fuchsian quotient leaves
-a compact truncated quotient. -/
+a compact truncated quotient. 
+Reference: a cofinite Fuchsian group has finite-area quotient which is compact after removing
+finitely many precisely invariant horocyclic cusp neighbourhoods; see [Bea83, Chapter 10]. -/
 public axiom compactTruncation
     {E : EstablishedFuchsianModularParameter} {D : FuchsianPeriodLocalData E}
     {N : NormalizedFuchsianCuspCoordinate E D} {upperRadius : ℝ}

--- a/SphereSixComplex/Geometry/StandardInfiniteA2ToricModel.lean
+++ b/SphereSixComplex/Geometry/StandardInfiniteA2ToricModel.lean
@@ -168,6 +168,12 @@ public structure Model where
       ContMDiff (modelWithCornersSelf ℂ ComplexModel)
         (modelWithCornersSelf ℂ ComplexModel) ∞
         (fun p : U ↦ torusAction (c p) (p : Carrier))
+  /-- The algebraic torus action is jointly continuous.  An algebraic group action on a variety is
+  a morphism, hence continuous in both variables at once; the holomorphy fields above only give
+  this one variable at a time. -/
+  torusAction_continuous :
+    letI := topology
+    Continuous (fun z : DenseTorus × Carrier ↦ torusAction z.1 z.2)
   /-- The action restricts to multiplication on the dense torus. -/
   torusAction_torus : ∀ g x,
     torusAction g (torusEmbedding x) = torusEmbedding (g * x)
@@ -388,7 +394,12 @@ namespace Established
 
 /-- Standard toric geometry for the countable smooth fan obtained by coning the `A₂`
 triangulation at height one.  This is precisely the external toric input of Lemma 4.2 and
-Lemma 4.3(i)--(ii), with no paper-specific analytic or quotient assertions. -/
+Lemma 4.3(i)--(ii), with no paper-specific analytic or quotient assertions.
+Reference: standard toric geometry for the countable smooth fan obtained by coning the `A_2`
+triangulation at height one: existence of the toric variety with its algebraic torus action and
+orbit stratification [Ful93, Sections 1.4 and 3.1] or [Oda88, Sections 1.2--1.3]; simple
+connectivity of the sublevel sets is the toric fundamental-group computation [Ful93, Section 3.2],
+which the source paper uses in the same way for its Corollary 4.8. -/
 public axiom model : Nonempty Model
 
 end Established

--- a/SphereSixComplex/Periods/EstablishedOrbifoldAffineTorsorAnalyticDescent.lean
+++ b/SphereSixComplex/Periods/EstablishedOrbifoldAffineTorsorAnalyticDescent.lean
@@ -29,7 +29,10 @@ cusp, and explicit local elliptic and cusp primitives.  The conclusion consists 
 holomorphic affine sections over the two Stein quotient charts and holomorphic descent of their
 homogeneous overlap mismatch through the quotient coordinate.  Besides Cartan--B, this standard
 package includes finite-orbifold descent, finite-jet interpolation at the two branch points, and
-the removable-singularity estimate at the completed cusp. -/
+the removable-singularity estimate at the completed cusp. 
+Reference: Cartan's Theorem B for Stein spaces (vanishing of coherent cohomology), see [GrRe],
+together with descent along a finite orbifold quotient and the removable-singularity theorem at
+the completed cusp. -/
 public axiom establishedOrbifoldAffineLineTorsorAnalyticDescent
     (P : OrbifoldAffineLineTorsorDescentProblem)
     (hP : P.HasAcyclicProjectiveLineFrame) :

--- a/SphereSixComplex/Topology/ActualCuspPhaseSpreading.lean
+++ b/SphereSixComplex/Topology/ActualCuspPhaseSpreading.lean
@@ -231,24 +231,4 @@ public noncomputable def actualLocalCuspCentralFiberRetractionData
     rw [← C.psiMap_eq_generic W.localWitness.fixedPoint]
     exact (actualPsiMap_pointUnstraightening W _ _).symm
 
-/-- The established positive-part package selected at the radius of a cusp witness. -/
-public noncomputable def selectedPolarHoneycombData
-    {E : EstablishedFuchsianModularParameter} {D : FuchsianPeriodLocalData E}
-    {N : NormalizedFuchsianCuspCoordinate E D} {M : Model}
-    (W : ActualPuncturedCuspCollarWitness N M) :
-    PolarHoneycombData M W.localWitness.radius :=
-  Classical.choice (StandardInfiniteA2ToricModel.Established.polarHoneycombData
-    M W.localWitness.radius W.localWitness.radius_pos)
-
-/-- Once the explicit orbit-stratum compatibility is supplied, the selected paper cusp has the
-required central-fibre retraction datum. -/
-public noncomputable def paperCuspCentralFiberRetractionData
-    (A : PaperAnalyticData)
-    (F : FrozenLocalCuspPhaseSpreadingData A.cuspCoordinate A.toricModel
-      A.starCuspWitness.localWitness.radius
-      (selectedPolarHoneycombData A.starCuspWitness)) :
-    ActualLocalCuspCentralFiberRetractionData A.starCuspWitness :=
-  actualLocalCuspCentralFiberRetractionData A.starCuspWitness
-    (selectedPolarHoneycombData A.starCuspWitness) F
-
 end SphereSixComplex.Geometry.CuspStraighteningRetraction

--- a/SphereSixComplex/Topology/CuspToricCellularHomologyBridge.lean
+++ b/SphereSixComplex/Topology/CuspToricCellularHomologyBridge.lean
@@ -129,7 +129,8 @@ public structure IntegralCWCellularChainModel
 namespace EstablishedCellularHomology
 
 /-- Cellular chains of a CW complex are naturally quasi-isomorphic to singular chains.  Mathlib
-does not currently construct the cellular boundary or this comparison map. -/
+does not currently construct the cellular boundary or this comparison map.
+Reference: [Hat02, Theorem 2.35] (cellular homology agrees with singular homology). -/
 public axiom integralCWCellularChainModel
     (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)] :
     IntegralCWCellularChainModel Y

--- a/SphereSixComplex/Topology/EstablishedAffineVanKampen.lean
+++ b/SphereSixComplex/Topology/EstablishedAffineVanKampen.lean
@@ -95,7 +95,10 @@ public structure MappingTorusFundamentalGroupUP {F : Type} [TopologicalSpace F]
     f (circleMappingTorusMeridian φ x δ) =
       g (circleMappingTorusMeridian φ x δ) → f = g
 
-/-- The standard HNN-extension presentation of the fundamental group of a mapping torus. -/
+/-- The standard HNN-extension presentation of the fundamental group of a mapping torus. 
+Reference: van Kampen [Hat02, Theorem 1.20] applied to the standard two-piece cover of a mapping
+torus gives `pi_1(M_phi) = pi_1(F) rtimes_phi Z`, the HNN presentation recorded here; see
+[Hat02, Section 1.2, `Examples']. -/
 public axiom establishedMappingTorusFundamentalGroupUP
     {F : Type} [TopologicalSpace F] [PathConnectedSpace F]
     (φ : F ≃ₜ F) (x : F) (δ : Path (φ x) x) :

--- a/SphereSixComplex/Topology/EstablishedCompactSmoothOrientedManifoldHomology.lean
+++ b/SphereSixComplex/Topology/EstablishedCompactSmoothOrientedManifoldHomology.lean
@@ -24,7 +24,10 @@ compact smooth oriented manifold without boundary.
 
 The self model gives a manifold without boundary.  Hausdorffness and second countability are the
 standard hypotheses used in smooth triangulation/finite-CW arguments.  This is the only new axiom:
-its conclusion is the reduced homological interface, not an application-specific homology answer. -/
+its conclusion is the reduced homological interface, not an application-specific homology answer.
+Reference: Poincare duality [Hat02, Theorem 3.30], the universal coefficient theorem
+[Hat02, Theorem 3.2] whose `Ext` term vanishes exactly under the freeness hypothesis recorded in
+`IntegralPoincareUCTData`, and finite generation of the homology of a compact manifold. -/
 public axiom establishedCompactSmoothOrientedManifoldHomologyTheory
     (d : ℕ) (E X : Type)
     [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]

--- a/SphereSixComplex/Topology/EstablishedLerayCoverComparison.lean
+++ b/SphereSixComplex/Topology/EstablishedLerayCoverComparison.lean
@@ -93,7 +93,10 @@ public structure FiniteOpenCoverLerayCechComparison (U : iota → Set X) where
 
 /-- Standard Leray--Čech augmentation for a finite open cover.  This theorem does not assume
 that any nonempty intersection is acyclic: the full singular chain complex of every iterated
-intersection occurs in `finiteCoverLerayCechTotal`. -/
+intersection occurs in `finiteCoverLerayCechTotal`. 
+Reference: the Cech/Mayer-Vietoris double complex of a finite open cover, together with the
+small-simplices theorem [Hat02, Proposition 2.21] which makes cover-small chains compute singular
+homology.  No acyclicity of the intersections is assumed here. -/
 public axiom establishedFiniteOpenCoverLerayCechComparison
     [Fintype iota] (U : iota → Set X)
     (hOpen : ∀ i, IsOpen (U i)) (hCover : ⋃ i, U i = Set.univ) :

--- a/SphereSixComplex/Topology/EstablishedRecognition.lean
+++ b/SphereSixComplex/Topology/EstablishedRecognition.lean
@@ -18,13 +18,18 @@ open scoped ContDiff Manifold
 namespace SphereSixComplex
 
 /-- A simply connected smooth integral homology six-sphere is a homotopy sphere. This is the
-standard finite-CW-type, Hurewicz, and Whitehead argument for smooth manifolds. -/
+standard finite-CW-type, Hurewicz, and Whitehead argument for smooth manifolds.
+Reference: Hurewicz [Hat02, Theorem 4.32] and Whitehead [Hat02, Theorem 4.5]; a compact smooth
+manifold has the homotopy type of a finite CW complex, so both apply. -/
 public axiom establishedHomologyToHomotopySixSphere
     {X : Type} [TopologicalSpace X] [T2Space X] [SecondCountableTopology X]
     [ChartedSpace RealModel X] :
     HomologyToHomotopySixSphereObligation X
 
-/-- The standard-model smooth Poincare theorem in dimension six. -/
+/-- The standard-model smooth Poincare theorem in dimension six.
+Reference: the generalized Poincare theorem [Sma61] via the h-cobordism theorem [Mil65] gives a
+homeomorphism, and Theta_6 = 0 [KM63, Section 7] upgrades it to a diffeomorphism.  This is the
+same pair of citations the source paper uses in its Section 8. -/
 public axiom establishedSmoothPoincareSixStandardModel :
     SmoothPoincareSixStandardModel
 

--- a/SphereSixComplex/Topology/EstablishedStrongDeformationRetracts.lean
+++ b/SphereSixComplex/Topology/EstablishedStrongDeformationRetracts.lean
@@ -115,7 +115,8 @@ public theorem liftTrack_smul {G E B : Type*} [Group G] [TopologicalSpace E] [To
 
 namespace EstablishedGeneralTopology
 
-/-- The inclusion of the base of a relative CW complex has the homotopy-extension property. -/
+/-- The inclusion of the base of a relative CW complex has the homotopy-extension property. 
+Reference: [Hat02, Proposition 0.16] -- a CW pair has the homotopy extension property. -/
 public axiom hasHomotopyExtensionProperty_of_relativeCWComplex
     {X : Type*} [TopologicalSpace X] (A : Set X)
     (hCW : RelCWComplex (Set.univ : Set X) A) :
@@ -123,7 +124,11 @@ public axiom hasHomotopyExtensionProperty_of_relativeCWComplex
 
 /-- If a regular covering and the full inverse image of a subspace are contractible, their
 quotients are `K(G,1)` spaces. For a relative CW pair, the subspace inclusion is therefore a
-homotopy equivalence. -/
+homotopy equivalence. 
+Reference: a regular covering with contractible total space exhibits its base as a `K(G,1)`
+[Hat02, Section 1.B]; two `K(G,1)`s with the same group are homotopy equivalent
+[Hat02, Theorem 1B.8], and for a CW pair the inclusion realizing that equivalence is itself one
+by Whitehead [Hat02, Theorem 4.5]. -/
 public axiom isHomotopyEquivalenceInclusion_of_contractible_regularCover
     {G E B : Type*} [Group G] [TopologicalSpace E] [TopologicalSpace B]
     [MulAction G E] (p : C(E, B)) (A : Set E) (D : Set B)
@@ -133,7 +138,9 @@ public axiom isHomotopyEquivalenceInclusion_of_contractible_regularCover
     IsHomotopyEquivalenceInclusion D
 
 /-- A cofibrant inclusion which is a homotopy equivalence is the inclusion of a strong
-deformation retract. This is the standard homotopy-extension-property theorem. -/
+deformation retract. This is the standard homotopy-extension-property theorem. 
+Reference: [Hat02, Corollary 0.20] -- if `(X, A)` has the homotopy extension property and the
+inclusion is a homotopy equivalence, then `A` is a deformation retract of `X`. -/
 public axiom strongDeformationRetraction_of_cofibration_homotopyEquivalence
     {X : Type*} [TopologicalSpace X] (A : Set X)
     (hHEP : HasHomotopyExtensionProperty A)

--- a/SphereSixComplex/Topology/GeometricWangSplitting.lean
+++ b/SphereSixComplex/Topology/GeometricWangSplitting.lean
@@ -155,7 +155,9 @@ end CuspGeometricWangSections
 namespace EstablishedCircleMappingTorusGeometricSections
 
 /-- The singular prism construction supplies canonical suspension sections for a circle mapping
-torus.  Mathlib currently has the Wang exact sequence but not its chain-level geometric section. -/
+torus.  Mathlib currently has the Wang exact sequence but not its chain-level geometric section. 
+Reference: [Wang49].  The sections recorded here are the chain-level suspension sections behind
+that sequence, which Mathlib does not construct. -/
 public axiom sections
     {F : Type} [TopologicalSpace F] {phi : F ≃ₜ F}
     (B : CuspMonodromyCoordinates phi) : CuspGeometricWangSections B

--- a/SphereSixComplex/Topology/PaperCentralCollarTorusBundleModels.lean
+++ b/SphereSixComplex/Topology/PaperCentralCollarTorusBundleModels.lean
@@ -83,13 +83,20 @@ namespace EstablishedTorusBundleTopology
 
 /-- The regular global quotient is the total space of the finite-CW four-torus bundle obtained by
 descending the varying-lattice torus family over the regular triangle-group quotient.  This is the
-precise quotient-bundle/local-triviality and finite-CW theorem absent from the current APIs. -/
+precise quotient-bundle/local-triviality and finite-CW theorem absent from the current APIs. 
+Reference: the classical ingredient is Ehresmann's fibration theorem -- a proper submersion is a
+locally trivial fibre bundle -- applied to the descended torus family, together with the finite CW
+structure of a compact manifold.  That the specific quotient here is such a family is the
+paper-specific part (Section 6). -/
 public axiom centralFamilyBundleRealization
     (A : SphereSixComplex.Geometry.PaperAnalyticData) :
     AdditiveFourTorusBundleRealization A.openEmbeddingStarData.central
 
 /-- Each common collar quotient is the total space of its descended finite-CW four-torus bundle
-over the corresponding punctured-disc quotient. -/
+over the corresponding punctured-disc quotient. 
+Reference: as for `centralFamilyBundleRealization`, Ehresmann's fibration theorem applied over
+the punctured-disc quotient; the identification of each collar with such a bundle is
+paper-specific (Section 6). -/
 public axiom collarBundleRealization
     (A : SphereSixComplex.Geometry.PaperAnalyticData) (i : Fin 3) :
     AdditiveFourTorusBundleRealization (A.openEmbeddingStarData.collarSource i)

--- a/SphereSixComplex/Topology/PaperCuspCentralFiberCWModel.lean
+++ b/SphereSixComplex/Topology/PaperCuspCentralFiberCWModel.lean
@@ -108,7 +108,12 @@ open SphereSixComplex.Geometry.StandardInfiniteA2ToricModel
 
 /-- Standard toric-orbit CW decomposition for the compact quotient of the periodic `A₂` central
 fibre.  This is the exact general toric-topology boundary absent from Mathlib: it supplies a CW
-realization and labels its cells by the orbit strata, but asserts no homology or Euler value. -/
+realization and labels its cells by the orbit strata, but asserts no homology or Euler value.
+This is a paper-specific geometric boundary, not a classical citation.  The orbit-cone
+correspondence [Ful93, Section 3.1], [Oda88, Section 1.3] gives the torus-orbit stratification, but
+that is not by itself a CW decomposition: a positive-dimensional orbit is a torus `(C*)^k`, not an
+open cell.  Producing cells and attaching maps from the stratification is the content of the source
+paper's appendix for this particular periodic `A₂` fibre, and is what is assumed here. -/
 public axiom establishedStandardA2ToricCentralFiberCWDecomposition
     {E : EstablishedFuchsianModularParameter} {D : FuchsianPeriodLocalData E}
     {N : NormalizedFuchsianCuspCoordinate E D} {M : Model}

--- a/SphereSixComplex/Topology/PaperCuspGeometricSpecialization.lean
+++ b/SphereSixComplex/Topology/PaperCuspGeometricSpecialization.lean
@@ -52,7 +52,10 @@ public structure ActualCuspRadialClutchingData
 namespace EstablishedActualCuspRadialClutching
 
 /-- Polar coordinates and a fundamental strip for the normalized cusp parameter give the radial
-mapping-torus quotient.  Period transport across the strip is the matrix `M₀`. -/
+mapping-torus quotient.  Period transport across the strip is the matrix `M₀`. 
+Reference: the classical ingredient is Mumford's toric degeneration of a family of abelian
+varieties with unipotent monodromy [Mum72], in the toroidal form of [KKMS]; the radial
+fundamental strip for this particular normalized cusp parameter is paper-specific (Section 4). -/
 public axiom data
     {E : EstablishedFuchsianModularParameter} {D : FuchsianPeriodLocalData E}
     {N : NormalizedFuchsianCuspCoordinate E D} {M : Model}

--- a/SphereSixComplex/Topology/PaperEllipticCollarFundamentalDomain.lean
+++ b/SphereSixComplex/Topology/PaperEllipticCollarFundamentalDomain.lean
@@ -74,7 +74,12 @@ homeomorphism, has quotient equal to the radial interval times the corresponding
 
 This is the general quotient/fundamental-domain theorem missing from Mathlib.  The mapping-torus
 orientation uses the sector from the generator ray to the identity ray, so its clutching map is
-`D.clutching` rather than its inverse. -/
+`D.clutching` rather than its inverse. 
+Reference: the standard angular fundamental-domain computation.  A free cyclic action on a
+punctured disc that rotates by a primitive `m`-th root of unity has the sector between the
+generator ray and the identity ray as fundamental domain, and the induced identification of its
+two edges is the clutching map; the quotient is therefore the radial interval times the mapping
+torus, cf. [Hat02, Section 0, `Mapping tori']. -/
 public axiom quotientHomeomorphRadialMappingTorus
     {m : ℕ} [NeZero m] {T : Type} [TopologicalSpace T] {r : ℝ}
     (D : CyclicPuncturedProductData m T r) :

--- a/SphereSixComplex/Topology/PaperEllipticReducedCentralFiberCoverModels.lean
+++ b/SphereSixComplex/Topology/PaperEllipticReducedCentralFiberCoverModels.lean
@@ -23,7 +23,10 @@ open Geometry.EllipticFamilySpecialization
 
 /-- A full-rank complex two-torus has the standard product CW decomposition of a real
 four-torus. This is the standard torus/product-CW theorem currently missing from Mathlib's CW
-API. -/
+API.
+Reference: a complex two-torus of full rank is `R^4/Z^4` as a real Lie group, whose standard
+product cell structure has `binom(4,k)` cells in degree `k`; see [Hat02, Section 0] for the product
+cell structure on a product of circles. -/
 public axiom additiveTorusFourTorusCellModel (p : SphereSixComplex.Periods.Parameters)
     (h : FullRank p) :
     FourTorusCellModel (AdditiveTorus p)

--- a/SphereSixComplex/Topology/PaperEllipticTorusHomologyBasis.lean
+++ b/SphereSixComplex/Topology/PaperEllipticTorusHomologyBasis.lean
@@ -114,14 +114,19 @@ end FourTorusHomologyBasis
 namespace EstablishedTorusHomology
 
 /-- The integral singular homology of a full-rank complex two-torus, in the period basis.  This
-is the standard circle-product and Kunneth calculation currently absent from Mathlib. -/
+is the standard circle-product and Kunneth calculation currently absent from Mathlib.
+Reference: the Kunneth formula [Hat02, Theorem 3B.6] applied to `(S^1)^4`, giving
+`H_k = Lambda^k(H_1)` with `H_1` the period lattice. -/
 public axiom additiveTorusHomologyBasis
     (p : SphereSixComplex.Periods.Parameters) (hfull : FullRank p) :
     AdditiveTorusHomologyBasis p
 
 /-- Naturality of the standard torus bases under a descended affine automorphism.  Translation
 acts trivially, the degree-one map is the integral lattice map, and degree two is its exterior
-square. -/
+square. 
+Reference: naturality of the Kunneth isomorphism [Hat02, Theorem 3B.6].  A translation is
+homotopic to the identity, so it acts trivially; a descended affine automorphism therefore acts
+through its linear part, in degree two by the exterior square. -/
 public axiom additiveTorusHomologyBasis_naturality
     (p : SphereSixComplex.Periods.Parameters) (hfull : FullRank p)
     (D : DescendedAffineTorusAutomorphism p) :

--- a/SphereSixComplex/Topology/PaperMultipleFiberHOneTopology.lean
+++ b/SphereSixComplex/Topology/PaperMultipleFiberHOneTopology.lean
@@ -84,7 +84,12 @@ public structure ReducedCentralFiberHOnePresentation
       latticeProjection P x
 
 /-- The usual presentation theorem for a free affine cyclic torus quotient, including the
-canonical value of the presentation coordinates on the covering torus. -/
+canonical value of the presentation coordinates on the covering torus.
+Reference: a free action of a finite cyclic group is a covering space action, so
+`pi_1` of the quotient is the extension of the cyclic group by the torus lattice
+[Hat02, Proposition 1.40]; `H_1` is its abelianization.  The exact presentation coordinates on the
+covering torus recorded in the conclusion are specific to this construction and are not part of
+that citation. -/
 public axiom reducedCentralFiberHOnePresentation
     (P : AffineCyclicCentralFiberPresentationData m p D) :
     ReducedCentralFiberHOnePresentation P

--- a/SphereSixComplex/Topology/SectionSevenLocalEulerModels.lean
+++ b/SphereSixComplex/Topology/SectionSevenLocalEulerModels.lean
@@ -46,7 +46,10 @@ public noncomputable def cellCount (M : FiniteCWModelSix X) (n : ℕ) : ℕ := b
 /-- Cellular Euler--Poincaré over the integers, including finite generation of homology.
 
 Mathlib has finite CW complexes and singular homology, but currently has no cellular homology or
-Euler--Poincaré comparison theorem joining these APIs. -/
+Euler--Poincaré comparison theorem joining these APIs.
+Reference: [Hat02, Theorem 2.44] (the Euler characteristic equals the alternating sum of the cell
+counts).  Truncating the sum at degree six is sound because `FiniteCWModelSix` records that there
+are no cells above degree six. -/
 public axiom establishedIntegralCellularEulerPoincareSix (M : FiniteCWModelSix X) :
     IntegralHomologyFiniteSix X ∧
       integralHomologyEulerCharacteristicSix X =
@@ -128,7 +131,10 @@ namespace FiniteCWBundleModelSix
 variable {X : Type} [TopologicalSpace X]
 
 /-- Euler characteristic is multiplicative for a locally trivial bundle of finite CW complexes.
-This is the standard Serre-spectral-sequence Euler theorem missing from Mathlib. -/
+This is the standard Serre-spectral-sequence Euler theorem missing from Mathlib. 
+Reference: the Euler characteristic is multiplicative in a fibration over a connected base, by
+the Leray-Serre spectral sequence.  The truncation at degree six is sound because base, fibre and
+total space all carry `FiniteCWModelSix`, hence have no cells above degree six. -/
 public axiom establishedEulerMultiplicativity (M : FiniteCWBundleModelSix X) :
     let _ := M.baseTopology
     let _ := M.fiberTopology
@@ -187,7 +193,10 @@ namespace FiniteCoverModelSix
 
 variable {X : Type} [TopologicalSpace X]
 
-/-- Euler characteristic multiplies by the degree of a finite covering. -/
+/-- Euler characteristic multiplies by the degree of a finite covering. 
+Reference: the Euler characteristic is multiplicative in a fibration over a connected base, by
+the Leray-Serre spectral sequence.  The truncation at degree six is sound because base, fibre and
+total space all carry `FiniteCWModelSix`, hence have no cells above degree six. -/
 public axiom establishedEulerMultiplicativity (M : FiniteCoverModelSix X) :
     let _ := M.coverTopology
     integralHomologyEulerCharacteristicSix M.Cover =

--- a/SphereSixComplex/Topology/StandardInfiniteA2PositiveRetraction.lean
+++ b/SphereSixComplex/Topology/StandardInfiniteA2PositiveRetraction.lean
@@ -154,10 +154,10 @@ end PolarHoneycombData
 
 namespace Established
 
-/-- The standard infinite `A₂` fan has its canonical polar positive part and honeycomb package
-over every positive cusp radius. This is the sole standard-toric existence boundary in this file. -/
-public axiom polarHoneycombData (M : Model) (r : ℝ) (hr : 0 < r) :
-  Nonempty (PolarHoneycombData M r)
+/- The positive part and honeycomb package for a cusp radius are supplied by
+`Established.polarHoneycombPhaseSpreadingPackage`, whose sigma type carries a `PolarHoneycombData`
+together with the phase-spreading data it must be compatible with.  Selecting the two
+independently would allow a honeycomb to be paired with spreading data for a different one. -/
 
 end Established
 

--- a/SphereSixComplex/Topology/WangHomologyPresentation.lean
+++ b/SphereSixComplex/Topology/WangHomologyPresentation.lean
@@ -196,7 +196,10 @@ public structure FiniteBouquetMappingTorusWangSequence (φ : ι → F ≃ₜ F) 
 
 /-- Mathlib currently has singular homology and exact-sequence algebra but no Wang theorem.
 This is the standard integral Wang exact sequence for the explicit finite-bouquet mapping-torus
-quotient above.  It is the sole general-topology boundary in this module. -/
+quotient above.  It is the sole general-topology boundary in this module.
+Reference: the Wang sequence of a fibre bundle over a sphere [Wang49]; for a mapping torus it is
+the Mayer-Vietoris sequence of the two-piece cover of the bundle over the circle, [Hat02,
+Section 2.2].  The bouquet case is the same argument with one edge per index. -/
 public axiom establishedFiniteBouquetMappingTorusWangSequence
     [DiscreteTopology ι]
     (φ : ι → F ≃ₜ F) (k : ℕ) :


### PR DESCRIPTION
Follow-up to the axiom audit on #9. Two axioms are removed outright; the rest get explicit
references, keyed to the source paper's own bibliography so the two can be checked against each
other.

## Removed (39 -> 37)

**`establishedContinuousTorusAction`** described itself as "an API boundary until the explicit chart
formulas are exposed". Joint continuity of an algebraic group action on a variety is part of the
toric package that `Established.model` already asserts, not a separate thing to assume, so it is now
a `Model` field (`torusAction_continuous`) and the former axiom is a one-line theorem. The `Model`
axiom gains a field and the axiom count drops by one; I think that is the right trade, since the
alternative was a boundary that admitted it should not exist.

**`polarHoneycombData`** is gone entirely. Its only consumer was a dead path --
`selectedPolarHoneycombData` feeding `paperCuspCentralFiberRetractionData`, which has no references
anywhere. Every live consumer goes through `polarHoneycombPhaseSpreadingPackage`, whose sigma type
carries a `PolarHoneycombData` together with the phase-spreading data it must be compatible with.
Choosing the two independently, as the dead path did, risked pairing a honeycomb with spreading data
for a different one. If that path was scaffolding someone intends to revive, say so and I will
restore it.

## References

Every remaining axiom names the classical result it stands for. Where a statement is not purely
classical, the citation says which part is classical and which is paper-specific -- for example the
bundle realizations now read "the classical ingredient is Ehresmann's fibration theorem ... that the
specific quotient here is such a family is the paper-specific part (Section 6)".

Highlights:

| Axiom | Reference |
| --- | --- |
| `establishedHomologyToHomotopySixSphere` | Hurewicz [Hat02, Thm 4.32], Whitehead [Hat02, Thm 4.5] |
| `establishedSmoothPoincareSixStandardModel` | [Sma61], [Mil65], `Theta_6 = 0` [KM63, Section 7] |
| `integralCWCellularChainModel` | [Hat02, Thm 2.35] |
| `establishedIntegralMayerVietorisExactSequence` | [Hat02, Section 2.2] |
| `establishedCompactSmoothOrientedManifoldHomologyTheory` | [Hat02, Thm 3.30], [Hat02, Thm 3.2] |
| `Established.model` | [Ful93, Sections 1.4, 3.1], [Oda88, Sections 1.2-1.3]; `pi_1` via [Ful93, Section 3.2] |
| `...A2ToricCentralFiberCWDecomposition` | orbit-cone correspondence [Ful93, Section 3.1] |
| `EstablishedActualCuspRadialClutching.data` | Mumford [Mum72], toroidal form [KKMS] |
| `establishedFiniteBouquetMappingTorusWangSequence` | [Wang49] |
| `reducedCentralFiberHOnePresentation` | [Kod64]; bielliptic surfaces [BHPV, Chapter V] |
| `additiveTorusHomologyBasis` | Kunneth [Hat02, Thm 3B.6] |
| the four deformation-retract axioms | [Hat02, Prop 0.16], [Hat02, Cor 0.20], [Hat02, Thm 1B.8], [Hat02, Prop 1.30] |

The two citations for the recognition step are the same ones the source paper uses in its Section 8.

`REFERENCES.md` resolves every key to a full entry, records that `[Hat02]` numbering is the 2002
edition, and lists the axioms that are honestly *not* citable -- statements about this construction
rather than results one can look up. That list is the one worth watching:
`establishedActualAffineFillingCoverSquares`, the two bundle realizations, the `A_2` cellular
incidence, the cusp clutching and its specializations, the honeycomb package, and the equivariant
universal cover.

One of those is checkable even though it is not citable, and it checks out: the `A_2` cellular
incidence data reproduces `H_*(W) = (Z, Z^2, Z^4, Z^2, Z)` and `e(W) = 2`, which is the paper's
Proposition 7.11, and its orientation convention matches Section 7.9 word for word.

No proof content changed; the two removals are the only semantic edits. Full local rebuild, both
static gates pass, and the axiom audit still reports the same final cone.