### PR TITLE
Add a --fix mode that regenerates the axiom trust artifacts

### DIFF
--- a/scripts/check-axioms.sh
+++ b/scripts/check-axioms.sh
@@ -6,11 +6,27 @@
 # and also runs `#print axioms` on the project endpoints. Add an allowlist entry only together with
 # a written justification of the new trust boundary; remove it when the dependency is discharged.
 #
-# Usage: ./scripts/check-axioms.sh
+# Usage: ./scripts/check-axioms.sh [--fix]
+#
+# With `--fix`, the three declared lists and the axiom catalog are rewritten from the computed
+# closures instead of being checked against them.  Discharging an axiom otherwise means editing `scripts/allowed-axioms.txt`,
+# `scripts/allowed-construction-axioms.txt` and `comparator.json` by hand and keeping them in
+# agreement, which is what drifts.  Surviving entries keep their position and section comment, and
+# new ones are appended under a marker to be filed by hand.  Review the resulting diff: `--fix`
+# records what the development currently assumes, it does not judge whether assuming it is
+# acceptable.
 #
 # Set CHECK_AXIOMS_SKIP_BUILD=1 to reuse an existing build instead of running `lake build`.
 
 set -euo pipefail
+
+fix_mode=0
+for arg in "$@"; do
+  case "$arg" in
+    --fix) fix_mode=1 ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 allowlist="$project_root/scripts/allowed-axioms.txt"
@@ -29,7 +45,7 @@ trap 'rm -rf "$work"' EXIT
   | { grep -v '^[[:space:]]*$' || true; } > "$work/allowed-in-order.txt"
 jq -r '.permitted_axioms[]' "$project_root/comparator.json" > "$work/comparator-allowed.txt"
 
-if ! cmp -s "$work/allowed-in-order.txt" "$work/comparator-allowed.txt"; then
+if [[ "$fix_mode" -eq 0 ]] && ! cmp -s "$work/allowed-in-order.txt" "$work/comparator-allowed.txt"; then
   echo "Axiom audit FAILED: comparator.json permitted_axioms differs from scripts/allowed-axioms.txt." >&2
   diff -u "$work/allowed-in-order.txt" "$work/comparator-allowed.txt" >&2 || true
   exit 1
@@ -42,14 +58,16 @@ if [[ -z "${CHECK_AXIOMS_SKIP_BUILD:-}" ]]; then
   lake build >/dev/null
 fi
 
-"$project_root/scripts/update-axiom-catalog.sh" --check
+if [[ "$fix_mode" -eq 0 ]]; then
+  "$project_root/scripts/update-axiom-catalog.sh" --check
+fi
 
 lake env lean "$project_root/scripts/ComparatorAxiomClosure.lean" \
   > "$work/comparator-closure.txt"
 sort -u "$work/allowed-in-order.txt" > "$work/allowed-sorted.txt"
 sort -u "$work/comparator-closure.txt" > "$work/comparator-closure-sorted.txt"
 
-if ! cmp -s "$work/allowed-sorted.txt" "$work/comparator-closure-sorted.txt"; then
+if [[ "$fix_mode" -eq 0 ]] && ! cmp -s "$work/allowed-sorted.txt" "$work/comparator-closure-sorted.txt"; then
   echo "Axiom audit FAILED: Comparator's recursive axiom closure differs from the allowlist." >&2
   diff -u "$work/allowed-sorted.txt" "$work/comparator-closure-sorted.txt" >&2 || true
   exit 1
@@ -58,6 +76,24 @@ fi
 lake env lean "$project_root/scripts/ConstructionAxiomClosure.lean" \
   > "$work/construction-closure.txt"
 sort -u "$work/construction-closure.txt" > "$work/construction.txt"
+
+if [[ "$fix_mode" -eq 1 ]]; then
+  echo "Rewriting the declared lists from the computed closures:"
+  python3 "$project_root/scripts/rewrite_axiom_list.py" "$allowlist" "$work/comparator-closure-sorted.txt"
+  python3 "$project_root/scripts/rewrite_axiom_list.py" "$construction_allowlist" "$work/construction.txt"
+  # comparator.json must list the same constants in the same order as the allowlist.
+  { grep -v '^[[:space:]]*#' "$allowlist" || true; } \
+    | { grep -v '^[[:space:]]*$' || true; } > "$work/allowed-rewritten.txt"
+  jq --slurpfile a <(jq -R -s -c 'split("\n") | map(select(length > 0))' "$work/allowed-rewritten.txt") \
+    '.permitted_axioms = $a[0]' "$project_root/comparator.json" > "$work/comparator.json"
+  mv "$work/comparator.json" "$project_root/comparator.json"
+  echo "  comparator.json: permitted_axioms set from the allowlist, same order"
+  "$project_root/scripts/update-axiom-catalog.sh" --write
+  echo "  ChallengeAxioms.lean: axiom catalog regenerated"
+  echo
+  echo "Review the diff before committing: this records what is assumed, not whether it is acceptable."
+  exit 0
+fi
 
 {
   echo "import SphereSixComplex.Main"

--- a/scripts/rewrite_axiom_list.py
+++ b/scripts/rewrite_axiom_list.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Rewrite a declared axiom list from a computed closure, preserving the file's structure.
+
+Entries already present keep their position and their section comment; entries no longer in the
+closure are dropped; entries new to the closure are appended under a marker so that they can be
+moved into the section they belong to.
+
+Usage: rewrite_axiom_list.py LIST_FILE CLOSURE_FILE
+"""
+
+import sys
+
+NEW_SECTION = "# Newly computed; move into the section it belongs to."
+
+
+def main(list_path: str, closure_path: str) -> None:
+    with open(closure_path) as handle:
+        closure = [line.strip() for line in handle if line.strip()]
+    closure_set = set(closure)
+
+    with open(list_path) as handle:
+        lines = [line.rstrip("\n") for line in handle]
+
+    kept: list[str] = []
+    present: set[str] = set()
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            if stripped == NEW_SECTION:
+                continue
+            kept.append(line)
+            continue
+        if stripped in closure_set:
+            kept.append(line)
+            present.add(stripped)
+
+    # Drop section headers left without entries, and any blank runs they leave behind.
+    pruned: list[str] = []
+    for index, line in enumerate(kept):
+        if line.strip().startswith("#"):
+            has_entry = False
+            for later in kept[index + 1:]:
+                if later.strip().startswith("#"):
+                    break
+                if later.strip():
+                    has_entry = True
+                    break
+            # The leading header block describes the file itself, so it always stays.
+            if not has_entry and any(entry.strip() and not entry.strip().startswith("#")
+                                     for entry in kept[:index]):
+                continue
+        pruned.append(line)
+
+    while pruned and not pruned[-1].strip():
+        pruned.pop()
+
+    added = [entry for entry in closure if entry not in present]
+    if added:
+        pruned.append("")
+        pruned.append(NEW_SECTION)
+        pruned.extend(added)
+
+    with open(list_path, "w") as handle:
+        handle.write("\n".join(pruned) + "\n")
+
+    removed = sum(1 for line in lines
+                  if line.strip() and not line.strip().startswith("#")
+                  and line.strip() not in closure_set)
+    print(f"  {list_path}: {len(present) + len(added)} constants "
+          f"({len(added)} added, {removed} removed)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Rebased onto `main`. The list edits this PR originally carried are gone — `62158ae` fixed that instance of the drift upstream, and the rebase dropped them automatically. What remains is the tooling, which the drift keeps earning.

## The problem

Discharging or renaming an axiom means updating **four** artifacts by hand and keeping them in exact agreement:

- `scripts/allowed-axioms.txt`
- `scripts/allowed-construction-axioms.txt`
- `comparator.json`'s `permitted_axioms` (same list, *same order* as the allowlist)
- the generated catalog block in `ChallengeAxioms.lean`

and the correct contents are only known after a build. That is why it drifts, and the drift takes the axiom gate — and *Build Blueprint site* behind it — red with it.

## What this adds

`./scripts/check-axioms.sh --fix` rewrites all four from the computed closures instead of checking against them.

The catalog check is skipped under `--fix`: it compares against the declared allowlist, so it would fail on exactly the drift being repaired. It is regenerated afterwards via `update-axiom-catalog.sh --write`, so one command leaves all four artifacts consistent.

`scripts/rewrite_axiom_list.py` does the list merge structurally, so the lists stay readable:

- surviving entries keep their position and their section comment,
- dropped entries are removed in place,
- new entries are appended under a marker to be filed into a section by hand,
- section headers left with no entries are pruned.

The diff then shows the trust change and nothing else — which is the point, since these files are what a reader consults to see what is assumed. Emitting a freshly sorted list would flatten the `# Established general topology and homology.` / `# Established analytic and toric models from the paper.` groupings that say what each block of axioms *is*.

## Checks

On current `main` (already synced), `--fix` is a clean no-op — it reports `0 added, 0 removed` for both lists and leaves `comparator.json` and `ChallengeAxioms.lean` untouched. The default path is unchanged and all three audits still pass:

```
Axiom catalog check passed.
Axiom audit passed. The final theorem depends on: ... (30 constants)
Construction audit passed. The construction depends on 28 constants
```

`--fix` is opt-in and never runs in CI. It records what the development currently assumes — whether assuming it is acceptable stays a review question, and the command says so on exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y
