### PR TITLE
Derive homological finiteness from the cellular chain model

### DIFF
--- a/SphereSixComplex/Main.lean
+++ b/SphereSixComplex/Main.lean
@@ -165,6 +165,7 @@ public import SphereSixComplex.Topology.HomologySphere
 public import SphereSixComplex.Topology.HurewiczWhitehead
 public import SphereSixComplex.Topology.HurewiczWhiteheadStages
 public import SphereSixComplex.Topology.MayerVietoris
+public import SphereSixComplex.Topology.CellularChainModel
 public import SphereSixComplex.Topology.MayerVietorisDegreeZeroBridge
 public import SphereSixComplex.Topology.ConnectedMayerVietorisDegreeZero
 public import SphereSixComplex.Topology.SectionSevenChainModel

--- a/SphereSixComplex/Topology/CellularChainModel.lean
+++ b/SphereSixComplex/Topology/CellularChainModel.lean
@@ -1,0 +1,92 @@
+module
+
+public import SphereSixComplex.Topology.MayerVietoris
+public import Mathlib.Topology.CWComplex.Classical.Finite
+public import Mathlib.Algebra.Category.Grp.EpiMono
+public import Mathlib.Algebra.Category.Grp.Zero
+public import Mathlib.RingTheory.Finiteness.Basic
+
+/-!
+# Cellular chains of a CW complex
+
+The cellular chain complex, its basis of cells, and its comparison with singular chains.  This is
+general CW topology with no dependence on the paper's construction, so it sits upstream of both the
+`A₂` cellular bridge and the Section 7 finite-CW models.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace SphereSixComplex
+
+/-- The standard integral cellular chain complex of a CW complex, with one free generator for
+each open cell and a comparison map to singular chains. -/
+public structure IntegralCWCellularChainModel
+    (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)] where
+  chainComplex : ChainComplex AddCommGrpCat ℕ
+  cellBasis : ∀ n,
+    (Topology.CWComplex.cell (Set.univ : Set Y) n →₀ ℤ) ≃+ chainComplex.X n
+  comparison : chainComplex ⟶ IntegralSingularChainComplex Y
+  comparison_homology_isIso : ∀ n, IsIso (chainComplex.homologyMap comparison n)
+
+namespace EstablishedCellularHomology
+
+/-- Cellular chains of a CW complex are naturally quasi-isomorphic to singular chains.  Mathlib
+does not currently construct the cellular boundary or this comparison map.
+
+Reference: [Hat02, Theorem 2.35] (cellular homology agrees with singular homology). -/
+public axiom integralCWCellularChainModel
+    (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)] :
+    IntegralCWCellularChainModel Y
+
+end EstablishedCellularHomology
+
+variable (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)]
+
+/-- The cellular chain group of a degree carrying no cells is a zero object. -/
+public theorem isZero_cellularChain_of_isEmpty_cell
+    (M : IntegralCWCellularChainModel Y) (n : ℕ)
+    [IsEmpty (Topology.CWComplex.cell (Set.univ : Set Y) n)] :
+    IsZero (M.chainComplex.X n) := by
+  have : Subsingleton (M.chainComplex.X n) := (M.cellBasis n).symm.injective.subsingleton
+  exact AddCommGrpCat.isZero_of_subsingleton _
+
+/-- A CW complex has no `n`-th integral singular homology once it has no `n`-cells. -/
+public theorem subsingleton_integralSingularHomology_of_isEmpty_cell (n : ℕ)
+    [IsEmpty (Topology.CWComplex.cell (Set.univ : Set Y) n)] :
+    Subsingleton (IntegralSingularHomology n Y) := by
+  obtain M := EstablishedCellularHomology.integralCWCellularChainModel Y
+  have hcell : IsZero (M.chainComplex.homology n) :=
+    (HomologicalComplex.ExactAt.of_isZero
+      (isZero_cellularChain_of_isEmpty_cell Y M n)).isZero_homology
+  have hiso : IsIso (M.chainComplex.homologyMap M.comparison n) := M.comparison_homology_isIso n
+  have : IsZero ((IntegralSingularChainComplex Y).homology n) :=
+    hcell.of_iso (asIso (M.chainComplex.homologyMap M.comparison n)).symm
+  exact AddCommGrpCat.subsingleton_of_isZero this
+
+/-- Homology of a chain complex of finitely generated abelian groups is finitely generated: the
+cycles are a subgroup of a finitely generated group, and the homology is a quotient of the
+cycles. -/
+public theorem module_finite_homology (C : ChainComplex AddCommGrpCat ℕ) (n : ℕ)
+    (h : Module.Finite ℤ (C.X n)) : Module.Finite ℤ (C.homology n) := by
+  have _inst := h
+  let i : (C.cycles n : AddCommGrpCat) →+ (C.X n : AddCommGrpCat) :=
+    ConcreteCategory.hom (HomologicalComplex.iCycles C n)
+  have hinj : Function.Injective i := by
+    rw [← AddCommGrpCat.mono_iff_injective]; infer_instance
+  have hcyc : Module.Finite ℤ (C.cycles n) :=
+    Module.Finite.of_injective i.toIntLinearMap hinj
+  let q : (C.cycles n : AddCommGrpCat) →+ (C.homology n : AddCommGrpCat) :=
+    ConcreteCategory.hom (HomologicalComplex.homologyπ C n)
+  have hsurj : Function.Surjective q := by
+    rw [← AddCommGrpCat.epi_iff_surjective]; infer_instance
+  exact Module.Finite.of_surjective q.toIntLinearMap hsurj
+
+end SphereSixComplex
+
+end
+
+end

--- a/SphereSixComplex/Topology/CellularDimensionVanishing.lean
+++ b/SphereSixComplex/Topology/CellularDimensionVanishing.lean
@@ -1,5 +1,6 @@
 module
 
+public import SphereSixComplex.Topology.CellularChainModel
 public import SphereSixComplex.Topology.CuspToricCellularHomologyBridge
 
 /-!
@@ -23,27 +24,6 @@ open CategoryTheory CategoryTheory.Limits
 namespace SphereSixComplex
 
 variable (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)]
-
-/-- The cellular chain group of a degree carrying no cells is a zero object. -/
-public theorem isZero_cellularChain_of_isEmpty_cell
-    (M : IntegralCWCellularChainModel Y) (n : ℕ)
-    [IsEmpty (Topology.CWComplex.cell (Set.univ : Set Y) n)] :
-    IsZero (M.chainComplex.X n) := by
-  have : Subsingleton (M.chainComplex.X n) := (M.cellBasis n).symm.injective.subsingleton
-  exact AddCommGrpCat.isZero_of_subsingleton _
-
-/-- A CW complex has no `n`-th integral singular homology once it has no `n`-cells. -/
-public theorem subsingleton_integralSingularHomology_of_isEmpty_cell (n : ℕ)
-    [IsEmpty (Topology.CWComplex.cell (Set.univ : Set Y) n)] :
-    Subsingleton (IntegralSingularHomology n Y) := by
-  obtain M := EstablishedCellularHomology.integralCWCellularChainModel Y
-  have hcell : IsZero (M.chainComplex.homology n) :=
-    (HomologicalComplex.ExactAt.of_isZero
-      (isZero_cellularChain_of_isEmpty_cell Y M n)).isZero_homology
-  have hiso : IsIso (M.chainComplex.homologyMap M.comparison n) := M.comparison_homology_isIso n
-  have : IsZero ((IntegralSingularChainComplex Y).homology n) :=
-    hcell.of_iso (asIso (M.chainComplex.homologyMap M.comparison n)).symm
-  exact AddCommGrpCat.subsingleton_of_isZero this
 
 /-- A space homeomorphic to a CW complex with no `n`-cells has no `n`-th integral singular
 homology.  The collars of Section 7 are described analytically and only then identified with a

--- a/SphereSixComplex/Topology/CuspToricCellularHomologyBridge.lean
+++ b/SphereSixComplex/Topology/CuspToricCellularHomologyBridge.lean
@@ -1,5 +1,6 @@
 module
 
+public import SphereSixComplex.Topology.CellularChainModel
 public import SphereSixComplex.Topology.CuspToricCellularAlgebra
 public import Mathlib.Algebra.Homology.ShortComplex.Ab
 
@@ -115,26 +116,6 @@ public noncomputable def cuspToricCellularChainComplex_homologyFourEquiv :
         ((ComplexShape.down ℕ).next_eq' (ComplexShape.down_mk 4 3 (by omega))))).trans
       h.left.homologyIso).addCommGroupIsoToAddEquiv.trans
       cuspToricCellularDegreeFourEquiv
-
-/-- The standard integral cellular chain complex of a CW complex, with one free generator for
-each open cell and a comparison map to singular chains. -/
-public structure IntegralCWCellularChainModel
-    (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)] where
-  chainComplex : ChainComplex AddCommGrpCat ℕ
-  cellBasis : ∀ n,
-    (Topology.CWComplex.cell (Set.univ : Set Y) n →₀ ℤ) ≃+ chainComplex.X n
-  comparison : chainComplex ⟶ IntegralSingularChainComplex Y
-  comparison_homology_isIso : ∀ n, IsIso (chainComplex.homologyMap comparison n)
-
-namespace EstablishedCellularHomology
-
-/-- Cellular chains of a CW complex are naturally quasi-isomorphic to singular chains.  Mathlib
-does not currently construct the cellular boundary or this comparison map. -/
-public axiom integralCWCellularChainModel
-    (Y : Type) [TopologicalSpace Y] [Topology.CWComplex (Set.univ : Set Y)] :
-    IntegralCWCellularChainModel Y
-
-end EstablishedCellularHomology
 
 public theorem cuspWCellIndexFinite (n : ℕ) : Finite (cuspWCellIndex n) := by
   rcases n with (_ | _ | _ | _ | _ | n)

--- a/SphereSixComplex/Topology/SectionSevenLocalEulerModels.lean
+++ b/SphereSixComplex/Topology/SectionSevenLocalEulerModels.lean
@@ -1,5 +1,6 @@
 module
 
+public import SphereSixComplex.Topology.CellularChainModel
 public import SphereSixComplex.Topology.SectionSevenLocalEulerCalculation
 public import Mathlib.Topology.CWComplex.Classical.Finite
 public import Mathlib.Topology.FiberBundle.Basic
@@ -16,7 +17,7 @@ covering models.  The resulting Section 7 contract contains no homology ranks an
 
 noncomputable section
 
-open AlgebraicTopology Set
+open AlgebraicTopology CategoryTheory Set
 open scoped ContinuousMap
 
 namespace SphereSixComplex
@@ -43,19 +44,50 @@ public noncomputable def cellCount (M : FiniteCWModelSix X) (n : ℕ) : ℕ := b
   let _ := M.finite
   exact Nat.card (Topology.CWComplex.cell (Set.univ : Set M.Carrier) n)
 
-/-- Cellular Euler--Poincaré over the integers, including finite generation of homology.
+/-- Cellular Euler--Poincaré over the integers.
 
-Mathlib has finite CW complexes and singular homology, but currently has no cellular homology or
-Euler--Poincaré comparison theorem joining these APIs. -/
+Mathlib has finite CW complexes, singular homology, and the Euler characteristics of a chain
+complex and of its homology, but not the theorem that the two agree.
+
+Reference: [Hat02, Theorem 2.44] (the Euler characteristic equals the alternating sum of the cell
+counts).  Truncating the sum at degree six is sound because `FiniteCWModelSix` records that there
+are no cells above degree six. -/
 public axiom establishedIntegralCellularEulerPoincareSix (M : FiniteCWModelSix X) :
-    IntegralHomologyFiniteSix X ∧
-      integralHomologyEulerCharacteristicSix X =
-        (M.cellCount 0 : ℤ) - M.cellCount 1 + M.cellCount 2 - M.cellCount 3 +
-          M.cellCount 4 - M.cellCount 5 + M.cellCount 6
+    integralHomologyEulerCharacteristicSix X =
+      (M.cellCount 0 : ℤ) - M.cellCount 1 + M.cellCount 2 - M.cellCount 3 +
+        M.cellCount 4 - M.cellCount 5 + M.cellCount 6
 
+/-- Finite generation and the dimension bound are consequences of the cellular chain model, not
+extra assumptions: the chain groups are free on finitely many cells, homology is a subquotient of
+them, and there are no cells above degree six. -/
 public theorem integralHomologyFiniteSix (M : FiniteCWModelSix X) :
-    IntegralHomologyFiniteSix X :=
-  M.establishedIntegralCellularEulerPoincareSix.1
+    IntegralHomologyFiniteSix X where
+  finiteHomology k := by
+    let _ := M.topology
+    let _ := M.cwComplex
+    let _ := M.finite
+    let CM := EstablishedCellularHomology.integralCWCellularChainModel M.Carrier
+    have hfin : Finite (Topology.CWComplex.cell (Set.univ : Set M.Carrier) k) :=
+      Topology.CWComplex.FiniteType.finite_cell (C := (Set.univ : Set M.Carrier)) k
+    have hX : Module.Finite ℤ (CM.chainComplex.X k) :=
+      Module.Finite.equiv (CM.cellBasis k).toIntLinearEquiv
+    have hhom : Module.Finite ℤ (CM.chainComplex.homology k) :=
+      module_finite_homology _ k hX
+    have hiso := CM.comparison_homology_isIso k
+    have hcar : Module.Finite ℤ (IntegralSingularHomology k M.Carrier) :=
+      Module.Finite.equiv (asIso (CM.chainComplex.homologyMap CM.comparison k)
+        |>.addCommGroupIsoToAddEquiv).toIntLinearEquiv
+    exact Module.Finite.equiv
+      (integralSingularHomologyEquivOfHomotopyEquiv k M.homotopyEquiv).symm.toIntLinearEquiv
+  homologyAboveDimension k hk := by
+    let _ := M.topology
+    let _ := M.cwComplex
+    have _hempty : IsEmpty (Topology.CWComplex.cell (Set.univ : Set M.Carrier) k) :=
+      M.cellsAboveSix k hk
+    have _hcar := subsingleton_integralSingularHomology_of_isEmpty_cell M.Carrier k
+    exact ⟨fun _ _ =>
+      (integralSingularHomologyEquivOfHomotopyEquiv k M.homotopyEquiv).injective
+        (Subsingleton.elim _ _)⟩
 
 end FiniteCWModelSix
 
@@ -98,7 +130,7 @@ public theorem integralHomologyFiniteSix (M : FourTorusCellModel X) :
 /-- Euler characteristic zero is derived from the standard four-torus cell counts. -/
 public theorem euler_eq_zero (M : FourTorusCellModel X) :
     integralHomologyEulerCharacteristicSix X = 0 := by
-  rw [M.toFiniteCWModelSix.establishedIntegralCellularEulerPoincareSix.2,
+  rw [M.toFiniteCWModelSix.establishedIntegralCellularEulerPoincareSix,
     M.cellsZero, M.cellsOne, M.cellsTwo, M.cellsThree, M.cellsFour,
     M.cellsFive, M.cellsSix]
   norm_num
@@ -246,7 +278,7 @@ public theorem integralHomologyFiniteSix (M : CuspToricCellModel X) :
 /-- The toric cusp cell decomposition has Euler characteristic two. -/
 public theorem euler_eq_two (M : CuspToricCellModel X) :
     integralHomologyEulerCharacteristicSix X = 2 := by
-  rw [M.toFiniteCWModelSix.establishedIntegralCellularEulerPoincareSix.2,
+  rw [M.toFiniteCWModelSix.establishedIntegralCellularEulerPoincareSix,
     M.cellsZero, M.cellsOne, M.cellsTwo, M.cellsThree, M.cellsFour,
     M.cellsFive, M.cellsSix]
   norm_num


### PR DESCRIPTION
`establishedIntegralCellularEulerPoincareSix` asserted a conjunction: that homology is finitely
generated and vanishes above degree six, *and* that the Euler characteristic is the alternating sum
of the cell counts. The first conjunct does not need assuming -- it follows from the cellular chain
model, which is already an axiom. The declaration now asserts only the Euler identity.

This does not change the axiom count; it changes what one axiom assumes, which is the standard you
have been applying.

## The derivation

`FiniteCWModelSix.integralHomologyFiniteSix` is now proved:

- **Finite generation.** `cellBasis` makes the chain group in degree `k` isomorphic to
  `cell k →₀ ℤ`, and `CWComplex.FiniteType.finite_cell` makes the index finite, so the chain group
  is finitely generated. A new general lemma `module_finite_homology` then gives finite generation
  of the homology: cycles inject into the chain group (mono in `AddCommGrpCat` is injective, and
  a subgroup of a finitely generated group over `ℤ` is finitely generated), and homology is a
  quotient of the cycles (`homologyπ` is epi, hence surjective). `comparison_homology_isIso`
  carries this to singular homology of the carrier, and the model's homotopy equivalence carries it
  to `X`.
- **Vanishing above six.** `cellsAboveSix` gives no cells, and
  `subsingleton_integralSingularHomology_of_isEmpty_cell` gives no homology, transported the same
  way.

## One structural change

The general cellular chain model -- the `IntegralCWCellularChainModel` structure and the
`integralCWCellularChainModel` axiom -- moves to a new `SphereSixComplex/Topology/CellularChainModel.lean`.

It had been sitting in `CuspToricCellularHomologyBridge`, which imports
`SectionSevenLocalEulerModels`; using it where the Euler axiom lives would have been an import
cycle. Nothing in it depends on the paper's construction, so upstream is where it belongs. The two
degree-vanishing lemmas move with it for the same reason. Names and namespaces are unchanged, so no
consumer moves.

Full local rebuild (146 modules, 0 failures); all three gates pass; final cone unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y