### PR TITLE
Refactor duplicated elliptic and topology APIs

### DIFF
--- a/SphereSixComplex/Geometry/CuspPeriodExpansion.lean
+++ b/SphereSixComplex/Geometry/CuspPeriodExpansion.lean
@@ -2,6 +2,7 @@ module
 
 public import SphereSixComplex.Geometry.CuspToricPhaseAction
 public import SphereSixComplex.Periods.FuchsianPeriodAssembly
+public import Mathlib.Analysis.Complex.Periodic
 import all SphereSixComplex.LatticeData
 import all SphereSixComplex.Periods.Functions
 import all SphereSixComplex.Periods.Matrix
@@ -68,15 +69,186 @@ public structure HolomorphicCuspDescent (H : ℝ) (f : ℂ → ℂ) where
 
 namespace Established
 
-/-- The classical removable-singularity theorem for the exponential quotient of a half-plane.
-This is a general one-variable analytic theorem, independent of the period family and of the
-paper's toric construction. -/
-public axiom periodicBoundedHolomorphicCuspDescent
+/- The mathlib periodic API is formulated for globally periodic functions.  A function periodic
+on a half-plane has the canonical zero extension below that half-plane; because real translation
+does not change the imaginary part, this extension is globally periodic and agrees with the
+original function where the latter is used. -/
+public def periodicExtension (H : ℝ) (f : ℂ → ℂ) : ℂ → ℂ :=
+  by
+    classical
+    exact fun s ↦ if s ∈ cuspHalfPlane H then f s else 0
+
+public theorem periodicExtension_periodic
+    (H : ℝ) (f : ℂ → ℂ)
+    (periodic : ∀ s ∈ cuspHalfPlane H, f (s - 1) = f s) :
+    Function.Periodic (periodicExtension H f) 1 := by
+  classical
+  intro s
+  by_cases hs : s ∈ cuspHalfPlane H
+  · have hs' : s + 1 ∈ cuspHalfPlane H := by
+      simpa [cuspHalfPlane] using hs
+    change H < s.im at hs
+    change H < (s + 1).im at hs'
+    have hs'' : H < (1 + s).im := by simpa [add_comm] using hs
+    have hsmem : s ∈ cuspHalfPlane H := hs
+    have hs'mem : 1 + s ∈ cuspHalfPlane H := hs''
+    have hsplusmem : s + 1 ∈ cuspHalfPlane H := hs'
+    simp [periodicExtension, hsplusmem, hsmem]
+    have hp := periodic (s + 1) hs'
+    convert hp.symm using 1; ring_nf
+  · have hs' : s + 1 ∉ cuspHalfPlane H := by
+      simpa [cuspHalfPlane] using hs
+    change ¬ H < s.im at hs
+    change ¬ H < (s + 1).im at hs'
+    have hs'' : ¬ H < (1 + s).im := by simpa [add_comm] using hs
+    have hsmem : s ∉ cuspHalfPlane H := hs
+    have hs'mem : 1 + s ∉ cuspHalfPlane H := hs''
+    have hsplusmem : s + 1 ∉ cuspHalfPlane H := hs'
+    simp [periodicExtension, hsplusmem, hsmem]
+
+public theorem periodicExtension_eq
+    (H : ℝ) (f : ℂ → ℂ) {s : ℂ} (hs : s ∈ cuspHalfPlane H) :
+    periodicExtension H f s = f s := by
+  classical
+  change H < s.im at hs
+  have hsmem : s ∈ cuspHalfPlane H := hs
+  simp [periodicExtension, hsmem]
+
+public theorem periodicExtension_differentiableAt
+    (H : ℝ) (f : ℂ → ℂ)
+    (holomorphic : DifferentiableOn ℂ f (cuspHalfPlane H))
+    {s : ℂ} (hs : s ∈ cuspHalfPlane H) :
+    DifferentiableAt ℂ (periodicExtension H f) s := by
+  classical
+  have hopen : IsOpen (cuspHalfPlane H) := by
+    exact isOpen_lt continuous_const Complex.continuous_im
+  apply (holomorphic.differentiableAt (hopen.mem_nhds hs)).congr_of_eventuallyEq
+  filter_upwards [hopen.mem_nhds hs] with z hz
+  change H < z.im at hz
+  have hzmem : z ∈ cuspHalfPlane H := hz
+  simp [periodicExtension, hzmem]
+
+public theorem periodicExtension_eventually_differentiableAt
+    (H : ℝ) (f : ℂ → ℂ)
+    (holomorphic : DifferentiableOn ℂ f (cuspHalfPlane H)) :
+    ∀ᶠ s in Filter.comap Complex.im Filter.atTop,
+      DifferentiableAt ℂ (periodicExtension H f) s := by
+  rw [Filter.eventually_comap]
+  filter_upwards [Filter.eventually_gt_atTop H] with y hy s hsy
+  exact periodicExtension_differentiableAt H f holomorphic (by
+    change H < s.im
+    simpa [hsy] using hy)
+
+public theorem periodicExtension_boundedAtFilter
+    (H : ℝ) (f : ℂ → ℂ) (bounded : NormBoundedOn f (cuspHalfPlane H)) :
+    Filter.BoundedAtFilter (Filter.comap Complex.im Filter.atTop)
+      (periodicExtension H f) := by
+  classical
+  obtain ⟨A, hA, hbound⟩ := bounded
+  rw [Filter.BoundedAtFilter]
+  apply Asymptotics.IsBigO.of_bound A
+  rw [Filter.eventually_comap]
+  filter_upwards [Filter.eventually_gt_atTop H] with y hy s hsy
+  have hs : H < s.im := by
+    simpa [hsy] using hy
+  simp only [Pi.one_apply, norm_one, mul_one]
+  change ‖if s ∈ cuspHalfPlane H then f s else 0‖ ≤ A
+  have hs' : s ∈ cuspHalfPlane H := hs
+  simp [hs']
+  exact hbound s hs
+
+/- The local/global bridge: the selected mathlib cusp function is differentiable on the whole
+disc of radius `exp (-2πH)`, even when that radius is larger than the unit disc. -/
+public theorem periodic_cuspFunction_differentiableOn
     (H : ℝ) (f : ℂ → ℂ)
     (holomorphic : DifferentiableOn ℂ f (cuspHalfPlane H))
     (periodic : ∀ s ∈ cuspHalfPlane H, f (s - 1) = f s)
     (bounded : NormBoundedOn f (cuspHalfPlane H)) :
-    Nonempty (HolomorphicCuspDescent H f)
+    DifferentiableOn ℂ
+      (Function.Periodic.cuspFunction 1 (periodicExtension H f))
+      (Metric.ball 0 (cuspRadius H)) := by
+  let g := periodicExtension H f
+  have hgper : Function.Periodic g 1 := periodicExtension_periodic H f periodic
+  have hghol : ∀ᶠ s in Filter.comap Complex.im Filter.atTop,
+      DifferentiableAt ℂ g s := periodicExtension_eventually_differentiableAt H f holomorphic
+  have hgbd : Filter.BoundedAtFilter (Filter.comap Complex.im Filter.atTop) g :=
+    periodicExtension_boundedAtFilter H f bounded
+  have hzero : DifferentiableAt ℂ (Function.Periodic.cuspFunction 1 g) 0 :=
+    Function.Periodic.differentiableAt_cuspFunction_zero one_pos hgper hghol hgbd
+  intro q hq
+  rcases eq_or_ne q 0 with rfl | hq0
+  · exact hzero.differentiableWithinAt
+  · have him : H < (Function.Periodic.invQParam 1 q).im := by
+      rw [← Function.Periodic.norm_qParam_lt_iff one_pos H]
+      rw [Function.Periodic.qParam_right_inv one_ne_zero hq0]
+      simpa [cuspRadius] using hq
+    have hd := Function.Periodic.differentiableAt_cuspFunction one_ne_zero hgper
+      (periodicExtension_differentiableAt H f holomorphic him)
+    rw [Function.Periodic.qParam_right_inv one_ne_zero hq0] at hd
+    simpa [g] using hd.differentiableWithinAt
+
+/- Compatibility wrapper retaining the established local API while delegating all analytic work
+to `Function.Periodic.cuspFunction` and its removable-singularity theorem. -/
+public theorem periodicBoundedHolomorphicCuspDescent
+    (H : ℝ) (f : ℂ → ℂ)
+    (holomorphic : DifferentiableOn ℂ f (cuspHalfPlane H))
+    (periodic : ∀ s ∈ cuspHalfPlane H, f (s - 1) = f s)
+    (bounded : NormBoundedOn f (cuspHalfPlane H)) :
+    Nonempty (HolomorphicCuspDescent H f) := by
+  let g := periodicExtension H f
+  let F := Function.Periodic.cuspFunction 1 g
+  have hgper : Function.Periodic g 1 := periodicExtension_periodic H f periodic
+  have hF : DifferentiableOn ℂ F (Metric.ball 0 (cuspRadius H)) := by
+    simpa [F, g] using periodic_cuspFunction_differentiableOn H f holomorphic periodic bounded
+  refine ⟨⟨F, hF, ?_, ?_⟩⟩
+  · intro s hs
+    have heq := Function.Periodic.eq_cuspFunction one_ne_zero hgper s
+    simpa [F, g, cuspQ, Function.Periodic.qParam, periodicExtension, hs] using heq
+  · intro G hG hGfactor q hq
+    rcases eq_or_ne q 0 with rfl | hq0
+    · have hF0 : DifferentiableAt ℂ F 0 :=
+        hF.differentiableAt (Metric.ball_mem_nhds (0 : ℂ) (by simpa using cuspRadius_pos H))
+      have hG0 : DifferentiableAt ℂ G 0 :=
+        hG.differentiableAt (Metric.ball_mem_nhds (0 : ℂ) (by simpa using cuspRadius_pos H))
+      let : (Filter.comap Complex.im Filter.atTop).NeBot :=
+        Filter.NeBot.comap_of_surj inferInstance Complex.im_surjective
+      have hqt : Filter.Tendsto (fun s : ℂ ↦ Function.Periodic.qParam 1 s)
+          (Filter.comap Complex.im Filter.atTop) (nhds 0) :=
+        (Function.Periodic.qParam_tendsto one_pos).mono_right nhdsWithin_le_nhds
+      have heq : (fun s : ℂ ↦ G (Function.Periodic.qParam 1 s)) =ᶠ[
+          Filter.comap Complex.im Filter.atTop]
+          (fun s ↦ F (Function.Periodic.qParam 1 s)) := by
+        change ∀ᶠ s in Filter.comap Complex.im Filter.atTop,
+          G (Function.Periodic.qParam 1 s) = F (Function.Periodic.qParam 1 s)
+        rw [Filter.eventually_comap]
+        filter_upwards [Filter.eventually_gt_atTop H] with y hy s hsy
+        have hs : H < s.im := by simpa [hsy] using hy
+        have hGs := hGfactor s hs
+        have hFs := Function.Periodic.eq_cuspFunction one_ne_zero hgper s
+        have hGs' : G (Function.Periodic.qParam 1 s) = f s := by
+          simpa [cuspQ, Function.Periodic.qParam] using hGs
+        exact hGs'.trans ((periodicExtension_eq H f hs).symm.trans (by
+          simpa [F] using hFs.symm))
+      exact tendsto_nhds_unique
+        ((hG0.continuousAt.tendsto.comp hqt).congr' heq)
+        (hF0.continuousAt.tendsto.comp hqt)
+    · have him : H < (Function.Periodic.invQParam 1 q).im := by
+        rw [← Function.Periodic.norm_qParam_lt_iff one_pos H]
+        rw [Function.Periodic.qParam_right_inv one_ne_zero hq0]
+        simpa [cuspRadius] using hq
+      have hGq := hGfactor (Function.Periodic.invQParam 1 q) him
+      have hGq' : G (Function.Periodic.qParam 1
+          (Function.Periodic.invQParam 1 q)) = g (Function.Periodic.invQParam 1 q) := by
+        calc
+          G (Function.Periodic.qParam 1 (Function.Periodic.invQParam 1 q)) =
+              f (Function.Periodic.invQParam 1 q) := by
+                simpa [cuspQ, Function.Periodic.qParam] using hGq
+          _ = g (Function.Periodic.invQParam 1 q) :=
+            (periodicExtension_eq H f him).symm
+      rw [Function.Periodic.qParam_right_inv one_ne_zero hq0] at hGq'
+      have hFq : F q = g (Function.Periodic.invQParam 1 q) := by
+        simpa [F] using Function.Periodic.cuspFunction_eq_of_nonzero 1 g hq0
+      exact hGq'.trans hFq.symm
 
 end Established
 

--- a/SphereSixComplex/Geometry/EllipticLinearCollarGlobalDescent.lean
+++ b/SphereSixComplex/Geometry/EllipticLinearCollarGlobalDescent.lean
@@ -264,27 +264,93 @@ public theorem ellipticFixedPoints_eq_of_fuchsian
   · apply (FreeProductTorsion.fuchsianSourceAction_gTwo_fixed_iff U.zTwo).mp
     simpa only [← hsource] using U.zTwo_fixed
 
-@[expose] public def OrderThreeLinearCollarSourceData (r : ℝ) : Prop :=
+/-! The two local collars have the same source-side input.  Keeping the varying data in this
+record makes the order-specific declarations below aliases, rather than parallel propositions. -/
+
+/-- Indexed data for one elliptic linear collar. -/
+public structure IndexedLinearCollarModel (m : ℕ) [NeZero m] where
+  center : UpperHalfPlane
+  other : UpperHalfPlane
+  cayley : UpperHalfPlane → ComplexUnitDisc
+  cayley_eq : ∀ z, cayley z = cayleyHomeomorph center z
+  cyclicInclusion : FiniteCyclic m → Delta
+
+/-- Source regularity and separation data for an indexed elliptic linear collar. -/
+@[expose] public def LinearCollarSourceData
+    (m : ℕ) [NeZero m] (M : IndexedLinearCollarModel m) (r : ℝ) : Prop :=
   (∀ z : UpperHalfPlane,
-      0 < ‖(orderThreeCayleyHomeomorph z : ℂ)‖ →
-      ‖(orderThreeCayleyHomeomorph z : ℂ)‖ < r →
+      0 < ‖(M.cayley z : ℂ)‖ →
+      ‖(M.cayley z : ℂ)‖ < r →
       IsRegularBasePoint (U := U) z) ∧
     ∀ z x : UpperHalfPlane,
-      ‖(orderThreeCayleyHomeomorph z : ℂ)‖ < r →
-      ‖(orderThreeCayleyHomeomorph x : ℂ)‖ < r →
+      ‖(M.cayley z : ℂ)‖ < r →
+      ‖(M.cayley x : ℂ)‖ < r →
       ∀ g : Delta, U.sourceAction g • x = z →
-        ∃ a : CyclicThree, g = Monoid.Coprod.inl a
+        ∃ a : FiniteCyclic m, g = M.cyclicInclusion a
+
+public theorem linearCollarSourceData_mono
+    (m : ℕ) [NeZero m] {M : IndexedLinearCollarModel m} {r' r : ℝ} (hrr : r' ≤ r)
+    (D : LinearCollarSourceData (U := U) m M r) :
+    LinearCollarSourceData (U := U) m M r' := by
+  rw [LinearCollarSourceData.eq_def] at D ⊢
+  constructor
+  · intro z hz hzr
+    exact D.1 z hz (hzr.trans_le hrr)
+  · intro z x hzr hxr g hg
+    exact D.2 z x (hzr.trans_le hrr) (hxr.trans_le hrr) g hg
+
+public theorem exists_indexedCollarSlice_radius
+    {m : ℕ} [NeZero m] {M : IndexedLinearCollarModel m}
+    (hsource : U.sourceAction = fuchsianSourceAction)
+    (hproper : SourceActionProperlyDiscontinuous (U := U))
+    (hcenterOther : M.center ∉ sourceOrbitSet (U := U) M.other) :
+    let _ : MulAction Delta UpperHalfPlane := fuchsianSourceMulAction
+    ∃ S : Set UpperHalfPlane, IsOpen S ∧ M.center ∈ S ∧
+      (∀ g : Delta, ((fun y : UpperHalfPlane => g • y) '' S ∩ S).Nonempty ↔
+        g ∈ MulAction.stabilizer Delta M.center) ∧
+      ∃ r : ℝ, 0 < r ∧ r < 1 ∧
+        (∀ z : UpperHalfPlane, ‖(M.cayley z : ℂ)‖ < r →
+          z ∈ S ∩ (sourceOrbitSet (U := U) M.other)ᶜ) := by
+  let _ : MulAction Delta UpperHalfPlane := fuchsianSourceMulAction
+  let _ : ProperlyDiscontinuousSMul Delta UpperHalfPlane :=
+    fuchsianProperlyDiscontinuous_of_source hsource hproper
+  let _ : ContinuousConstSMul Delta UpperHalfPlane :=
+    ⟨fun g => (fuchsianSourceAction_contMDiff g 0).continuous⟩
+  obtain ⟨S, hSopen, hcenterS, _hSinvariant, htranslate⟩ :=
+    exists_open_stabilizer_slice (G := Delta) M.center
+  let T := S ∩ (sourceOrbitSet (U := U) M.other)ᶜ
+  have hTopen : IsOpen T := hSopen.inter
+    (sourceOrbitSet_isClosed hproper M.other).isOpen_compl
+  have hcenterT : M.center ∈ T := ⟨hcenterS, hcenterOther⟩
+  obtain ⟨r, hr, hr1, hrT⟩ :=
+    exists_cayleyRadius_subset M.center hTopen hcenterT
+  exact ⟨S, hSopen, hcenterS, htranslate, r, hr, hr1, fun z hz =>
+    ⟨(hrT z (by simpa [M.cayley_eq z] using hz)).1, (hrT z
+      (by simpa [M.cayley_eq z] using hz)).2⟩⟩
+
+/-- The order-three Cayley coordinate and its inclusion into the deck group. -/
+public abbrev orderThreeLinearCollarModel :
+  IndexedLinearCollarModel 3 :=
+  { center := fuchsianOneFixedPoint
+    other := fuchsianTwoFixedPoint
+    cayley := orderThreeCayleyHomeomorph
+    cayley_eq := by intro z; rfl
+    cyclicInclusion := Monoid.Coprod.inl }
+
+/-- The order-four Cayley coordinate and its inclusion into the deck group. -/
+public abbrev orderFourLinearCollarModel :
+  IndexedLinearCollarModel 4 :=
+  { center := fuchsianTwoFixedPoint
+    other := fuchsianOneFixedPoint
+    cayley := orderFourCayleyHomeomorph
+    cayley_eq := by intro z; rfl
+    cyclicInclusion := Monoid.Coprod.inr }
+
+@[expose] public def OrderThreeLinearCollarSourceData (r : ℝ) : Prop :=
+  LinearCollarSourceData (U := U) 3 orderThreeLinearCollarModel r
 
 @[expose] public def OrderFourLinearCollarSourceData (r : ℝ) : Prop :=
-  (∀ z : UpperHalfPlane,
-      0 < ‖(orderFourCayleyHomeomorph z : ℂ)‖ →
-      ‖(orderFourCayleyHomeomorph z : ℂ)‖ < r →
-      IsRegularBasePoint (U := U) z) ∧
-    ∀ z x : UpperHalfPlane,
-      ‖(orderFourCayleyHomeomorph z : ℂ)‖ < r →
-      ‖(orderFourCayleyHomeomorph x : ℂ)‖ < r →
-      ∀ g : Delta, U.sourceAction g • x = z →
-        ∃ a : CyclicFour, g = Monoid.Coprod.inr a
+  LinearCollarSourceData (U := U) 4 orderFourLinearCollarModel r
 
 public theorem exists_orderThreeLinearCollarSourceData
     (hsource : U.sourceAction = fuchsianSourceAction)
@@ -295,27 +361,25 @@ public theorem exists_orderThreeLinearCollarSourceData
     fuchsianProperlyDiscontinuous_of_source hsource hproper
   let _ : ContinuousConstSMul Delta UpperHalfPlane :=
     ⟨fun g => (fuchsianSourceAction_contMDiff g 0).continuous⟩
-  obtain ⟨S, hSopen, hcenterS, _hSinvariant, htranslate⟩ :=
-    exists_open_stabilizer_slice (G := Delta) fuchsianOneFixedPoint
   obtain ⟨hzOne, hzTwo⟩ := ellipticFixedPoints_eq_of_fuchsian hsource
-  let T := S ∩ (sourceOrbitSet (U := U) U.zTwo)ᶜ
-  have hTopen : IsOpen T := hSopen.inter
-    (sourceOrbitSet_isClosed hproper U.zTwo).isOpen_compl
   have hcenterNotTwo : fuchsianOneFixedPoint ∉ sourceOrbitSet (U := U) U.zTwo := by
     simp only [sourceOrbitSet.eq_def, mem_iUnion, mem_singleton_iff]
     rintro ⟨g, hg⟩
     apply fuchsianTwo_orbit_ne_one g
     simpa only [hsource, hzOne, hzTwo] using hg.symm
-  have hcenterT : fuchsianOneFixedPoint ∈ T := ⟨hcenterS, hcenterNotTwo⟩
-  obtain ⟨r, hr, hr1, hrT⟩ :=
-    exists_cayleyRadius_subset fuchsianOneFixedPoint hTopen hcenterT
+  obtain ⟨S, hSopen, hcenterS, htranslate, r, hr, hr1, hrT⟩ :=
+    exists_indexedCollarSlice_radius hsource hproper
+      (M := orderThreeLinearCollarModel)
+      (by simpa [orderThreeLinearCollarModel, hzTwo] using hcenterNotTwo)
+  let T := S ∩ (sourceOrbitSet (U := U) U.zTwo)ᶜ
   refine ⟨r, hr, hr1, ?_⟩
   rw [OrderThreeLinearCollarSourceData.eq_def]
   constructor
   · intro z hzpos hzr
     unfold IsRegularBasePoint
     intro g
-    have hzT : z ∈ T := hrT z hzr
+    have hzT : z ∈ T := by
+      simpa [T, orderThreeLinearCollarModel, hzTwo] using hrT z hzr
     constructor
     · intro hgone
       have hzEq : fuchsianSourceAction g⁻¹ • fuchsianOneFixedPoint = z := by
@@ -330,7 +394,9 @@ public theorem exists_orderThreeLinearCollarSourceData
       have hzcenter : z = fuchsianOneFixedPoint := by
         rw [← hzEq]
         exact hfix
-      rw [hzcenter, orderThreeCayleyHomeomorph.eq_def] at hzpos
+      rw [hzcenter] at hzpos
+      change 0 < ‖(orderThreeCayleyHomeomorph fuchsianOneFixedPoint : ℂ)‖ at hzpos
+      rw [orderThreeCayleyHomeomorph.eq_def] at hzpos
       have hc : cayleyHomeomorph fuchsianOneFixedPoint fuchsianOneFixedPoint =
           discCenter := by
         apply Subtype.ext
@@ -368,27 +434,25 @@ public theorem exists_orderFourLinearCollarSourceData
     fuchsianProperlyDiscontinuous_of_source hsource hproper
   let _ : ContinuousConstSMul Delta UpperHalfPlane :=
     ⟨fun g => (fuchsianSourceAction_contMDiff g 0).continuous⟩
-  obtain ⟨S, hSopen, hcenterS, _hSinvariant, htranslate⟩ :=
-    exists_open_stabilizer_slice (G := Delta) fuchsianTwoFixedPoint
   obtain ⟨hzOne, hzTwo⟩ := ellipticFixedPoints_eq_of_fuchsian hsource
-  let T := S ∩ (sourceOrbitSet (U := U) U.zOne)ᶜ
-  have hTopen : IsOpen T := hSopen.inter
-    (sourceOrbitSet_isClosed hproper U.zOne).isOpen_compl
   have hcenterNotOne : fuchsianTwoFixedPoint ∉ sourceOrbitSet (U := U) U.zOne := by
     simp only [sourceOrbitSet.eq_def, mem_iUnion, mem_singleton_iff]
     rintro ⟨g, hg⟩
     apply fuchsianOne_orbit_ne_two g
     simpa only [hsource, hzOne, hzTwo] using hg.symm
-  have hcenterT : fuchsianTwoFixedPoint ∈ T := ⟨hcenterS, hcenterNotOne⟩
-  obtain ⟨r, hr, hr1, hrT⟩ :=
-    exists_cayleyRadius_subset fuchsianTwoFixedPoint hTopen hcenterT
+  obtain ⟨S, hSopen, hcenterS, htranslate, r, hr, hr1, hrT⟩ :=
+    exists_indexedCollarSlice_radius hsource hproper
+      (M := orderFourLinearCollarModel)
+      (by simpa [orderFourLinearCollarModel, hzOne] using hcenterNotOne)
+  let T := S ∩ (sourceOrbitSet (U := U) U.zOne)ᶜ
   refine ⟨r, hr, hr1, ?_⟩
   rw [OrderFourLinearCollarSourceData.eq_def]
   constructor
   · intro z hzpos hzr
     unfold IsRegularBasePoint
     intro g
-    have hzT : z ∈ T := hrT z hzr
+    have hzT : z ∈ T := by
+      simpa [T, orderFourLinearCollarModel, hzOne] using hrT z hzr
     constructor
     · intro hgone
       have hzOrbit : z ∈ sourceOrbitSet (U := U) U.zOne := by
@@ -414,7 +478,9 @@ public theorem exists_orderFourLinearCollarSourceData
       have hzcenter : z = fuchsianTwoFixedPoint := by
         rw [← hzEq]
         exact hfix
-      rw [hzcenter, orderFourCayleyHomeomorph.eq_def] at hzpos
+      rw [hzcenter] at hzpos
+      change 0 < ‖(orderFourCayleyHomeomorph fuchsianTwoFixedPoint : ℂ)‖ at hzpos
+      rw [orderFourCayleyHomeomorph.eq_def] at hzpos
       have hc : cayleyHomeomorph fuchsianTwoFixedPoint fuchsianTwoFixedPoint =
           discCenter := by
         apply Subtype.ext
@@ -705,10 +771,10 @@ public theorem orderThreeLinearCollarToPuncturedGlobalFamily_injective
       rw [familyTotalSpaceBase_familyDeckMap] at hbase
       rw [OrderThreeLinearCollarSourceData.eq_def] at D
       obtain ⟨a, ha⟩ := D.2 (familyTotalSpaceBase F q) (familyTotalSpaceBase F x)
-        (by simpa only [orderThreePuncturedFamilyCollar.eq_def, Set.mem_ofPred_eq,
-          orderThreeFamilyRadius.eq_def] using q.property.2)
-        (by simpa only [orderThreePuncturedFamilyCollar.eq_def, Set.mem_ofPred_eq,
-          orderThreeFamilyRadius.eq_def] using x.property.2) g hbase
+        (by simpa [orderThreeLinearCollarModel, orderThreePuncturedFamilyCollar.eq_def,
+          Set.mem_ofPred_eq, orderThreeFamilyRadius.eq_def] using q.property.2)
+        (by simpa [orderThreeLinearCollarModel, orderThreePuncturedFamilyCollar.eq_def,
+          Set.mem_ofPred_eq, orderThreeFamilyRadius.eq_def] using x.property.2) g hbase
       apply Quotient.sound
       let _ := restrictedMulAction (orderThreeLinearFamilyAction F)
         (orderThreeLinearPuncturedCarrier F hsource r)
@@ -717,7 +783,9 @@ public theorem orderThreeLinearCollarToPuncturedGlobalFamily_injective
       refine ⟨a, ?_⟩
       apply Subtype.ext
       change actionMap (orderThreeLinearFamilyAction F) a x = q
-      rw [orderThreeLinear_actionMap, ← ha]
+      have ha' : g = Monoid.Coprod.inl a := by
+        simpa [orderThreeLinearCollarModel] using ha
+      rw [orderThreeLinear_actionMap, ← ha']
       exact htotal
 
 public theorem orderFourLinearCollarToPuncturedGlobalFamily_injective
@@ -753,10 +821,10 @@ public theorem orderFourLinearCollarToPuncturedGlobalFamily_injective
       rw [familyTotalSpaceBase_familyDeckMap] at hbase
       rw [OrderFourLinearCollarSourceData.eq_def] at D
       obtain ⟨a, ha⟩ := D.2 (familyTotalSpaceBase F q) (familyTotalSpaceBase F x)
-        (by simpa only [orderFourPuncturedFamilyCollar.eq_def, Set.mem_ofPred_eq,
-          orderFourFamilyRadius.eq_def] using q.property.2)
-        (by simpa only [orderFourPuncturedFamilyCollar.eq_def, Set.mem_ofPred_eq,
-          orderFourFamilyRadius.eq_def] using x.property.2) g hbase
+        (by simpa [orderFourLinearCollarModel, orderFourPuncturedFamilyCollar.eq_def,
+          Set.mem_ofPred_eq, orderFourFamilyRadius.eq_def] using q.property.2)
+        (by simpa [orderFourLinearCollarModel, orderFourPuncturedFamilyCollar.eq_def,
+          Set.mem_ofPred_eq, orderFourFamilyRadius.eq_def] using x.property.2) g hbase
       apply Quotient.sound
       let _ := restrictedMulAction (orderFourLinearFamilyAction F)
         (orderFourLinearPuncturedCarrier F hsource r)
@@ -765,7 +833,9 @@ public theorem orderFourLinearCollarToPuncturedGlobalFamily_injective
       refine ⟨a, ?_⟩
       apply Subtype.ext
       change actionMap (orderFourLinearFamilyAction F) a x = q
-      rw [orderFourLinear_actionMap, ← ha]
+      have ha' : g = Monoid.Coprod.inr a := by
+        simpa [orderFourLinearCollarModel] using ha
+      rw [orderFourLinear_actionMap, ← ha']
       exact htotal
 
 public theorem orderThreeLinearCollarToPuncturedGlobalFamily_continuous

--- a/SphereSixComplex/Geometry/EllipticLocalCoordinates.lean
+++ b/SphereSixComplex/Geometry/EllipticLocalCoordinates.lean
@@ -284,21 +284,59 @@ public theorem discScalarEquiv_pow_fixed_iff (lambda : ℂ) (hlambda : ‖lambda
     apply Subtype.ext
     simp [discScalarEquiv_pow_apply_val, discCenter]
 
+/-! The finite cyclic disc action depends on only two pieces of varying mathematical data: its
+multiplier and its order.  The common construction is indexed by that order; the explicit
+order-three and order-four records below are intentionally tiny specializations. -/
+
+public structure IndexedDiscRotationData (m : ℕ) [NeZero m] where
+  multiplier : ℂ
+  multiplier_norm : ‖multiplier‖ = 1
+  multiplier_pow : multiplier ^ m = 1
+
+public noncomputable abbrev indexedDiscRotation
+    (m : ℕ) [NeZero m] (D : IndexedDiscRotationData m) : Equiv.Perm ComplexUnitDisc :=
+  discScalarEquiv D.multiplier D.multiplier_norm
+
+public noncomputable abbrev indexedDiscRepresentation
+    (m : ℕ) [NeZero m] (D : IndexedDiscRotationData m) :
+    FiniteCyclic m →* Equiv.Perm ComplexUnitDisc :=
+  cyclicRepresentation m (indexedDiscRotation m D)
+    (discScalarEquiv_pow_eq_one D.multiplier D.multiplier_norm m D.multiplier_pow)
+
+public theorem indexedDiscRotation_pow
+    (m : ℕ) [NeZero m] (D : IndexedDiscRotationData m) :
+    (indexedDiscRotation m D) ^ m = 1 :=
+  discScalarEquiv_pow_eq_one D.multiplier D.multiplier_norm m D.multiplier_pow
+
+public theorem indexedDiscRepresentation_generator
+    (m : ℕ) [NeZero m] (D : IndexedDiscRotationData m) :
+    indexedDiscRepresentation m D (cyclicGenerator m) = indexedDiscRotation m D :=
+  cyclicRepresentation_generator m (indexedDiscRotation m D)
+    (indexedDiscRotation_pow m D)
+
+public abbrev orderThreeDiscRotationData : IndexedDiscRotationData 3 :=
+  { multiplier := orderThreeMultiplier
+    multiplier_norm := norm_orderThreeMultiplier
+    multiplier_pow := orderThreeMultiplier_pow_three }
+
+public abbrev orderFourDiscRotationData : IndexedDiscRotationData 4 :=
+  { multiplier := orderFourMultiplier
+    multiplier_norm := norm_orderFourMultiplier
+    multiplier_pow := orderFourMultiplier_pow_four }
+
 /-- The order-three rotation on the explicit Cayley disc. -/
-@[expose] public noncomputable def orderThreeDiscRotation : Equiv.Perm ComplexUnitDisc :=
-  discScalarEquiv orderThreeMultiplier norm_orderThreeMultiplier
+public noncomputable abbrev orderThreeDiscRotation : Equiv.Perm ComplexUnitDisc :=
+  indexedDiscRotation 3 orderThreeDiscRotationData
 
 /-- The order-four rotation on the explicit Cayley disc. -/
-@[expose] public noncomputable def orderFourDiscRotation : Equiv.Perm ComplexUnitDisc :=
-  discScalarEquiv orderFourMultiplier norm_orderFourMultiplier
+public noncomputable abbrev orderFourDiscRotation : Equiv.Perm ComplexUnitDisc :=
+  indexedDiscRotation 4 orderFourDiscRotationData
 
 public theorem orderThreeDiscRotation_pow : orderThreeDiscRotation ^ 3 = 1 :=
-  discScalarEquiv_pow_eq_one orderThreeMultiplier norm_orderThreeMultiplier 3
-    orderThreeMultiplier_pow_three
+  indexedDiscRotation_pow 3 orderThreeDiscRotationData
 
 public theorem orderFourDiscRotation_pow : orderFourDiscRotation ^ 4 = 1 :=
-  discScalarEquiv_pow_eq_one orderFourMultiplier norm_orderFourMultiplier 4
-    orderFourMultiplier_pow_four
+  indexedDiscRotation_pow 4 orderFourDiscRotationData
 
 @[expose] public def discOffCenter : ComplexUnitDisc := ⟨1 / 2, by norm_num⟩
 
@@ -340,24 +378,24 @@ public theorem orderFourDiscRotation_fixed_iff
   ⟨orderFourCayley z, norm_orderFourCayley_lt_one z⟩
 
 /-- Local cyclic representation at the order-three elliptic point. -/
-@[expose] public noncomputable def orderThreeDiscRepresentation :
-    FiniteCyclic 3 →* Equiv.Perm ComplexUnitDisc :=
-  cyclicRepresentation 3 orderThreeDiscRotation orderThreeDiscRotation_pow
+public noncomputable abbrev orderThreeDiscRepresentation :
+  FiniteCyclic 3 →* Equiv.Perm ComplexUnitDisc :=
+  indexedDiscRepresentation 3 orderThreeDiscRotationData
 
 /-- Local cyclic representation at the order-four elliptic point. -/
-@[expose] public noncomputable def orderFourDiscRepresentation :
+public noncomputable abbrev orderFourDiscRepresentation :
     FiniteCyclic 4 →* Equiv.Perm ComplexUnitDisc :=
-  cyclicRepresentation 4 orderFourDiscRotation orderFourDiscRotation_pow
+  indexedDiscRepresentation 4 orderFourDiscRotationData
 
 @[simp]
 public theorem orderThreeDiscRepresentation_generator :
     orderThreeDiscRepresentation (cyclicGenerator 3) = orderThreeDiscRotation :=
-  cyclicRepresentation_generator 3 orderThreeDiscRotation orderThreeDiscRotation_pow
+  indexedDiscRepresentation_generator 3 orderThreeDiscRotationData
 
 @[simp]
 public theorem orderFourDiscRepresentation_generator :
     orderFourDiscRepresentation (cyclicGenerator 4) = orderFourDiscRotation :=
-  cyclicRepresentation_generator 4 orderFourDiscRotation orderFourDiscRotation_pow
+  indexedDiscRepresentation_generator 4 orderFourDiscRotationData
 
 /-- The order-three Cayley coordinate intertwines the Fuchsian stabilizer generator with the
 local cyclic disc representation. -/
@@ -397,45 +435,65 @@ public structure EllipticFiberData (m : ℕ) [NeZero m]
     ((∃ x : Torus, (affineEquiv automorphism translation ^ k) x = x) ↔
       (m : ℤ) ∣ (k : ℤ) * gamma translationVector)
 
+/-! Assemble the common elliptic action record from the genuinely varying base and fibre data. -/
+public structure IndexedBaseActionData (m : ℕ) [NeZero m] (Base : Type*) where
+  rotation : Equiv.Perm Base
+  center : Base
+  offCenter : Base
+  offCenter_ne : offCenter ≠ center
+  rotation_pow : rotation ^ m = 1
+  rotation_fixed_iff : ∀ k, 0 < k → k < m → ∀ z,
+    (rotation ^ k) z = z ↔ z = center
+
+@[expose] public def assembleEllipticActionData
+    {m : ℕ} [NeZero m] {Base Torus : Type*} [AddCommGroup Torus]
+    (B : IndexedBaseActionData m Base) (D : EllipticFiberData m Torus) :
+    EllipticActionData m Base Torus where
+  rotation := B.rotation
+  center := B.center
+  offCenter := B.offCenter
+  offCenter_ne := B.offCenter_ne
+  rotation_pow := B.rotation_pow
+  rotation_fixed_iff := B.rotation_fixed_iff
+  automorphism := D.automorphism
+  translation := D.translation
+  translationVector := D.translationVector
+  translation_fixed := D.translation_fixed
+  automorphism_pow := D.automorphism_pow
+  translation_torsion := D.translation_torsion
+  fiber_fixed_iff := D.fiber_fixed_iff
+
 namespace EllipticFiberData
 
 variable {Torus : Type*} [AddCommGroup Torus]
 
+public abbrev orderThreeBaseActionData : IndexedBaseActionData 3 ComplexUnitDisc :=
+  { rotation := orderThreeDiscRotation
+    center := discCenter
+    offCenter := discOffCenter
+    offCenter_ne := discOffCenter_ne
+    rotation_pow := orderThreeDiscRotation_pow
+    rotation_fixed_iff := orderThreeDiscRotation_fixed_iff }
+
+public abbrev orderFourBaseActionData : IndexedBaseActionData 4 ComplexUnitDisc :=
+  { rotation := orderFourDiscRotation
+    center := discCenter
+    offCenter := discOffCenter
+    offCenter_ne := discOffCenter_ne
+    rotation_pow := orderFourDiscRotation_pow
+    rotation_fixed_iff := orderFourDiscRotation_fixed_iff }
+
 /-- Complete order-three filling data obtained by adjoining the explicit Cayley-disc base. -/
 @[expose] public noncomputable def orderThreeActionData
     (D : EllipticFiberData 3 Torus) :
-    EllipticActionData 3 ComplexUnitDisc Torus where
-  rotation := orderThreeDiscRotation
-  center := discCenter
-  offCenter := discOffCenter
-  offCenter_ne := discOffCenter_ne
-  rotation_pow := orderThreeDiscRotation_pow
-  rotation_fixed_iff := orderThreeDiscRotation_fixed_iff
-  automorphism := D.automorphism
-  translation := D.translation
-  translationVector := D.translationVector
-  translation_fixed := D.translation_fixed
-  automorphism_pow := D.automorphism_pow
-  translation_torsion := D.translation_torsion
-  fiber_fixed_iff := D.fiber_fixed_iff
+    EllipticActionData 3 ComplexUnitDisc Torus :=
+  assembleEllipticActionData orderThreeBaseActionData D
 
 /-- Complete order-four filling data obtained by adjoining the explicit Cayley-disc base. -/
 @[expose] public noncomputable def orderFourActionData
     (D : EllipticFiberData 4 Torus) :
-    EllipticActionData 4 ComplexUnitDisc Torus where
-  rotation := orderFourDiscRotation
-  center := discCenter
-  offCenter := discOffCenter
-  offCenter_ne := discOffCenter_ne
-  rotation_pow := orderFourDiscRotation_pow
-  rotation_fixed_iff := orderFourDiscRotation_fixed_iff
-  automorphism := D.automorphism
-  translation := D.translation
-  translationVector := D.translationVector
-  translation_fixed := D.translation_fixed
-  automorphism_pow := D.automorphism_pow
-  translation_torsion := D.translation_torsion
-  fiber_fixed_iff := D.fiber_fixed_iff
+    EllipticActionData 4 ComplexUnitDisc Torus :=
+  assembleEllipticActionData orderFourBaseActionData D
 
 /-- The existing order-three filling freeness theorem applies directly to the explicit local
 Cayley base. -/

--- a/SphereSixComplex/Geometry/EllipticPuncturedCollarGaugeHomeomorph.lean
+++ b/SphereSixComplex/Geometry/EllipticPuncturedCollarGaugeHomeomorph.lean
@@ -642,52 +642,68 @@ public theorem orderFourFamilyRadius_linearRepresentation
 @[expose] public noncomputable def orderThreeAffinePuncturedCarrier
     (hsource : U.sourceAction = fuchsianSourceAction) (r : ℝ) :
     InvariantOpenCarrier (orderThreeAffineFamilyAction F) where
-  carrier := orderThreePuncturedFamilyCollar F r
+  toSubMulAction := by
+    letI := orderThreeAffineFamilyAction F
+    exact {
+      carrier := orderThreePuncturedFamilyCollar F r
+      smul_mem' := by
+        intro g q hq
+        change orderThreeAffineFamilyRepresentation F g q ∈
+          orderThreePuncturedFamilyCollar F r
+        exact (orderThreePuncturedFamilyCollar_invariant F hsource r g q).2 hq }
   isOpen_carrier := orderThreePuncturedFamilyCollar_isOpen F r
-  invariant := by
-    intro g q hq
-    rw [actionMap.eq_def]
-    exact (orderThreePuncturedFamilyCollar_invariant F hsource r g q).2 hq
 
 @[expose] public noncomputable def orderFourAffinePuncturedCarrier
     (hsource : U.sourceAction = fuchsianSourceAction) (r : ℝ) :
     InvariantOpenCarrier (orderFourAffineFamilyAction F) where
-  carrier := orderFourPuncturedFamilyCollar F r
+  toSubMulAction := by
+    letI := orderFourAffineFamilyAction F
+    exact {
+      carrier := orderFourPuncturedFamilyCollar F r
+      smul_mem' := by
+        intro g q hq
+        change orderFourAffineFamilyRepresentation F g q ∈
+          orderFourPuncturedFamilyCollar F r
+        exact (orderFourPuncturedFamilyCollar_invariant F hsource r g q).2 hq }
   isOpen_carrier := orderFourPuncturedFamilyCollar_isOpen F r
-  invariant := by
-    intro g q hq
-    rw [actionMap.eq_def]
-    exact (orderFourPuncturedFamilyCollar_invariant F hsource r g q).2 hq
 
 @[expose] public noncomputable def orderThreeLinearPuncturedCarrier
     (hsource : U.sourceAction = fuchsianSourceAction) (r : ℝ) :
     InvariantOpenCarrier (orderThreeLinearFamilyAction F) where
-  carrier := orderThreePuncturedFamilyCollar F r
+  toSubMulAction := by
+    letI := orderThreeLinearFamilyAction F
+    exact {
+      carrier := orderThreePuncturedFamilyCollar F r
+      smul_mem' := by
+        intro g q hq
+        have hr : orderThreeFamilyRadius F
+          (orderThreeFamilyRepresentation F g q) =
+          orderThreeFamilyRadius F q := by
+          exact orderThreeFamilyRadius_linearRepresentation F hsource g q
+        change 0 < orderThreeFamilyRadius F (orderThreeFamilyRepresentation F g q) ∧
+          orderThreeFamilyRadius F (orderThreeFamilyRepresentation F g q) < r
+        rw [hr]
+        exact hq }
   isOpen_carrier := orderThreePuncturedFamilyCollar_isOpen F r
-  invariant := by
-    intro g q hq
-    have hr : orderThreeFamilyRadius F
-        (actionMap (orderThreeLinearFamilyAction F) g q) =
-      orderThreeFamilyRadius F q := by
-      rw [actionMap.eq_def]
-      change orderThreeFamilyRadius F (orderThreeFamilyRepresentation F g q) = _
-      exact orderThreeFamilyRadius_linearRepresentation F hsource g q
-    simpa only [orderThreePuncturedFamilyCollar.eq_def, Set.mem_ofPred_eq, hr] using hq
 
 @[expose] public noncomputable def orderFourLinearPuncturedCarrier
     (hsource : U.sourceAction = fuchsianSourceAction) (r : ℝ) :
     InvariantOpenCarrier (orderFourLinearFamilyAction F) where
-  carrier := orderFourPuncturedFamilyCollar F r
+  toSubMulAction := by
+    letI := orderFourLinearFamilyAction F
+    exact {
+      carrier := orderFourPuncturedFamilyCollar F r
+      smul_mem' := by
+        intro g q hq
+        have hr : orderFourFamilyRadius F
+          (orderFourFamilyRepresentation F g q) =
+          orderFourFamilyRadius F q := by
+          exact orderFourFamilyRadius_linearRepresentation F hsource g q
+        change 0 < orderFourFamilyRadius F (orderFourFamilyRepresentation F g q) ∧
+          orderFourFamilyRadius F (orderFourFamilyRepresentation F g q) < r
+        rw [hr]
+        exact hq }
   isOpen_carrier := orderFourPuncturedFamilyCollar_isOpen F r
-  invariant := by
-    intro g q hq
-    have hr : orderFourFamilyRadius F
-        (actionMap (orderFourLinearFamilyAction F) g q) =
-      orderFourFamilyRadius F q := by
-      rw [actionMap.eq_def]
-      change orderFourFamilyRadius F (orderFourFamilyRepresentation F g q) = _
-      exact orderFourFamilyRadius_linearRepresentation F hsource g q
-    simpa only [orderFourPuncturedFamilyCollar.eq_def, Set.mem_ofPred_eq, hr] using hq
 
 public theorem orderThreePrincipalGauge_generator
     (hsource : U.sourceAction = fuchsianSourceAction) (r : ℝ)

--- a/SphereSixComplex/Geometry/EquivariantQuotientHomeomorph.lean
+++ b/SphereSixComplex/Geometry/EquivariantQuotientHomeomorph.lean
@@ -67,22 +67,41 @@ public theorem orbitQuotientHomeomorph_mk
 
 /-- An open carrier invariant under an explicitly supplied action. -/
 public structure InvariantOpenCarrier (A : MulAction G X) where
-  carrier : Set X
-  isOpen_carrier : IsOpen carrier
-  invariant : ∀ (g : G), MapsTo (actionMap A g) carrier carrier
+  toSubMulAction : letI := A; SubMulAction G X
+  isOpen_carrier : IsOpen (toSubMulAction : Set X)
+
+/-- The underlying carrier, retained as compatibility API for the open-carrier wrapper. -/
+public abbrev InvariantOpenCarrier.carrier
+    {A : MulAction G X} (S : InvariantOpenCarrier A) : Set X :=
+  letI := A
+  S.toSubMulAction.carrier
+
+omit [MulAction G X] in
+/-- Invariance of the underlying carrier, retained as compatibility API. -/
+public theorem InvariantOpenCarrier.invariant
+    {A : MulAction G X} (S : InvariantOpenCarrier A) :
+    ∀ (g : G), MapsTo (actionMap A g) S.carrier S.carrier := by
+  intro g x hx
+  exact S.toSubMulAction.smul_mem' g hx
 
 /-- The action restricted to an invariant open carrier. -/
+@[expose, instance_reducible] public def restrictedMulAction
+  (A : MulAction G X) (S : InvariantOpenCarrier A) : MulAction G S.carrier := by
+  letI := A
+  exact S.toSubMulAction.mulAction
+
 @[expose] public def restrictedActionMap
     {A : MulAction G X} (S : InvariantOpenCarrier A)
     (g : G) (x : S.carrier) : S.carrier :=
-  ⟨actionMap A g x, S.invariant g x.property⟩
+  letI := restrictedMulAction A S
+  g • x
 
 omit [MulAction G X] in
+@[simp]
 public theorem restrictedActionMap_one
     {A : MulAction G X} (S : InvariantOpenCarrier A) (x : S.carrier) :
     restrictedActionMap S 1 x = x := by
-  apply Subtype.ext
-  simp [restrictedActionMap, actionMap]
+  exact (restrictedMulAction A S).one_smul x
 
 omit [MulAction G X] in
 public theorem restrictedActionMap_mul
@@ -90,15 +109,7 @@ public theorem restrictedActionMap_mul
     (g h : G) (x : S.carrier) :
     restrictedActionMap S (g * h) x =
       restrictedActionMap S g (restrictedActionMap S h x) := by
-  apply Subtype.ext
-  simp [restrictedActionMap, actionMap, mul_smul]
-
-@[expose, instance_reducible]
-public def restrictedMulAction (A : MulAction G X) (S : InvariantOpenCarrier A) :
-    MulAction G S.carrier where
-  smul := restrictedActionMap S
-  one_smul := restrictedActionMap_one S
-  mul_smul := restrictedActionMap_mul S
+  exact (restrictedMulAction A S).mul_smul g h x
 
 /-- The orbit relation of the action restricted to an invariant carrier. -/
 @[expose] public def restrictedOrbitRel

--- a/SphereSixComplex/Geometry/PaperAnalyticFillingPieces.lean
+++ b/SphereSixComplex/Geometry/PaperAnalyticFillingPieces.lean
@@ -59,41 +59,55 @@ public theorem restrictedContinuousConstSMul
   exact ⟨fun g => Continuous.subtype_mk
     ((continuous_const_smul g).comp continuous_subtype_val) _⟩
 
+/-! The radial open set used by every indexed elliptic filling. -/
+public abbrev indexedFillingOpen {X : Type*} [TopologicalSpace X]
+    (radius : X → ℝ) (hradius : Continuous radius) (r : ℝ) :
+    TopologicalSpace.Opens X :=
+  ⟨{q | radius q < r}, isOpen_lt hradius continuous_const⟩
+
 namespace PaperAnalyticData
 
 variable (A : PaperAnalyticData)
 
 @[expose] public noncomputable def orderThreeFillingOpen (r : ℝ) :
     TopologicalSpace.Opens (TotalSpace (parameterMap A.periods)) :=
-  ⟨{q | orderThreeFamilyRadius A.periods q < r},
-    isOpen_lt (orderThreeFamilyRadius_continuous A.periods) continuous_const⟩
+  indexedFillingOpen (orderThreeFamilyRadius A.periods)
+    (orderThreeFamilyRadius_continuous A.periods) r
 
 @[expose] public noncomputable def orderFourFillingOpen (r : ℝ) :
     TopologicalSpace.Opens (TotalSpace (parameterMap A.periods)) :=
-  ⟨{q | orderFourFamilyRadius A.periods q < r},
-    isOpen_lt (orderFourFamilyRadius_continuous A.periods) continuous_const⟩
+  indexedFillingOpen (orderFourFamilyRadius A.periods)
+    (orderFourFamilyRadius_continuous A.periods) r
 
 @[expose] public noncomputable def orderThreeFillingCarrier (r : ℝ) :
     InvariantOpenCarrier (orderThreeAffineFamilyAction A.periods) where
-  carrier := A.orderThreeFillingOpen r
+  toSubMulAction := by
+    letI := orderThreeAffineFamilyAction A.periods
+    exact {
+      carrier := A.orderThreeFillingOpen r
+      smul_mem' := by
+        intro g q hq
+        change orderThreeFamilyRadius A.periods
+          (orderThreeAffineFamilyRepresentation A.periods g q) < r
+        rw [orderThreeFamilyRadius_representation A.periods
+          A.modular.modularParameter.toTriangleUniformization_sourceAction]
+        exact hq }
   isOpen_carrier := (A.orderThreeFillingOpen r).2
-  invariant g q hq := by
-    change orderThreeFamilyRadius A.periods
-      (orderThreeAffineFamilyRepresentation A.periods g q) < r
-    rw [orderThreeFamilyRadius_representation A.periods
-      A.modular.modularParameter.toTriangleUniformization_sourceAction]
-    exact hq
 
 @[expose] public noncomputable def orderFourFillingCarrier (r : ℝ) :
     InvariantOpenCarrier (orderFourAffineFamilyAction A.periods) where
-  carrier := A.orderFourFillingOpen r
+  toSubMulAction := by
+    letI := orderFourAffineFamilyAction A.periods
+    exact {
+      carrier := A.orderFourFillingOpen r
+      smul_mem' := by
+        intro g q hq
+        change orderFourFamilyRadius A.periods
+          (orderFourAffineFamilyRepresentation A.periods g q) < r
+        rw [orderFourFamilyRadius_representation A.periods
+          A.modular.modularParameter.toTriangleUniformization_sourceAction]
+        exact hq }
   isOpen_carrier := (A.orderFourFillingOpen r).2
-  invariant g q hq := by
-    change orderFourFamilyRadius A.periods
-      (orderFourAffineFamilyRepresentation A.periods g q) < r
-    rw [orderFourFamilyRadius_representation A.periods
-      A.modular.modularParameter.toTriangleUniformization_sourceAction]
-    exact hq
 
 @[expose, instance_reducible]
 public noncomputable def orderThreeFillingAction (r : ℝ) :
@@ -772,43 +786,53 @@ public theorem orderFourPuncturedCollarToCentralFamily_isOpenEmbedding
       A.modular.modularParameter.toTriangleUniformization_sourceAction)
     A.modular.modularParameter.toTriangleUniformization_sourceAction D
 
-public structure OrderThreeFillingPiece where
-  radius : ℝ
-  radius_pos : 0 < radius
-  radius_lt_one : radius < 1
-  sourceData : OrderThreeLinearCollarSourceData
-    (U := A.modular.modularParameter.toTriangleUniformization) radius
+/-! A filling piece only varies in its radius and in the source-side separation proof.  This
+indexed record is shared by the two elliptic orders; the order-specific names below are aliases
+kept for the paper-facing API. -/
 
-public structure OrderFourFillingPiece where
+public structure IndexedFillingPiece (SourceData : ℝ → Prop) where
   radius : ℝ
   radius_pos : 0 < radius
   radius_lt_one : radius < 1
-  sourceData : OrderFourLinearCollarSourceData
-    (U := A.modular.modularParameter.toTriangleUniformization) radius
+  sourceData : SourceData radius
+
+/-- A monotone source collar yields filling pieces of every positive smaller radius. -/
+public theorem exists_indexedFillingPiece_below
+    {SourceData : ℝ → Prop}
+    (hExists : Nonempty (IndexedFillingPiece SourceData))
+    (hmono : ∀ {r' r : ℝ}, r' ≤ r → SourceData r → SourceData r')
+    {R : ℝ} (hR : 0 < R) :
+    ∃ P : IndexedFillingPiece SourceData, P.radius < R := by
+  obtain ⟨P⟩ := hExists
+  let r := min P.radius (R / 2)
+  have hr : 0 < r := lt_min P.radius_pos (half_pos hR)
+  have hrr : r ≤ P.radius := min_le_left _ _
+  have hrR : r < R := (min_le_right _ _).trans_lt (half_lt_self hR)
+  exact ⟨⟨r, hr, hrr.trans_lt P.radius_lt_one, hmono hrr P.sourceData⟩, hrR⟩
+
+public abbrev OrderThreeFillingPiece :=
+  IndexedFillingPiece (fun r => OrderThreeLinearCollarSourceData
+    (U := A.modular.modularParameter.toTriangleUniformization) r)
+
+public abbrev OrderFourFillingPiece :=
+  IndexedFillingPiece (fun r => OrderFourLinearCollarSourceData
+    (U := A.modular.modularParameter.toTriangleUniformization) r)
 
 public theorem orderThreeLinearCollarSourceData_mono {r' r : ℝ} (hrr : r' ≤ r)
     (D : OrderThreeLinearCollarSourceData
       (U := A.modular.modularParameter.toTriangleUniformization) r) :
     OrderThreeLinearCollarSourceData
-      (U := A.modular.modularParameter.toTriangleUniformization) r' := by
-  rw [OrderThreeLinearCollarSourceData.eq_def] at D ⊢
-  constructor
-  · intro z hz hzr
-    exact D.1 z hz (hzr.trans_le hrr)
-  · intro z x hzr hxr g hg
-    exact D.2 z x (hzr.trans_le hrr) (hxr.trans_le hrr) g hg
+      (U := A.modular.modularParameter.toTriangleUniformization) r' :=
+  linearCollarSourceData_mono (U := A.modular.modularParameter.toTriangleUniformization)
+    3 (M := orderThreeLinearCollarModel) hrr D
 
 public theorem orderFourLinearCollarSourceData_mono {r' r : ℝ} (hrr : r' ≤ r)
     (D : OrderFourLinearCollarSourceData
       (U := A.modular.modularParameter.toTriangleUniformization) r) :
     OrderFourLinearCollarSourceData
-      (U := A.modular.modularParameter.toTriangleUniformization) r' := by
-  rw [OrderFourLinearCollarSourceData.eq_def] at D ⊢
-  constructor
-  · intro z hz hzr
-    exact D.1 z hz (hzr.trans_le hrr)
-  · intro z x hzr hxr g hg
-    exact D.2 z x (hzr.trans_le hrr) (hxr.trans_le hrr) g hg
+      (U := A.modular.modularParameter.toTriangleUniformization) r' :=
+  linearCollarSourceData_mono (U := A.modular.modularParameter.toTriangleUniformization)
+    4 (M := orderFourLinearCollarModel) hrr D
 
 public theorem exists_orderThreeFillingPiece : Nonempty A.OrderThreeFillingPiece := by
   obtain ⟨r, hr, hr1, D⟩ := exists_orderThreeLinearCollarSourceData
@@ -825,24 +849,14 @@ public theorem exists_orderFourFillingPiece : Nonempty A.OrderFourFillingPiece :
   exact ⟨⟨r, hr, hr1, D⟩⟩
 
 public theorem exists_orderThreeFillingPiece_below {R : ℝ} (hR : 0 < R) :
-    ∃ P : A.OrderThreeFillingPiece, P.radius < R := by
-  obtain ⟨P⟩ := A.exists_orderThreeFillingPiece
-  let r := min P.radius (R / 2)
-  have hr : 0 < r := lt_min P.radius_pos (half_pos hR)
-  have hrr : r ≤ P.radius := min_le_left _ _
-  have hrR : r < R := (min_le_right _ _).trans_lt (half_lt_self hR)
-  exact ⟨⟨r, hr, hrr.trans_lt P.radius_lt_one,
-    A.orderThreeLinearCollarSourceData_mono hrr P.sourceData⟩, hrR⟩
+    ∃ P : A.OrderThreeFillingPiece, P.radius < R :=
+  exists_indexedFillingPiece_below A.exists_orderThreeFillingPiece
+    (fun hrr D => A.orderThreeLinearCollarSourceData_mono hrr D) hR
 
 public theorem exists_orderFourFillingPiece_below {R : ℝ} (hR : 0 < R) :
-    ∃ P : A.OrderFourFillingPiece, P.radius < R := by
-  obtain ⟨P⟩ := A.exists_orderFourFillingPiece
-  let r := min P.radius (R / 2)
-  have hr : 0 < r := lt_min P.radius_pos (half_pos hR)
-  have hrr : r ≤ P.radius := min_le_left _ _
-  have hrR : r < R := (min_le_right _ _).trans_lt (half_lt_self hR)
-  exact ⟨⟨r, hr, hrr.trans_lt P.radius_lt_one,
-    A.orderFourLinearCollarSourceData_mono hrr P.sourceData⟩, hrR⟩
+    ∃ P : A.OrderFourFillingPiece, P.radius < R :=
+  exists_indexedFillingPiece_below A.exists_orderFourFillingPiece
+    (fun hrr D => A.orderFourLinearCollarSourceData_mono hrr D) hR
 
 @[expose] public noncomputable def orderThreeFillingPiece : A.OrderThreeFillingPiece :=
   Classical.choice A.exists_orderThreeFillingPiece

--- a/SphereSixComplex/Topology/BoundarySevenCechOrderedLocalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenCechOrderedLocalComparison.lean
@@ -113,15 +113,15 @@ public noncomputable def boundarySevenProperCechTupleCoordinatePoint
 
 /-- In barycentric coordinates, realizing the common-face inclusion is the literal insertion
 of the complementary coordinates. -/
-public theorem boundarySevenComparisonToStdSimplex_faceToBoundary_faceIso
+public theorem boundarySevenRealizationToStdSimplex_faceToBoundary_faceIso
     {n : SimplexCategoryᵒᵖ} (a : BoundarySevenProperCechTuple n)
     (x : SSet.toTop.obj
       (Δ[boundarySevenProperCechTupleFaceDimension a] : SSet.{0})) :
-    boundarySevenComparisonToStdSimplex
+    boundarySevenRealizationToStdSimplex
         (SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a)
           (SSet.toTop.map (boundarySevenProperCechTupleFaceIso a).hom x)) =
       boundarySevenProperCechTupleCoordinatePoint a x := by
-  unfold boundarySevenComparisonToStdSimplex
+  unfold boundarySevenRealizationToStdSimplex
   change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
       (SSet.toTop.map (SSet.boundary 7).ι
         (SSet.toTop.map (boundarySevenProperCechTupleFaceToBoundarySSetMap a)
@@ -179,7 +179,7 @@ public noncomputable def boundarySevenProperCechTupleStandardSimplexToIntersecti
     rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
     intro i hi
     have hcoord :
-        boundarySevenComparisonToStdSimplex
+        boundarySevenRealizationToStdSimplex
             (boundarySevenRealizationHomeomorphStandardBoundary.symm (q x)) i = 0 := by
       rw [← boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
       rw [Homeomorph.apply_symm_apply]
@@ -250,7 +250,7 @@ public theorem boundarySevenProperCechTupleFaceToIntersection_comp_ambientInclus
         (boundarySevenProperCechTupleFaceToBoundarySSetMap a) x) :
           stdSimplex ℝ (Fin 8))
   rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
-  rw [← boundarySevenComparisonToStdSimplex_faceToBoundary_faceIso a
+  rw [← boundarySevenRealizationToStdSimplex_faceToBoundary_faceIso a
     (SSet.toTop.map J.inv x)]
   congr 2
   rw [← ConcreteCategory.comp_apply, ← SSet.toTop.map_comp,

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodComparison.lean
@@ -37,7 +37,7 @@ public def boundarySevenFaceNeighborhoodIntersection (s : Finset (Fin 8)) :
 public theorem mem_boundarySevenFaceNeighborhoodIntersection_iff
     (s : Finset (Fin 8)) (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
     x ∈ boundarySevenFaceNeighborhoodIntersection s ↔
-      ∀ i ∈ s, boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8 := by
+      ∀ i ∈ s, boundarySevenRealizationToStdSimplex x i < (1 : ℝ) / 8 := by
   simp [boundarySevenFaceNeighborhoodIntersection,
     boundarySevenComparisonFaceNeighborhood]
 
@@ -56,7 +56,7 @@ public theorem boundarySevenFaceNeighborhoodIntersection_univ_eq_empty :
   have hcoord :=
     (mem_boundarySevenFaceNeighborhoodIntersection_iff Finset.univ x).mp hx
   have hsum :
-      ∑ i : Fin 8, boundarySevenComparisonToStdSimplex x i <
+      ∑ i : Fin 8, boundarySevenRealizationToStdSimplex x i <
         ∑ _i : Fin 8, (1 : ℝ) / 8 := by
     apply Finset.sum_lt_sum
     · intro i _
@@ -107,7 +107,7 @@ public theorem boundarySevenComparisonMapLandsInAffineBoundary :
   intro x
   obtain ⟨i, y, rfl⟩ := boundarySevenRealization_exists_face_representation x
   refine ⟨i, ?_⟩
-  rw [boundarySevenComparisonToStdSimplex_face]
+  rw [boundarySevenRealizationToStdSimplex_face]
   classical
   simp only [stdSimplex.map_coe, FunOnFinite.linearMap_apply_apply]
   apply Finset.sum_eq_zero

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodDeformation.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodDeformation.lean
@@ -328,7 +328,7 @@ public noncomputable def boundarySevenRealizationHomeomorphStandardBoundary :
 public theorem boundarySevenRealizationHomeomorphStandardBoundary_apply_val
     (x : SSet.toTop.obj (∂Δ[7] : SSet.{0})) :
     (boundarySevenRealizationHomeomorphStandardBoundary x :
-        stdSimplex ℝ (Fin 8)) = boundarySevenComparisonToStdSimplex x :=
+        stdSimplex ℝ (Fin 8)) = boundarySevenRealizationToStdSimplex x :=
   rfl
 
 /-- The actual realization face neighbourhood is homeomorphic to its ordinary barycentric
@@ -338,7 +338,7 @@ public noncomputable def boundarySevenFaceNeighborhoodHomeomorphStandard
     boundarySevenComparisonFaceNeighborhood i ≃ₜ
       standardBoundarySevenFaceNeighborhood i :=
   boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
-    change boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8 ↔
+    change boundarySevenRealizationToStdSimplex x i < (1 : ℝ) / 8 ↔
       (boundarySevenRealizationHomeomorphStandardBoundary x :
         stdSimplex ℝ (Fin 8)) i < (1 : ℝ) / 8
     rw [boundarySevenRealizationHomeomorphStandardBoundary_apply_val]
@@ -362,11 +362,11 @@ public theorem boundarySevenFaceNeighborhoodHomeomorphStandard_comp_face
   intro y
   apply Subtype.ext
   apply Subtype.ext
-  change boundarySevenComparisonToStdSimplex
+  change boundarySevenRealizationToStdSimplex
       (SSet.toTop.map (SSet.boundary.ι i) y) =
     stdSimplex.map i.succAbove
       (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) y)
-  exact boundarySevenComparisonToStdSimplex_face i y
+  exact boundarySevenRealizationToStdSimplex_face i y
 
 /-- Every canonical realized face is a homotopy equivalence onto its open affine
 neighbourhood. -/

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersections.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodIntersections.lean
@@ -549,7 +549,7 @@ public theorem standardBoundarySevenFaceNeighborhoodIntersection_pathConnectedSp
 /-- The common affine face inside the geometric realization. -/
 public def boundarySevenAffineFaceIntersection (s : Finset (Fin 8)) :
     Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
-  {x | ∀ i ∈ s, boundarySevenComparisonToStdSimplex x i = 0}
+  {x | ∀ i ∈ s, boundarySevenRealizationToStdSimplex x i = 0}
 
 /-- The canonical barycentric homeomorphism restricted to an intersection of face
 neighbourhoods. -/
@@ -559,7 +559,7 @@ public noncomputable def boundarySevenFaceNeighborhoodIntersectionHomeomorphStan
       standardBoundarySevenFaceNeighborhoodIntersection s :=
   boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
     rw [mem_boundarySevenFaceNeighborhoodIntersection_iff]
-    change (∀ i ∈ s, boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8) ↔
+    change (∀ i ∈ s, boundarySevenRealizationToStdSimplex x i < (1 : ℝ) / 8) ↔
       ∀ i ∈ s,
         (boundarySevenRealizationHomeomorphStandardBoundary x :
           stdSimplex ℝ (Fin 8)) i < (1 : ℝ) / 8
@@ -570,7 +570,7 @@ public noncomputable def boundarySevenAffineFaceIntersectionHomeomorphStandard
     (s : Finset (Fin 8)) :
     boundarySevenAffineFaceIntersection s ≃ₜ standardBoundarySevenAffineFace s :=
   boundarySevenRealizationHomeomorphStandardBoundary.subtype fun x ↦ by
-    change (∀ i ∈ s, boundarySevenComparisonToStdSimplex x i = 0) ↔
+    change (∀ i ∈ s, boundarySevenRealizationToStdSimplex x i = 0) ↔
       ∀ i ∈ s,
         (boundarySevenRealizationHomeomorphStandardBoundary x :
           stdSimplex ℝ (Fin 8)) i = 0

--- a/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodLocalComparison.lean
+++ b/SphereSixComplex/Topology/BoundarySevenFaceNeighborhoodLocalComparison.lean
@@ -64,7 +64,8 @@ public theorem boundarySevenFaceNeighborhoodLocalIntegralComparison_quasiIso
   let hstandard : QuasiIso
       (simplicialToRealizationSingularChainMap
         (Δ[6] : SSet.{0}) (AddCommGrpCat.of ℤ)) :=
-    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso 6
+    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso
+      (AddCommGrpCat.of ℤ) 6
   let hneighborhood : QuasiIso
       (boundarySevenFaceNeighborhoodIntegralSingularChainMap i) :=
     boundarySevenFaceNeighborhoodIntegralSingularChainMap_quasiIso i

--- a/SphereSixComplex/Topology/BoundarySevenRealization.lean
+++ b/SphereSixComplex/Topology/BoundarySevenRealization.lean
@@ -1,5 +1,6 @@
 module
 
+public import SphereSixComplex.Topology.BoundarySevenStandardSimplexMap
 public import SphereSixComplex.Topology.SimplicialSingularComparison
 public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits
 public import Mathlib.Analysis.Convex.GaugeRescale
@@ -26,31 +27,6 @@ namespace SphereSixComplex
 /-- The ordinary boundary of a standard simplex: at least one barycentric coordinate vanishes. -/
 public abbrev StandardSimplexBoundary (n : ℕ) :=
   {w : stdSimplex ℝ (Fin (n + 1)) // ∃ i, w i = 0}
-
-/-- The canonical map from realization of the simplicial boundary into the ordinary standard
-seven-simplex. -/
-public noncomputable def boundarySevenRealizationToStdSimplex :
-    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
-  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
-      (SSet.toTop.map (SSet.boundary 7).ι x),
-    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
-      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
-
-/-- On each simplicial face, the canonical realization map is the usual affine face inclusion. -/
-public theorem boundarySevenRealizationToStdSimplex_face
-    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
-    boundarySevenRealizationToStdSimplex
-        (SSet.toTop.map (SSet.boundary.ι i) x) =
-      stdSimplex.map i.succAbove
-        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
-  unfold boundarySevenRealizationToStdSimplex
-  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
-      (SSet.toTop.map (SSet.boundary 7).ι
-        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
-  rw [← ConcreteCategory.comp_apply]
-  rw [← SSet.toTop.map_comp]
-  rw [SSet.boundary.ι_ι]
-  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
 
 /-- The ordinary affine inclusion of a codimension-one face lands in the topological boundary. -/
 public noncomputable def standardSimplexFaceToBoundary

--- a/SphereSixComplex/Topology/BoundarySevenStandardSimplexMap.lean
+++ b/SphereSixComplex/Topology/BoundarySevenStandardSimplexMap.lean
@@ -1,0 +1,47 @@
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.Boundary
+public import Mathlib.AlgebraicTopology.SimplicialSet.TopAdj
+
+/-!
+# The canonical affine map from the simplicial boundary to a standard simplex
+
+This is the elementary realization map used by both the geometric identification and the
+simplicial--singular comparison argument.  Keeping it in this low-level module avoids making
+either argument depend on the other.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open CategoryTheory CategoryTheory.Limits Set Simplicial
+
+namespace SphereSixComplex
+
+/-- The canonical map from realization of the simplicial boundary into the ordinary standard
+seven-simplex. -/
+public noncomputable def boundarySevenRealizationToStdSimplex :
+    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
+  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι x),
+    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
+      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
+
+/-- On each simplicial face, the canonical realization map is the usual affine face inclusion. -/
+public theorem boundarySevenRealizationToStdSimplex_face
+    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
+    boundarySevenRealizationToStdSimplex
+        (SSet.toTop.map (SSet.boundary.ι i) x) =
+      stdSimplex.map i.succAbove
+        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
+  unfold boundarySevenRealizationToStdSimplex
+  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
+      (SSet.toTop.map (SSet.boundary 7).ι
+        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
+  rw [← ConcreteCategory.comp_apply]
+  rw [← SSet.toTop.map_comp]
+  rw [SSet.boundary.ι_ι]
+  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
+
+end SphereSixComplex

--- a/SphereSixComplex/Topology/ContractibleSingularMapQuasiIso.lean
+++ b/SphereSixComplex/Topology/ContractibleSingularMapQuasiIso.lean
@@ -1,6 +1,6 @@
 module
 
-public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparisonGeneral
+public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularComparison
 public import Mathlib.AlgebraicTopology.SingularHomology.HomotopyInvariance
 
 /-!
@@ -88,7 +88,7 @@ public theorem standardSimplexToContractibleSingularChainMap_quasiIso
     standardSimplexRealization_contractibleSpace n
   let hstandard : QuasiIso
       (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) :=
-    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso_general R n
+    standardSimplex_simplicialToRealizationSingularChainMap_quasiIso R n
   let htarget : QuasiIso
       (SSet.chainComplexMap (TopCat.toSSet.map (TopCat.ofHom f)) R) :=
     singularChainMap_quasiIso_of_contractibleSpaces R f

--- a/SphereSixComplex/Topology/SimplicialSingularComparisonProof.lean
+++ b/SphereSixComplex/Topology/SimplicialSingularComparisonProof.lean
@@ -1,6 +1,7 @@
 module
 
 public import SphereSixComplex.Topology.SimplicialSingularComparison
+public import SphereSixComplex.Topology.BoundarySevenStandardSimplexMap
 public import SphereSixComplex.Topology.SingularExcisionOpenCover
 
 /-!
@@ -107,44 +108,18 @@ public theorem simplicialToSingularComparisonQuasiIsomorphism_iff_coverSmallLift
   rw [← simplicialToCoverSmallSingularChainMap_comp_inclusion K U hsmall]
   exact quasiIso_iff_comp_right _ _ (hφ' := hcover)
 
-/-- The canonical map from the boundary realization to the ordinary affine standard
-seven-simplex, duplicated here so that the comparison proof is independent of any later geometric
-identification of the boundary realization. -/
-public noncomputable def boundarySevenComparisonToStdSimplex :
-    C((SSet.toTop.obj (∂Δ[7] : SSet.{0}) : Type), stdSimplex ℝ (Fin 8)) :=
-  ⟨fun x ↦ SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
-      (SSet.toTop.map (SSet.boundary 7).ι x),
-    (SimplexCategory.toTopHomeo (SimplexCategory.mk 7)).continuous.comp
-      (SSet.toTop.map (SSet.boundary 7).ι).hom.continuous⟩
-
-/-- On a codimension-one face, the comparison map is the usual affine face inclusion. -/
-public theorem boundarySevenComparisonToStdSimplex_face
-    (i : Fin 8) (x : (SSet.toTop.obj (Δ[6] : SSet.{0}) : Type)) :
-    boundarySevenComparisonToStdSimplex
-        (SSet.toTop.map (SSet.boundary.ι i) x) =
-      stdSimplex.map i.succAbove
-        (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) := by
-  unfold boundarySevenComparisonToStdSimplex
-  change SimplexCategory.toTopHomeo (SimplexCategory.mk 7)
-      (SSet.toTop.map (SSet.boundary 7).ι
-        (SSet.toTop.map (SSet.boundary.ι i) x)) = _
-  rw [← ConcreteCategory.comp_apply]
-  rw [← SSet.toTop.map_comp]
-  rw [SSet.boundary.ι_ι]
-  exact SimplexCategory.toTopHomeo_naturality_apply (SimplexCategory.δ i) x
-
 /-- An open neighborhood of the `i`-th affine face, pulled back to the realization of
 `∂Δ[7]`. -/
 public def boundarySevenComparisonFaceNeighborhood (i : Fin 8) :
     Set (SSet.toTop.obj (∂Δ[7] : SSet.{0})) :=
-  {x | boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8}
+  {x | boundarySevenRealizationToStdSimplex x i < (1 : ℝ) / 8}
 
 /-- The affine face neighborhoods are open. -/
 public theorem boundarySevenComparisonFaceNeighborhood_isOpen (i : Fin 8) :
     IsOpen (boundarySevenComparisonFaceNeighborhood i) := by
   apply isOpen_lt
   · exact ((continuous_apply i).comp continuous_subtype_val).comp
-      boundarySevenComparisonToStdSimplex.continuous
+      boundarySevenRealizationToStdSimplex.continuous
   · exact continuous_const
 
 /-- The realization of the `i`-th simplicial face lands in its corresponding open affine
@@ -155,9 +130,9 @@ public noncomputable def boundarySevenFaceToComparisonFaceNeighborhood (i : Fin 
   refine TopCat.ofHom
     { toFun := fun x ↦ ⟨SSet.toTop.map (SSet.boundary.ι i) x, ?_⟩
       continuous_toFun := ?_ }
-  · change boundarySevenComparisonToStdSimplex
+  · change boundarySevenRealizationToStdSimplex
         (SSet.toTop.map (SSet.boundary.ι i) x) i < (1 : ℝ) / 8
-    rw [boundarySevenComparisonToStdSimplex_face]
+    rw [boundarySevenRealizationToStdSimplex_face]
     change stdSimplex.map i.succAbove
       (SimplexCategory.toTopHomeo (SimplexCategory.mk 6) x) i < (1 : ℝ) / 8
     have hz : stdSimplex.map i.succAbove
@@ -241,7 +216,7 @@ neighborhoods cover the whole realization.  It states precisely that the compari
 realized simplicial boundary lands in the affine boundary. -/
 public def BoundarySevenComparisonMapLandsInAffineBoundary : Prop :=
   ∀ x : SSet.toTop.obj (∂Δ[7] : SSet.{0}),
-    ∃ i : Fin 8, boundarySevenComparisonToStdSimplex x i = 0
+    ∃ i : Fin 8, boundarySevenRealizationToStdSimplex x i = 0
 
 /-- If the comparison map lands in the affine boundary, the eight explicit face neighborhoods
 cover the realization. -/
@@ -253,7 +228,7 @@ public theorem boundarySevenComparisonFaceNeighborhood_iUnion
   obtain ⟨i, hi⟩ := hboundary x
   apply Set.mem_iUnion.2
   refine ⟨i, ?_⟩
-  change boundarySevenComparisonToStdSimplex x i < (1 : ℝ) / 8
+  change boundarySevenRealizationToStdSimplex x i < (1 : ℝ) / 8
   rw [hi]
   norm_num
 

--- a/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparison.lean
+++ b/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparison.lean
@@ -38,11 +38,8 @@ public noncomputable def chainComplexXZeroIsoCyclesZero
 /-- The canonical augmentation on degree-zero simplicial homology is natural in the simplicial
 set.  This is the residual naturality calculation needed in the standard-simplex comparison. -/
 public theorem simplicialHomologyZeroAugmentation_naturality
-    {X Y : SSet.{0}} (f : X ⟶ Y) :
-    SSet.homologyMap f (AddCommGrpCat.of ℤ) 0 ≫
-        Y.homology₀ε (AddCommGrpCat.of ℤ) =
-      X.homology₀ε (AddCommGrpCat.of ℤ) := by
-  let R := AddCommGrpCat.of ℤ
+    {X Y : SSet.{0}} (f : X ⟶ Y) (R : AddCommGrpCat) :
+    SSet.homologyMap f R 0 ≫ Y.homology₀ε R = X.homology₀ε R := by
   let K := X.chainComplex R
   let L := Y.chainComplex R
   let φ := SSet.chainComplexMap f R
@@ -125,7 +122,7 @@ public theorem standardSimplex_isConnected (n : ℕ) :
 public theorem standardSimplexRealization_contractibleSpace (n : ℕ) :
     ContractibleSpace
       (SSet.toTop.obj (SSet.stdSimplex.obj (SimplexCategory.mk n)) : Type) := by
-  letI : ContractibleSpace (stdSimplex ℝ (Fin (n + 1))) :=
+  let : ContractibleSpace (stdSimplex ℝ (Fin (n + 1))) :=
     (convex_stdSimplex ℝ (Fin (n + 1))).contractibleSpace
       ⟨stdSimplex.vertex (0 : Fin (n + 1)),
         (stdSimplex.vertex (0 : Fin (n + 1))).2⟩
@@ -134,10 +131,10 @@ public theorem standardSimplexRealization_contractibleSpace (n : ℕ) :
 /-- Simplicial chains of a standard simplex are exact in every positive degree, by the canonical
 extra degeneracy. -/
 public theorem standardSimplex_simplicialChains_exactAt
-    (n k : ℕ) (hk : k ≠ 0) :
-    ((Δ[n] : SSet.{0}).chainComplex (AddCommGrpCat.of ℤ)).ExactAt k := by
+    (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
+    ((Δ[n] : SSet.{0}).chainComplex R).ExactAt k := by
   let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
-    (SimplexCategory.mk n)).map (sigmaConst.obj (AddCommGrpCat.of ℤ))
+    (SimplexCategory.mk n)).map (sigmaConst.obj R)
   let e := ed.homotopyEquiv
   exact (exactAt_iff_of_quasiIsoAt e.hom k).mpr
     (HomologicalComplex.exactAt_single_obj _ _ _ _ hk)
@@ -145,73 +142,71 @@ public theorem standardSimplex_simplicialChains_exactAt
 /-- Singular chains of the realization of a standard simplex are exact in every positive degree,
 by contractibility and homotopy invariance. -/
 public theorem standardSimplexRealization_singularChains_exactAt
-    (n k : ℕ) (hk : k ≠ 0) :
-    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex
-      (AddCommGrpCat.of ℤ)).ExactAt k := by
-  letI : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
+    (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
+    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex R).ExactAt k := by
+  let : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
     standardSimplexRealization_contractibleSpace n
   obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
     (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type)
   have hunit := AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
-    AddCommGrpCat k (AddCommGrpCat.of ℤ) (TopCat.of Unit) hk
+    AddCommGrpCat k R (TopCat.of Unit) hk
   have hzero := hunit.of_iso (singularHomologyIsoOfHomotopyEquiv
-    (AddCommGrpCat.of ℤ) k e)
+    R k e)
   rw [HomologicalComplex.exactAt_iff_isZero_homology]
   exact hzero
 
 /-- The canonical realization/singular adjunction-unit chain map is a quasi-isomorphism for every
 standard simplex. -/
 public theorem standardSimplex_simplicialToRealizationSingularChainMap_quasiIso
-    (n : ℕ) :
+    (R : AddCommGrpCat) (n : ℕ) :
     QuasiIso (simplicialToRealizationSingularChainMap
-      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)) := by
+      (Δ[n] : SSet.{0}) R) := by
   rw [quasiIso_iff]
   intro k
   by_cases hk : k = 0
   · subst hk
     rw [quasiIsoAt_iff_isIso_homologyMap]
-    letI : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
+    let : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
       standardSimplex_isConnected n
-    letI : ContractibleSpace
+    let : ContractibleSpace
         (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
       standardSimplexRealization_contractibleSpace n
-    letI : PathConnectedSpace
+    let : PathConnectedSpace
         (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) := inferInstance
-    letI : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
+    let : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
       inferInstance
     let φ := simplicialToRealizationSingularChainMap
-      (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ)
+      (Δ[n] : SSet.{0}) R
     have hε : HomologicalComplex.homologyMap φ 0 ≫
         (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
-          (AddCommGrpCat.of ℤ) =
-      (Δ[n] : SSet.{0}).homology₀ε (AddCommGrpCat.of ℤ) := by
+          R = (Δ[n] : SSet.{0}).homology₀ε R := by
       exact simplicialHomologyZeroAugmentation_naturality
-        (sSetTopAdj.unit.app (Δ[n] : SSet.{0}))
-    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε
-        (AddCommGrpCat.of ℤ)) := inferInstance
+        (sSetTopAdj.unit.app (Δ[n] : SSet.{0})) R
+    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε R) := inferInstance
     let htarget : IsIso
         ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
-          (AddCommGrpCat.of ℤ)) :=
+          R) :=
       inferInstanceAs (IsIso ((TopCat.toSSet.obj
-        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε (AddCommGrpCat.of ℤ)))
+        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε R))
     have hcomp : IsIso (HomologicalComplex.homologyMap φ 0 ≫
         (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
-          (AddCommGrpCat.of ℤ)) := by
+          R) := by
       rw [hε]
       exact hsource
     exact @IsIso.of_isIso_comp_right _ _ _ _ _
       (HomologicalComplex.homologyMap φ 0)
       ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε
-        (AddCommGrpCat.of ℤ)) htarget hcomp
+        R) htarget hcomp
   · exact (quasiIsoAt_iff_exactAt _ k
-      (standardSimplex_simplicialChains_exactAt n k hk)).mpr
-        (standardSimplexRealization_singularChains_exactAt n k hk)
+      (standardSimplex_simplicialChains_exactAt R n k hk)).mpr
+        (standardSimplexRealization_singularChains_exactAt R n k hk)
 
 /-- In the terminology used by the project, every standard simplex satisfies the canonical
 integral simplicial--singular comparison. -/
 public theorem standardSimplex_integralComparison (n : ℕ) :
     SimplicialToSingularComparisonQuasiIsomorphism
       (Δ[n] : SSet.{0}) (AddCommGrpCat.of ℤ) :=
-  standardSimplex_simplicialToRealizationSingularChainMap_quasiIso n
+  standardSimplex_simplicialToRealizationSingularChainMap_quasiIso
+    (AddCommGrpCat.of ℤ) n
 
 end SphereSixComplex

--- a/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparisonGeneral.lean
+++ b/SphereSixComplex/Topology/StandardSimplexSimplicialSingularComparisonGeneral.lean
@@ -5,8 +5,8 @@ public import SphereSixComplex.Topology.StandardSimplexSimplicialSingularCompari
 /-!
 # Simplicial--singular comparison for a standard simplex with arbitrary coefficients
 
-The integral proof does not use a special property of `ℤ`.  This file records the coefficient-
-general statement, including the degree-zero augmentation calculation.
+The coefficient-general results live in
+`StandardSimplexSimplicialSingularComparison`; this module is retained as a compatibility import.
 -/
 
 @[expose] public section
@@ -17,117 +17,29 @@ open AlgebraicTopology CategoryTheory CategoryTheory.Limits Simplicial
 
 namespace SphereSixComplex
 
-/-- The degree-zero simplicial augmentation is natural for an arbitrary coefficient object. -/
+/-! The suffixed declarations were part of the original public API of this compatibility module.
+Keep them as thin aliases while the unsuffixed declarations now live in the main module. -/
+
 public theorem simplicialHomologyZeroAugmentation_naturality_general
     {X Y : SSet.{0}} (f : X ⟶ Y) (R : AddCommGrpCat) :
-    SSet.homologyMap f R 0 ≫ Y.homology₀ε R = X.homology₀ε R := by
-  let K := X.chainComplex R
-  let L := Y.chainComplex R
-  let φ := SSet.chainComplexMap f R
-  let e₀ := chainComplexXZeroIsoCyclesZero K
-  apply (cancel_epi (K.homologyπ 0)).1
-  apply (cancel_epi e₀.hom).1
-  apply X.chainComplex_hom_ext
-  intro x
-  change X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫
-      HomologicalComplex.homologyMap φ 0 ≫ Y.homology₀ε R =
-    X.ιChainComplex x ≫ e₀.hom ≫ K.homologyπ 0 ≫ X.homology₀ε R
-  rw [HomologicalComplex.homologyπ_naturality_assoc]
-  change X.ιChainComplex x ≫
-      K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
-        HomologicalComplex.cyclesMap φ 0 ≫ L.homologyπ 0 ≫
-          Y.homology₀ε R =
-    X.ιChainComplex x ≫ K.liftCycles (𝟙 _) 0 (by simp) (by simp) ≫
-      K.homologyπ 0 ≫ X.homology₀ε R
-  simp only [← Category.assoc, HomologicalComplex.comp_liftCycles,
-    Category.comp_id]
-  simp only [HomologicalComplex.liftCycles_comp_cyclesMap]
-  change L.liftCycles
-      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) ≫
-        L.homologyπ 0 ≫ Y.homology₀ε R =
-    K.liftCycles (X.ιChainComplex x) 0 (by simp) (by simp) ≫
-      K.homologyπ 0 ≫ X.homology₀ε R
-  have hlift : L.liftCycles
-      (X.ιChainComplex x ≫ (SSet.chainComplexMap f R).f 0) 0 (by simp) (by simp) =
-      L.liftCycles (Y.ιChainComplex (f.app _ x)) 0 (by simp) (by simp) := by
-    apply (cancel_mono (L.iCycles 0)).1
-    simpa only [HomologicalComplex.liftCycles_i] using
-      SSet.ι_chainComplexMap_f X Y f R x
-  rw [hlift]
-  calc
-    _ = 𝟙 R := by
-      simpa only [] using
-        Y.liftCycles_ιChainComplex_homologyπ_homology₀ε R (f.app _ x)
-    _ = _ := by
-      symm
-      simpa only [] using
-        X.liftCycles_ιChainComplex_homologyπ_homology₀ε R x
+    SSet.homologyMap f R 0 ≫ Y.homology₀ε R = X.homology₀ε R :=
+  simplicialHomologyZeroAugmentation_naturality f R
 
-/-- Simplicial chains of a standard simplex are exact in positive degrees for arbitrary
-coefficients. -/
 public theorem standardSimplex_simplicialChains_exactAt_general
     (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
-    ((Δ[n] : SSet.{0}).chainComplex R).ExactAt k := by
-  let ed := (SSet.Augmented.StandardSimplex.extraDegeneracy
-    (SimplexCategory.mk n)).map (sigmaConst.obj R)
-  let e := ed.homotopyEquiv
-  exact (exactAt_iff_of_quasiIsoAt e.hom k).mpr
-    (HomologicalComplex.exactAt_single_obj _ _ _ _ hk)
+    ((Δ[n] : SSet.{0}).chainComplex R).ExactAt k :=
+  standardSimplex_simplicialChains_exactAt R n k hk
 
-/-- Singular chains of the realization of a standard simplex are exact in positive degrees for
-arbitrary coefficients. -/
 public theorem standardSimplexRealization_singularChains_exactAt_general
     (R : AddCommGrpCat) (n k : ℕ) (hk : k ≠ 0) :
-    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex R).ExactAt k := by
-  letI : ContractibleSpace (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
-    standardSimplexRealization_contractibleSpace n
-  obtain ⟨e⟩ := ContractibleSpace.hequiv_unit
-    (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type)
-  have hunit := AlgebraicTopology.isZero_singularHomologyFunctor_of_totallyDisconnectedSpace
-    AddCommGrpCat k R (TopCat.of Unit) hk
-  have hzero := hunit.of_iso (singularHomologyIsoOfHomotopyEquiv R k e)
-  rw [HomologicalComplex.exactAt_iff_isZero_homology]
-  exact hzero
+    ((TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).chainComplex R).ExactAt k :=
+  standardSimplexRealization_singularChains_exactAt R n k hk
 
-/-- The canonical comparison for a standard simplex is a quasi-isomorphism with every
-coefficient object in `AddCommGrpCat`. -/
 public theorem standardSimplex_simplicialToRealizationSingularChainMap_quasiIso_general
     (R : AddCommGrpCat) (n : ℕ) :
-    QuasiIso (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) := by
-  rw [quasiIso_iff]
-  intro k
-  by_cases hk : k = 0
-  · subst hk
-    rw [quasiIsoAt_iff_isIso_homologyMap]
-    letI : (SSet.stdSimplex.obj (SimplexCategory.mk n)).IsConnected :=
-      standardSimplex_isConnected n
-    letI : ContractibleSpace
-        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) :=
-      standardSimplexRealization_contractibleSpace n
-    letI : PathConnectedSpace
-        (SSet.toTop.obj (Δ[n] : SSet.{0}) : Type) := inferInstance
-    letI : (TopCat.toSSet.obj (SSet.toTop.obj (Δ[n] : SSet.{0}))).IsConnected :=
-      inferInstance
-    let φ := simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R
-    have hε : HomologicalComplex.homologyMap φ 0 ≫
-        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R =
-      (Δ[n] : SSet.{0}).homology₀ε R :=
-      simplicialHomologyZeroAugmentation_naturality_general
-        (sSetTopAdj.unit.app (Δ[n] : SSet.{0})) R
-    let hsource : IsIso ((Δ[n] : SSet.{0}).homology₀ε R) := inferInstance
-    let htarget : IsIso
-        ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) :=
-      inferInstanceAs (IsIso ((TopCat.toSSet.obj
-        (SSet.toTop.obj (Δ[n] : SSet.{0}))).homology₀ε R))
-    have hcomp : IsIso (HomologicalComplex.homologyMap φ 0 ≫
-        (SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) := by
-      rw [hε]
-      exact hsource
-    exact @IsIso.of_isIso_comp_right _ _ _ _ _
-      (HomologicalComplex.homologyMap φ 0)
-      ((SSet.toTop.obj (Δ[n] : SSet.{0})).singularHomology₀ε R) htarget hcomp
-  · exact (quasiIsoAt_iff_exactAt _ k
-      (standardSimplex_simplicialChains_exactAt_general R n k hk)).mpr
-        (standardSimplexRealization_singularChains_exactAt_general R n k hk)
+    QuasiIso (simplicialToRealizationSingularChainMap (Δ[n] : SSet.{0}) R) :=
+  standardSimplex_simplicialToRealizationSingularChainMap_quasiIso R n
 
 end SphereSixComplex
+
+end


### PR DESCRIPTION
## Summary

- factor the order-three/order-four elliptic construction through indexed rotation, action, collar, slice-radius, and filling-piece APIs
- store invariant open carriers as mathlib `SubMulAction`s and derive the restricted action/orbit compatibility layer
- replace the cusp-descent axiom with a proof based on the merged `Mathlib.Analysis.Complex.Periodic` API
- make the standard-simplex simplicial–singular comparison coefficient-general by default while retaining compatibility aliases
- deduplicate the boundary-seven realization map into a shared low-level module

This is a stacked PR against `codex/theta-six-continuation-snapshots`, the audited source branch. Targeting `main` directly would mix in the unrelated theta-six continuation series.

## Verification

- `lake build` — successful, 4583 jobs
- focused builds for all changed geometry and topology modules
- `git diff --check`
- no new axioms or `sorry`

Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
