### PR TITLE
Document elliptic finite-cover homology realization

### DIFF
--- a/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
+++ b/blueprint/SphereSixComplexBlueprint/Chapters/Construction.lean
@@ -519,10 +519,16 @@ through four. The exact external boundaries are the standard cellular-to-singula
 the chosen standard $`A_2` CW decomposition with its incidence formula.
 :::
 
-:::theorem "elliptic-multiple-fibre-homology" (parent := "section-seven-paper-assembly") (lean := "SphereSixComplex.Topology.PaperMultipleFiberHOneTopology.EstablishedAffineCyclicQuotientHomology.reducedCentralFiberHOneEquivPresentation, SphereSixComplex.Topology.PaperMultipleFiberHOneTopology.orderThreeReducedCentralFiberHOneEquivIntSquared, SphereSixComplex.Topology.PaperMultipleFiberHOneTopology.orderFourReducedCentralFiberHOneEquivIntSquared")
-The order-three and order-four reduced central fibres have the explicit first-homology
-presentations used in Section 7. Their reduction to $`\mathbb Z^2` is proved; the exact external
-boundary is the general affine cyclic-quotient abelianization theorem.
+:::theorem "elliptic-multiple-fibre-homology" (parent := "section-seven-paper-assembly") (lean := "SphereSixComplex.Topology.PaperMultipleFiberHOneTopology.EstablishedAffineCyclicQuotientHomology.reducedCentralFiberHOneEquivPresentation, SphereSixComplex.Topology.PaperMultipleFiberHOneTopology.orderThreeReducedCentralFiberHOneEquivIntSquared, SphereSixComplex.Topology.PaperMultipleFiberHOneTopology.orderFourReducedCentralFiberHOneEquivIntSquared, SphereSixComplex.Topology.FiniteCoverPerfectPairing.orderThreeFixedHOneBasis_projection, SphereSixComplex.Topology.FiniteCoverPerfectPairing.orderFourFixedHOneBasis_projection, SphereSixComplex.Topology.FiniteCoverPerfectPairing.orderThreeHOneNaturality, SphereSixComplex.Topology.FiniteCoverPerfectPairing.orderFourHOneNaturality, SphereSixComplex.Topology.FiniteCoverPerfectPairing.DegreeTwoPullbackRealization.toFiniteCoverDegreeTwoPullbackBasis, SphereSixComplex.Topology.FiniteCoverPerfectPairing.EllipticDegreeTwoPullbackBases.ofRealizations, SphereSixComplex.Topology.FiniteCoverPerfectPairing.establishedEllipticDegreeTwoPullbackRealizations, SphereSixComplex.Topology.FiniteCoverPerfectPairing.ellipticDegreeTwoPullbackBases, SphereSixComplex.Topology.FiniteCoverPerfectPairing.ellipticFiniteCoverHomologyRealization")
+The order-three and order-four reduced central fibres have explicit first-homology presentations,
+and the fixed bases satisfy the required covering-projection coordinate formulas. These degree-one
+naturality results require no additional realization parameter, while retaining the established
+general affine cyclic-quotient abelianization theorem as their external boundary.
+
+In degree two, explicit quotient-homology realizations are converted to perfect-pairing packages;
+together these give the full `ellipticFiniteCoverHomologyRealization` for the two covers. The exact
+external boundary is `establishedEllipticDegreeTwoPullbackRealizations`, which records the
+Proposition 7.14 calculation for the actual covers.
 :::
 
 :::theorem "section-seven-chain-model" (parent := "integral-homology") (lean := "SphereSixComplex.sectionSevenFirstBoundaryMatrix_det, SphereSixComplex.sectionSevenDegreeOneCellularComplex_homology_one_isZero, SphereSixComplex.sectionSevenDegreeOneCellularComplex_homology_two_isZero, SphereSixComplex.integralSingularHomology_one_subsingleton_of_sectionSevenCellularComparison")


### PR DESCRIPTION
## Summary

Synchronize the existing `elliptic-multiple-fibre-homology` Blueprint node
with the degree-one and degree-two realization API now on `main`.

## Implementation

- Reference the two fixed-basis projection formulas and the resulting
  order-three/order-four H1 naturality theorems.
- Reference the conversion from explicit degree-two quotient-homology
  realizations to perfect-pairing packages and the resulting full
  `ellipticFiniteCoverHomologyRealization`.
- Keep the trust boundary explicit:
  `establishedEllipticDegreeTwoPullbackRealizations` records the Proposition
  7.14 calculation for the actual covers, while the degree-one calculation
  still rests on the established affine cyclic-quotient presentation.

## Trust-boundary delta

Documentation only. No Lean declaration, import, dependency, placeholder, or
allowlist changes. The current baseline remains 40 project axioms: 3 reachable
from `Final`, 37 further reachable from `Main`, and 0 in neither cone.

## Scope / non-goals

One existing Blueprint node in one file. This does not prove Proposition 7.14,
change Section 7 assembly data, or claim any issue complete.

## Validation

Local static checks:

- `git diff --check` — passed
- `python3 scripts/axiom_inventory.py` — 40 axioms: 3 Final, 37 further Main,
  0 neither
- `python3 scripts/check-imports.py` — 501/501 modules reachable
- `python3 scripts/check-sorries.py` — 3 declared placeholders, none elsewhere
- every newly cited declaration was located at its current definition

The worktree has no provisioned root or Blueprint `.lake` cache, so the
Blueprint build was not run locally and is pending PR CI.
