### PR TITLE
Prove the equivariant deformation-retract lift

### DIFF
--- a/SphereSixComplex/Topology/EstablishedStrongDeformationRetracts.lean
+++ b/SphereSixComplex/Topology/EstablishedStrongDeformationRetracts.lean
@@ -17,7 +17,7 @@ full homotopy-extension and quotient-covering data used below.
 
 noncomputable section
 
-open Set Topology
+open Set Topology unitInterval
 open scoped ContinuousMap
 
 namespace SphereSixComplex
@@ -45,6 +45,73 @@ public structure StrongDeformationRetraction (X : Type*) [TopologicalSpace X] (A
   retract_mem : ∀ x, retract x ∈ A
   retract_fixed : ∀ x, x ∈ A → retract x = x
   homotopy_fixed : ∀ s x, x ∈ A → homotopy (s, x) = x
+
+/-- The track through `e` of a base homotopy, lifted through a covering. -/
+public noncomputable def liftTrack {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+    {p : C(E, B)} (cov : IsCoveringMap p) {D : Set B}
+    (R : StrongDeformationRetraction B D) (e : E) : C(I, E) :=
+  cov.liftPath ⟨fun s => R.homotopy (s, p e), by fun_prop⟩ e (by simp)
+
+public theorem liftTrack_lifts {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+    {p : C(E, B)} (cov : IsCoveringMap p) {D : Set B}
+    (R : StrongDeformationRetraction B D) (e : E) (s : I) :
+    p (liftTrack cov R e s) = R.homotopy (s, p e) :=
+  congrFun (cov.liftPath_lifts ⟨fun s => R.homotopy (s, p e), by fun_prop⟩ e (by simp)) s
+
+public theorem liftTrack_zero {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+    {p : C(E, B)} (cov : IsCoveringMap p) {D : Set B}
+    (R : StrongDeformationRetraction B D) (e : E) : liftTrack cov R e 0 = e :=
+  cov.liftPath_zero _ e (by simp)
+
+/-- The lifted homotopy is jointly continuous.  Continuity in each variable separately is what
+`liftPath` provides; `IsLocalHomeomorph.continuous_lift` upgrades it. -/
+public theorem continuous_liftTrack {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+    {p : C(E, B)} (cov : IsCoveringMap p) {D : Set B}
+    (R : StrongDeformationRetraction B D) :
+    Continuous (fun z : I × E => liftTrack cov R z.2 z.1) :=
+  @IsLocalHomeomorph.continuous_lift E B E _ _ _ (⇑p) cov.isLocalHomeomorph cov.isSeparatedMap
+    ⟨fun z : I × E => R.homotopy (z.1, p z.2), by fun_prop⟩
+    (fun z => liftTrack cov R z.2 z.1)
+    (by funext z; exact liftTrack_lifts cov R z.2 z.1)
+    (by simpa only [liftTrack_zero] using continuous_id')
+    (fun e => (liftTrack cov R e).continuous)
+
+/-- A deck transformation does not change the image under the covering. -/
+public theorem apply_smul_eq {G E B : Type*} [Group G] [TopologicalSpace E] [TopologicalSpace B]
+    [MulAction G E] {p : C(E, B)} (hp : IsQuotientCoveringMap p G) (g : G) (e : E) :
+    p (g • e) = p e :=
+  hp.apply_eq_iff_mem_orbit.mpr ⟨g, rfl⟩
+
+/-- Uniqueness of lifts: anything continuous that lifts the same track and starts at `e` is the
+lifted track. -/
+public theorem liftTrack_eq {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+    {p : C(E, B)} (cov : IsCoveringMap p) {D : Set B}
+    (R : StrongDeformationRetraction B D) (e : E) (F : I → E)
+    (hcont : Continuous F) (hlift : ∀ s, p (F s) = R.homotopy (s, p e)) (h0 : F 0 = e) :
+    ∀ s, F s = liftTrack cov R e s := by
+  have hg0 : (⟨fun s => R.homotopy (s, p e), by fun_prop⟩ : C(I, B)) 0 = p e := by simp
+  have h := (cov.eq_liftPath_iff hg0 (Γ := F)).mpr ⟨hcont, funext hlift, h0⟩
+  exact fun s => congrFun h s
+
+/-- Over the base retract the track is constant, so its lift is too. -/
+public theorem liftTrack_fixed {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+    {p : C(E, B)} (cov : IsCoveringMap p) {D : Set B}
+    (R : StrongDeformationRetraction B D) {e : E} (he : p e ∈ D) (s : I) :
+    liftTrack cov R e s = e :=
+  (liftTrack_eq cov R e (fun _ => e) continuous_const
+    (fun s => (R.homotopy_fixed s (p e) he).symm) rfl s).symm
+
+/-- The lifted track is equivariant, again by uniqueness of lifts. -/
+public theorem liftTrack_smul {G E B : Type*} [Group G] [TopologicalSpace E] [TopologicalSpace B]
+    [MulAction G E] {p : C(E, B)} (hp : IsQuotientCoveringMap p G) {D : Set B}
+    (R : StrongDeformationRetraction B D) (g : G) (e : E) (s : I) :
+    liftTrack hp.isCoveringMap R (g • e) s = g • liftTrack hp.isCoveringMap R e s := by
+  let _ := hp.toContinuousConstSMul
+  refine (liftTrack_eq hp.isCoveringMap R (g • e) (fun s => g • liftTrack hp.isCoveringMap R e s)
+    ((continuous_const_smul g).comp (liftTrack hp.isCoveringMap R e).continuous) ?_ ?_ s).symm
+  · intro s
+    rw [apply_smul_eq hp, liftTrack_lifts, apply_smul_eq hp]
+  · rw [liftTrack_zero]
 
 namespace EstablishedGeneralTopology
 
@@ -75,13 +142,38 @@ public axiom strongDeformationRetraction_of_cofibration_homotopyEquivalence
 
 /-- A strong deformation retraction lifts uniquely through a regular quotient covering. The
 lift is equivariant under the deck group and retracts onto the full inverse image of the base
-retract. -/
-public axiom equivariantStrongDeformationRetraction_lift
+retract.
+
+Proved from Mathlib's covering-space lifting API: each track is lifted by
+`IsCoveringMap.liftPath`, joint continuity comes from `IsLocalHomeomorph.continuous_lift`, and both
+the fixing on the preimage and the equivariance are uniqueness-of-lift arguments
+(`IsCoveringMap.eq_liftPath_iff`). -/
+public theorem equivariantStrongDeformationRetraction_lift
     {G E B : Type*} [Group G] [TopologicalSpace E] [TopologicalSpace B]
     [MulAction G E] (p : C(E, B)) (A : Set E) (D : Set B)
     (hp : IsQuotientCoveringMap p G) (hpreimage : p ⁻¹' D = A)
     (R : StrongDeformationRetraction B D) :
-    Nonempty (EquivariantStrongDeformationRetraction G E A)
+    Nonempty (EquivariantStrongDeformationRetraction G E A) := by
+  let _ := hp.toContinuousConstSMul
+  have hmemA : ∀ {x : E}, x ∈ A → p x ∈ D := fun {x} hx =>
+    Set.mem_preimage.mp (by rw [hpreimage]; exact hx)
+  exact ⟨{
+    retract :=
+      ⟨fun e => liftTrack hp.isCoveringMap R e 1,
+        (continuous_liftTrack hp.isCoveringMap R).comp (continuous_const.prodMk continuous_id)⟩
+    homotopy :=
+      { toFun := fun z => liftTrack hp.isCoveringMap R z.2 z.1
+        continuous_toFun := continuous_liftTrack hp.isCoveringMap R
+        map_zero_left := fun e => liftTrack_zero hp.isCoveringMap R e
+        map_one_left := fun _ => rfl }
+    retract_mem := fun x => by
+      have hD : p (liftTrack hp.isCoveringMap R x 1) ∈ D := by
+        rw [liftTrack_lifts]; simpa using R.retract_mem (p x)
+      rw [← hpreimage]; exact Set.mem_preimage.mpr hD
+    retract_fixed := fun x hx => liftTrack_fixed hp.isCoveringMap R (hmemA hx) 1
+    homotopy_fixed := fun s x hx => liftTrack_fixed hp.isCoveringMap R (hmemA hx) s
+    retract_equivariant := fun g x => liftTrack_smul hp R g x 1
+    homotopy_equivariant := fun g s x => liftTrack_smul hp R g x s }⟩
 
 end EstablishedGeneralTopology
 


### PR DESCRIPTION
Closes #124. Independent of #123; based on main.

While checking the "missing from Mathlib" claims for #123 I found that this one does not hold.
`equivariantStrongDeformationRetraction_lift` was assumed, but `Mathlib/Topology/Homotopy/Lifting.lean`
already has everything it needs. It is now proved.

## How

- Each track `s ↦ R.homotopy (s, p e)` is lifted through the covering by `IsCoveringMap.liftPath`,
  giving `liftTrack cov R e : C(I, E)` with `liftTrack_lifts` and `liftTrack_zero`.
- Joint continuity is `IsLocalHomeomorph.continuous_lift`, whose two side conditions are exactly
  continuity at time zero (the identity, by `liftTrack_zero`) and continuity along each track
  (immediate, since `liftPath` is bundled). A covering map is a separated map, which is its
  remaining hypothesis.
- Over the base retract the track is constant, so `liftTrack_fixed` follows from uniqueness of
  lifts (`IsCoveringMap.eq_liftPath_iff`) against the constant lift.
- Equivariance is the same uniqueness argument: `(s, e) ↦ g⁻¹ • H(s, g • e)` lifts the same track --
  deck transformations satisfy `p (g • e) = p e`, which is `IsQuotientCoveringMap.apply_eq_iff_mem_orbit` --
  and agrees at time zero, hence equals it.

The statement, name and namespace are unchanged, so no consumer moves.

## Result

```
#print axioms SphereSixComplex.EstablishedGeneralTopology.equivariantStrongDeformationRetraction_lift
-- [propext, Classical.choice, Quot.sound]
```

No project axioms. Full local rebuild (143 modules, 0 failures), all three gates pass, and the
final cone is unchanged.

## Note on the neighbouring axioms

The other three in this file do *not* have the same escape: Mathlib has no
`HomotopyExtensionProperty`, and its `Cofibration` is the abstract model-category notion rather than
the topological one, so `hasHomotopyExtensionProperty_of_relativeCWComplex` and
`strongDeformationRetraction_of_cofibration_homotopyEquivalence` stay assumed. I checked before
attempting this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y