### PR TITLE
Add the universal property of the multiple-fibre presentation

### DIFF
--- a/SphereSixComplex/Topology/PaperLemmaSevenThirteenAlgebra.lean
+++ b/SphereSixComplex/Topology/PaperLemmaSevenThirteenAlgebra.lean
@@ -551,4 +551,30 @@ public instance orderTwoSelectedPresentation_noZeroSMulDivisors :
         simpa using congrFun h' i
       simpa using (mul_eq_zero.mp hi).resolve_left hc
 
+/-- Maps out of the multiple-fibre presentation are exactly pairs: a map killing the difference,
+together with a meridian image whose `m`-th multiple is the image of the twist.
+
+This is the universal property that an identification of `H₁` of a free affine cyclic quotient with
+this presentation has to go through, in either direction; see issue #148. -/
+public noncomputable def multipleFiberLift {B : Type} [AddCommGroup B]
+    (D : Lattice →ₗ[ℤ] Lattice) (v : Lattice) (m : ℤ)
+    (φ : Lattice →ₗ[ℤ] B) (hφ : ∀ x, φ (D x) = 0) (b : B) (hb : m • b = φ v) :
+    MultipleFiberHOnePresentation D v m →ₗ[ℤ] B := by
+  refine Submodule.liftQ _ ((Submodule.liftQ _ φ ?_).coprod
+    (LinearMap.toSpanSingleton ℤ B b)) ?_
+  · rintro x ⟨y, rfl⟩; exact hφ y
+  · rintro x ⟨k, rfl⟩
+    simp [multipleFiberRelationMap, LinearMap.toSpanSingleton, hb.symm, mul_comm]
+    rw [smul_smul, mul_comm k m]
+    exact neg_add_cancel _
+
+/-- The lift sends the class of `(x, k)` to `φ x + k • b`. -/
+public theorem multipleFiberLift_mk {B : Type} [AddCommGroup B]
+    (D : Lattice →ₗ[ℤ] Lattice) (v : Lattice) (m : ℤ)
+    (φ : Lattice →ₗ[ℤ] B) (hφ : ∀ x, φ (D x) = 0) (b : B) (hb : m • b = φ v)
+    (x : Lattice) (k : ℤ) :
+    multipleFiberLift D v m φ hφ b hb
+        (Submodule.Quotient.mk (Submodule.Quotient.mk x, k)) = φ x + k • b := by
+  simp [multipleFiberLift, LinearMap.toSpanSingleton]
+
 end SphereSixComplex.Topology.PaperLemmaSevenThirteenAlgebra


### PR DESCRIPTION
First step toward #148 (discharging `reducedCentralFiberHOnePresentation`, the `H₁` half of
Lemma 7.13). This does not change what is assumed; it adds the algebra that the eventual proof needs.

`MultipleFiberHOnePresentation D v m` unfolds to `((Λ / range D) × Z) ⧸ ⟨(-[v], m)⟩`. Its universal
property is that maps out of it are exactly pairs -- a map killing `D`, and a meridian image whose
`m`-th multiple is the image of the twist:

```lean
noncomputable def multipleFiberLift {B : Type} [AddCommGroup B]
    (D : Lattice →ₗ[ℤ] Lattice) (v : Lattice) (m : ℤ)
    (φ : Lattice →ₗ[ℤ] B) (hφ : ∀ x, φ (D x) = 0) (b : B) (hb : m • b = φ v) :
    MultipleFiberHOnePresentation D v m →ₗ[ℤ] B

theorem multipleFiberLift_mk … (x : Lattice) (k : ℤ) :
    multipleFiberLift D v m φ hφ b hb (Submodule.Quotient.mk (Submodule.Quotient.mk x, k))
      = φ x + k • b
```

Any identification of `H₁` of a free affine cyclic quotient with this presentation goes through
this in one direction or the other, so it is worth having independently of how the rest of #148
turns out.

Both statements are axiom-free (`[propext, Classical.choice, Quot.sound]`).

One implementation note in case it saves someone time: the hypothesis must be `[AddCommGroup B]`
alone, not `[AddCommGroup B] [Module ℤ B]`. With both, the two `ℤ`-actions are propositionally but
not syntactically equal, and `smul_smul` fails to fire on `k • m • b`.

Rebuild of the 50 dependent modules, 0 failures; all three gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y