### PR TITLE
Remove obsolete heartbeat overrides

### DIFF
--- a/SphereSixComplex/Geometry/CuspAnalyticFillingCollar.lean
+++ b/SphereSixComplex/Geometry/CuspAnalyticFillingCollar.lean
@@ -551,7 +551,6 @@ private noncomputable def expOnThreeDeriv (x : ComplexModel) : ComplexModel ≃L
     (mul_ne_zero twoPiI_ne_zero (Complex.exp_ne_zero _)))
 
 set_option maxRecDepth 8000 in
-set_option maxHeartbeats 1000000 in
 private theorem hasFDerivAt_expOnThree (x : ComplexModel) :
     HasFDerivAt expOnThree ((expOnThreeDeriv x : ComplexModel →L[ℂ] ComplexModel)) x := by
   set c : Fin 3 → ℂ := fun i ↦ twoPiI * Complex.exp (twoPiI * WithLp.ofLp x i) with hc
@@ -579,7 +578,6 @@ private theorem hasFDerivAt_expOnThree (x : ComplexModel) :
   show c i * WithLp.ofLp y i = WithLp.ofLp y i * c i
   exact mul_comm _ _
 
-set_option maxHeartbeats 1000000 in
 private theorem isLocalDiffeomorph_expCoords :
     IsLocalDiffeomorph (modelWithCornersSelf ℂ AdditiveCuspCover)
       (modelWithCornersSelf ℂ ComplexModel) ∞ expCoords := by

--- a/SphereSixComplex/Topology/MayerVietorisDegreeZeroBridge.lean
+++ b/SphereSixComplex/Topology/MayerVietorisDegreeZeroBridge.lean
@@ -252,7 +252,6 @@ private theorem sumMap_flattenPair_zero
             (rightOpenInUnionToRight A B hB) v) = _
   rw [hLeft', hRight']
 
-set_option maxHeartbeats 600000 in
 private theorem sumMap_flattenPair_eq_integralMVFromProduct
     {X : Type} [TopologicalSpace X] (A B : Set X)
     (hA : IsOpen A) (hB : IsOpen B)
@@ -274,7 +273,6 @@ private theorem sumMap_flattenPair_eq_integralMVFromProduct
     (integralMVFromProduct_pair_apply (Y := TopCat.of (A ∪ B : Set X))
       (leftOpenInUnion A B hA) (rightOpenInUnion A B hB) u v).symm
 
-set_option maxHeartbeats 600000 in
 private theorem sumMap_zero_has_preimage
     {X : Type} [TopologicalSpace X] (A B : Set X)
     (hA : IsOpen A) (hB : IsOpen B)


### PR DESCRIPTION
## Summary

Remove four per-declaration `maxHeartbeats` overrides that now elaborate under Lean's default 200,000-heartbeat limit.

This is maintenance of elaboration guardrails, not a runtime-performance claim. It changes no theorem statement or proof body.

## Implementation

- Remove the two 600,000-heartbeat wrappers in `MayerVietorisDegreeZeroBridge.lean`.
- Remove the two 1,000,000-heartbeat wrappers in `CuspAnalyticFillingCollar.lean`.
- Preserve the independent `maxRecDepth 8000` wrapper required by `hasFDerivAt_expOnThree`.

## API and trust boundary

There are no changes to declarations, proofs, imports, dependency pins, Blueprint sources, axioms, or placeholders.

The pre/post axiom inventories are byte-identical:

```text
45 axioms: 44 in the Final cone, 1 further in the Main cone, 0 in neither.
```

The exact final-theorem dependency audit remains at 44 dependencies, and the construction audit remains at 41 constants.

## Scope and non-goals

- The `maxHeartbeats 800000` wrapper in `BoundarySevenCechOrderedLocalComparison.lean` is deliberately retained because that file belongs to the active #144/#145 contribution stack. This PR has zero changed-file overlap with the exact current heads of either PR.
- A trial project-wide `autoImplicit = false` change is not included. A fresh build exposed an additional unrecorded dependent file, so that proposal needs a separate whole-project audit.
- This is not a general option audit, a mathematical change, a dependency or Blueprint change, or an issue-completion claim.

## Validation

Local validation on exact head `511c7f840d2a67fcc60d85327ce79f6ca74b9862`:

- `lake build SphereSixComplex.Topology.MayerVietorisDegreeZeroBridge SphereSixComplex.Geometry.CuspAnalyticFillingCollar` — passed (`4785 jobs`).
- `lake exe cache get` — `0` downloaded; `8450` already decompressed.
- `lake build` — passed (`9574 jobs`).
- `python3 scripts/check-imports.py` — all `556` modules reachable from `SphereSixComplex.Main`.
- `python3 scripts/check-sorries.py` — exactly the `2` declared placeholders and none elsewhere.
- `CHECK_AXIOMS_SKIP_BUILD=1 ./scripts/check-axioms.sh` — exact 44-dependency final-theorem list and 41-constant construction list passed.
- `blueprint/scripts/ci-pages.sh` — passed (`9926 jobs`) and verified the expected generated site artifacts.
- `git diff --check`, prohibited-token/debug additions scan, inventory comparison, and option-retention scan — passed.

GitHub Actions is separate from these local results and is pending.

## Tracking

Claims no issue complete.
