### PR TITLE
Allow active main CI runs to finish

### DIFF
--- a/.github/workflows/blueprint-pages.yml
+++ b/.github/workflows/blueprint-pages.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.repository }}-blueprint-pages-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- cancel obsolete pull-request workflow runs as before
- allow the active main-branch workflow to finish when a newer push arrives
- let completed main runs deploy and save the incremental Lean cache

## Why

All main pushes share the same concurrency group. With unconditional `cancel-in-progress: true`, frequent pushes cancel the active build before the post-job cache save step. The only existing incremental cache is consequently scoped to the cache PR and cannot bootstrap main.

GitHub may still replace older pending main runs, but this change preserves the actively running main build so it can publish both Pages and the reusable cache.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes