### PR TITLE
Prove the punctured family's point-set niceness instead of assuming it

### DIFF
--- a/SphereSixComplex/Geometry/FuchsianPuncturedGlobalFamilyNiceness.lean
+++ b/SphereSixComplex/Geometry/FuchsianPuncturedGlobalFamilyNiceness.lean
@@ -1,0 +1,108 @@
+module
+
+public import SphereSixComplex.Geometry.FuchsianRegularTorusFamily
+public import SphereSixComplex.Geometry.PaperCentralFamilyTopology
+public import SphereSixComplex.Topology.ManifoldLocallyContractible
+
+/-!
+# Local niceness of the punctured global family
+
+The punctured global family of a Fuchsian modular parameter is a complex manifold
+(`fuchsianPuncturedGlobalFamily_isManifold_and_projection_isLocalDiffeomorph`), so its local
+point-set properties are read off its charts rather than assumed.
+
+`fuchsianPuncturedGlobalFamilyProductCharts` records the product-model charted structure for an
+arbitrary Fuchsian modular parameter.  Over that model the family is strongly locally contractible,
+hence locally path connected and semilocally simply connected — the two hypotheses Tau Ceti's
+based-path universal cover needs of a base space.
+
+Path connectedness follows too: the family is connected for any triangle uniformization
+(`puncturedGlobalFamily_connected`), and a connected, locally path connected space is path
+connected.
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open scoped Manifold
+
+namespace SphereSixComplex.Geometry.GlobalTorusFamily
+
+open SphereSixComplex.Periods SphereSixComplex.TriangleGroup
+open SphereSixComplex.Geometry.ComplexTorus
+open SphereSixComplex.Geometry.TorusFamily SphereSixComplex.Geometry.AnalyticTorusFamily
+open SphereSixComplex.TriangleGroup.FuchsianArithmeticTermination
+
+variable (P : FuchsianModularParameter) (F : PeriodFunctions P.toTriangleUniformization)
+
+/-- Product-model charts on the punctured global family of a Fuchsian modular parameter. -/
+@[instance_reducible] public noncomputable def fuchsianPuncturedGlobalFamilyProductCharts :
+    ChartedSpace (ModelProd ℂ ComplexTwoSpace) (PuncturedGlobalFamily F) := by
+  let hproper : SourceActionProperlyDiscontinuous :=
+    sourceActionProperlyDiscontinuous_of_eq P.toTriangleUniformization_sourceAction
+  let _ := regularBaseChartedSpace hproper
+  let _ : LocallyCompactSpace (RegularBase (U := P.toTriangleUniformization)) :=
+    (isOpen_isRegularBasePoint hproper).locallyCompactSpace
+  let _ : IsManifold GlobalDeckBaseModel RegularSmoothnessOrder
+      (RegularBase (U := P.toTriangleUniformization)) :=
+    regularBase_isManifold hproper
+  let _ := familyIsCancelSMul (regularParameterMap F)
+  let _ := familyContinuousConstSMul (regularParameterMap F)
+    fun a => (regularPeriodSection_contMDiff F hproper a RegularSmoothnessOrder).continuous
+  let _ := familyProperlyDiscontinuousSMul (regularParameterMap F)
+    (compactlyUniformPeriods_of_compactUniformLowerBound (regularParameterMap F)
+      (regularParameterMap_compactUniformLowerBound F))
+  let htotal := regularTotalSpace_isManifold_and_projection_isLocalDiffeomorph
+    F hproper RegularSmoothnessOrder
+  let _ : IsManifold GlobalDeckTotalModel RegularSmoothnessOrder (RegularTotalSpace F) := htotal.1
+  let _ : LocallyCompactSpace (RegularTotalSpace F) :=
+    Manifold.locallyCompact_of_finiteDimensional GlobalDeckTotalModel
+  let _ := regularFamilyDeckAction F
+  let _ : IsCancelSMul Delta (RegularTotalSpace F) :=
+    regularFamilyDeckAction_isCancelSMul_of_fuchsian F
+      P.toTriangleUniformization_sourceAction hproper
+  let _ : ProperlyDiscontinuousSMul Delta (RegularTotalSpace F) :=
+    regularFamilyDeckAction_properlyDiscontinuous_of_source F hproper
+  let _ : ContinuousConstSMul Delta (RegularTotalSpace F) :=
+    regularFamilyDeckAction_continuousConstSMul F hproper
+  infer_instance
+
+/-- The punctured global family is strongly locally contractible: each chart identifies a
+neighbourhood with an open subset of `ℂ × ℂ²`, whose balls are convex. -/
+public theorem fuchsianPuncturedGlobalFamily_stronglyLocallyContractible :
+    StronglyLocallyContractibleSpace (PuncturedGlobalFamily F) := by
+  let _ := fuchsianPuncturedGlobalFamilyProductCharts P F
+  have _ : StronglyLocallyContractibleSpace (ModelProd ℂ ComplexTwoSpace) :=
+    normedSpace_stronglyLocallyContractibleSpace (E := ℂ × ComplexTwoSpace)
+  exact ChartedSpace.stronglyLocallyContractibleSpace (H := ModelProd ℂ ComplexTwoSpace)
+
+/-- The punctured global family is locally path connected. -/
+public theorem fuchsianPuncturedGlobalFamily_locallyPathConnected :
+    LocallyPathConnectedSpace (PuncturedGlobalFamily F) := by
+  have _ : StronglyLocallyContractibleSpace (PuncturedGlobalFamily F) :=
+    fuchsianPuncturedGlobalFamily_stronglyLocallyContractible P F
+  infer_instance
+
+/-- The punctured global family is path connected: it is connected, and locally path connected
+because it is a manifold. -/
+public theorem fuchsianPuncturedGlobalFamily_pathConnected :
+    PathConnectedSpace (PuncturedGlobalFamily F) := by
+  have _ : LocallyPathConnectedSpace (PuncturedGlobalFamily F) :=
+    fuchsianPuncturedGlobalFamily_locallyPathConnected P F
+  have _ : ConnectedSpace (PuncturedGlobalFamily F) := puncturedGlobalFamily_connected F
+  exact pathConnectedSpace_iff_connectedSpace.mpr inferInstance
+
+/-- The punctured global family is semilocally simply connected. -/
+public theorem fuchsianPuncturedGlobalFamily_semilocallySimplyConnected :
+    TauCeti.SemilocallySimplyConnectedSpace (PuncturedGlobalFamily F) := by
+  let _ := fuchsianPuncturedGlobalFamilyProductCharts P F
+  have _ : StronglyLocallyContractibleSpace (ModelProd ℂ ComplexTwoSpace) :=
+    normedSpace_stronglyLocallyContractibleSpace (E := ℂ × ComplexTwoSpace)
+  exact ChartedSpace.semilocallySimplyConnectedSpace (H := ModelProd ℂ ComplexTwoSpace)
+
+end SphereSixComplex.Geometry.GlobalTorusFamily
+
+end
+
+end

--- a/SphereSixComplex/Topology/EstablishedEquivariantUniversalCover.lean
+++ b/SphereSixComplex/Topology/EstablishedEquivariantUniversalCover.lean
@@ -1,6 +1,7 @@
 module
 
 public import SphereSixComplex.Topology.EstablishedEquivariantUniversalCoverProof
+public import SphereSixComplex.Geometry.FuchsianPuncturedGlobalFamilyNiceness
 public import SphereSixComplex.Periods.FuchsianUniformizationBridge
 
 /-!
@@ -15,12 +16,17 @@ family and derives the equivariant universal cover from it.
 
 ## What is assumed, and why in this form
 
-The retained input is `establishedPuncturedGlobalFamilyAffineFundamentalGroup`: the punctured
-global family is locally nice and its fundamental group is the affine deck group
+The retained input is `establishedPuncturedGlobalFamilyAffineFundamentalGroup`: the fundamental
+group of the punctured global family is the affine deck group
 `IntegerPeriods ⋊ FreeGroup (Fin 2)`, the two free meridians acting by the order-three and
 order-four integral period monodromies.  The equivariant universal cover itself is then a
 theorem, `establishedPuncturedGlobalFamilyEquivariantUniversalCover`, obtained from Tau Ceti's
 based-path universal cover in `EstablishedEquivariantUniversalCoverProof`.
+
+The based-path cover also needs the base to be path connected, locally path connected and
+semilocally simply connected.  None of the three is assumed: over a Fuchsian modular parameter the
+family is a complex manifold and connected, so all three follow
+(`Geometry.FuchsianPuncturedGlobalFamilyNiceness`).
 
 Two changes from the earlier form of this boundary are deliberate.
 
@@ -55,7 +61,7 @@ For a Fuchsian modular parameter, the regular locus of the uniformizing half-pla
 twice-punctured disc, so the punctured global family is an affine torus bundle over a pair of
 pants: its fundamental group is the lattice extended by the free group on the two meridians,
 which map to the order-three and order-four orbifold generators.  No covering space, filling
-relation or van Kampen conclusion is asserted. -/
+relation, van Kampen conclusion or local point-set property is asserted. -/
 public axiom establishedPuncturedGlobalFamilyAffineFundamentalGroup
     {P : Periods.FuchsianModularParameter}
     (F : PeriodFunctions P.toTriangleUniformization) :
@@ -72,6 +78,9 @@ public noncomputable def establishedPuncturedGlobalFamilyEquivariantUniversalCov
     (F : PeriodFunctions P.toTriangleUniformization) :
     ChosenEquivariantAffineUniversalCover IntegerPeriods Delta (PuncturedGlobalFamily F)
       (twoMeridianOrbifoldMap g₁ g₂) integralOrbifoldPeriodMonodromy :=
+  letI := fuchsianPuncturedGlobalFamily_locallyPathConnected P F
+  letI := fuchsianPuncturedGlobalFamily_pathConnected P F
+  letI := fuchsianPuncturedGlobalFamily_semilocallySimplyConnected P F
   puncturedGlobalFamilyEquivariantUniversalCover_of_fundamentalGroup F
     (establishedPuncturedGlobalFamilyAffineFundamentalGroup F)
 

--- a/SphereSixComplex/Topology/EstablishedEquivariantUniversalCoverProof.lean
+++ b/SphereSixComplex/Topology/EstablishedEquivariantUniversalCoverProof.lean
@@ -101,16 +101,17 @@ namespace Geometry.GlobalTorusFamily
 
 open Periods TriangleGroup Geometry.ComplexTorus
 
-/-- The classification input retained by `EstablishedEquivariantUniversalCover`: the punctured
-global family is locally nice, and its fundamental group at some base point is the
-affine deck group `IntegerPeriods ⋊ FreeGroup (Fin 2)` with the two free meridians acting by the
-order-three and order-four integral period monodromies.  No covering space is postulated. -/
+/-- The classification input retained by `EstablishedEquivariantUniversalCover`: the fundamental
+group of the punctured global family at some base point is the affine deck group
+`IntegerPeriods ⋊ FreeGroup (Fin 2)`, with the two free meridians acting by the order-three and
+order-four integral period monodromies.  No covering space is postulated.
+
+The point-set hypotheses of the based-path universal cover are not recorded here.  Over a Fuchsian
+modular parameter the family is a complex manifold and connected, so path connectedness, local path
+connectedness and semilocal simple connectedness are all proved in
+`Geometry.FuchsianPuncturedGlobalFamilyNiceness` and passed as instances below. -/
 public structure PuncturedGlobalFamilyAffineFundamentalGroup
     {U : TriangleUniformization} (F : PeriodFunctions U) where
-  locallyPathConnected : LocallyPathConnectedSpace (PuncturedGlobalFamily F)
-  pathConnected : PathConnectedSpace (PuncturedGlobalFamily F)
-  semilocallySimplyConnected :
-    TauCeti.SemilocallySimplyConnectedSpace (PuncturedGlobalFamily F)
   base : PuncturedGlobalFamily F
   identification :
     FreeTwoMeridianAffineDeck IntegerPeriods
@@ -122,13 +123,13 @@ public structure PuncturedGlobalFamilyAffineFundamentalGroup
 universal cover outright. -/
 public noncomputable def puncturedGlobalFamilyEquivariantUniversalCover_of_fundamentalGroup
     {U : TriangleUniformization} (F : PeriodFunctions U)
+    [PathConnectedSpace (PuncturedGlobalFamily F)]
+    [LocallyPathConnectedSpace (PuncturedGlobalFamily F)]
+    [TauCeti.SemilocallySimplyConnectedSpace (PuncturedGlobalFamily F)]
     (P : PuncturedGlobalFamilyAffineFundamentalGroup F) :
     ChosenEquivariantAffineUniversalCover IntegerPeriods Delta (PuncturedGlobalFamily F)
-      (twoMeridianOrbifoldMap g₁ g₂) integralOrbifoldPeriodMonodromy := by
-  letI := P.locallyPathConnected
-  letI := P.pathConnected
-  letI := P.semilocallySimplyConnected
-  exact chosenEquivariantAffineUniversalCover_of_fundamentalGroupEquiv P.base P.identification
+      (twoMeridianOrbifoldMap g₁ g₂) integralOrbifoldPeriodMonodromy :=
+  chosenEquivariantAffineUniversalCover_of_fundamentalGroupEquiv P.base P.identification
 
 /-- Exact residual statement: the equivariant universal-cover classification for the punctured
 global family follows from the affine fundamental-group identification above.  Conversely the
@@ -136,6 +137,9 @@ only thing the classification is used for downstream is that identification, thr
 `EquivariantAffineUniversalCover.fundamentalGroupCorePiOneData`. -/
 public theorem nonempty_chosenEquivariantAffineUniversalCover_of_fundamentalGroup
     {U : TriangleUniformization} (F : PeriodFunctions U)
+    [PathConnectedSpace (PuncturedGlobalFamily F)]
+    [LocallyPathConnectedSpace (PuncturedGlobalFamily F)]
+    [TauCeti.SemilocallySimplyConnectedSpace (PuncturedGlobalFamily F)]
     (P : PuncturedGlobalFamilyAffineFundamentalGroup F) :
     Nonempty (ChosenEquivariantAffineUniversalCover IntegerPeriods Delta
       (PuncturedGlobalFamily F) (twoMeridianOrbifoldMap g₁ g₂)


### PR DESCRIPTION
Closes part of #9 — the narrowing I flagged there and offered to apply.

## What comes out of the axiom

`PuncturedGlobalFamilyAffineFundamentalGroup` bundled three point-set properties with the fundamental-group identification:

```lean
  locallyPathConnected : LocallyPathConnectedSpace (PuncturedGlobalFamily F)
  pathConnected : PathConnectedSpace (PuncturedGlobalFamily F)
  semilocallySimplyConnected : TauCeti.SemilocallySimplyConnectedSpace (PuncturedGlobalFamily F)
```

All three are theorems, so all three come out. What remains assumed is the base point and the identification — i.e. exactly "π₁ of the punctured global family is the affine deck group", with no point-set content attached.

Over a Fuchsian modular parameter the family is a complex manifold (`fuchsianPuncturedGlobalFamily_isManifold_and_projection_isLocalDiffeomorph`), hence charted over `ModelProd ℂ ComplexTwoSpace`, whose balls are convex — and `Topology/ManifoldLocallyContractible.lean` already turns a charted space over a strongly locally contractible model into local path connectedness and semilocal simple connectedness. Path connectedness then follows from `puncturedGlobalFamily_connected`, which holds for an arbitrary triangle uniformization, since a connected locally path connected space is path connected.

`Geometry/FuchsianPuncturedGlobalFamilyNiceness.lean` records the product-model charts for an arbitrary Fuchsian modular parameter — generalizing `centralFamilyProductCharts`, which fixed the paper's analytic data — and derives:

- `fuchsianPuncturedGlobalFamily_stronglyLocallyContractible`
- `fuchsianPuncturedGlobalFamily_locallyPathConnected`
- `fuchsianPuncturedGlobalFamily_pathConnected`
- `fuchsianPuncturedGlobalFamily_semilocallySimplyConnected`

`puncturedGlobalFamilyEquivariantUniversalCover_of_fundamentalGroup` and `nonempty_chosenEquivariantAffineUniversalCover_of_fundamentalGroup` take the three as instances, supplied at the axiom site.

## No new trust

The derivation bottoms out in existing theorems and Mathlib — nothing enters either closure. The axiom *list* is unchanged, since this narrows a retained axiom's content rather than discharging it:

```
Import check passed: all 617 modules are reachable from SphereSixComplex.Main.
Placeholder check passed: 2 declared placeholder(s), none elsewhere.
```

43 downstream modules rebuild clean.

## One implementation note

The model space must be introduced as `normedSpace_stronglyLocallyContractibleSpace (E := ℂ × ComplexTwoSpace)`. Without the explicit `E`, the `ModelProd` topology instance and the normed-space topology are not syntactically equal and the `have` fails to apply.

## CI

The axiom-trust-boundary job is red on `main` independently of this branch: its closure differs from the allowlist by exactly

```
-SphereSixComplex.Geometry.PaperAnalyticData.establishedActualStarPeripheralNaturality
+SphereSixComplex.Geometry.PaperAnalyticData.establishedActualEllipticCentralNaturality
```

which is #191. That is the whole difference on this branch too — this change adds and removes no axioms. With #191 applied, all three gates pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQjnFGoyV3fTtZxzZAA21y
